### PR TITLE
Add MkDocs GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,52 @@
+name: Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "mkdocs>=1.5,<2.0" "mkdocs-material>=9.5,<9.6"
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# maridb
+
+**Maritime data layer — vessel, voyage, cargo, and AIS ingestion and transformation pipelines.**
+
+maridb is the shared data foundation for the edgesentry product stack. It collects and transforms raw vessel, voyage, cargo, and AIS data into structured Parquet datasets distributed via Cloudflare R2.
+
+## Quick links
+
+- [R2 Buckets](r2-buckets.md) — bucket architecture, partition layout, data flow
+
+## Product stack
+
+| Product | Role |
+|---|---|
+| **maridb** | Data layer — ingest, transform, validate, distribute to public R2 buckets |
+| **arktrace** | Shadow fleet detection — reads from `arktrace-public` R2. [github.com/edgesentry/arktrace](https://github.com/edgesentry/arktrace) |
+| **documaris** | Port call document generation — reads from `documaris-public` and `maridb-public` R2. [github.com/edgesentry/documaris](https://github.com/edgesentry/documaris) |
+| **edgesentry** | Physical layer — robotic inspection, sensor deployment |
+
+## R2 buckets
+
+| Bucket | URL | Contents |
+|---|---|---|
+| `maridb-public` | [pub-e088008b61ee432b906ef710d52af28c.r2.dev](https://pub-e088008b61ee432b906ef710d52af28c.r2.dev) | AIS, vessels, voyages, cargo, sanctions, ownership |
+| `arktrace-public` | existing | Detection-ready features, watchlist, SHAP signals |
+| `documaris-public` | [pub-2892b1afd7b94cc6a381e3dcec4edc30.r2.dev](https://pub-2892b1afd7b94cc6a381e3dcec4edc30.r2.dev) | Regulatory KB, form templates, voyage evidence |
+
+All buckets: unauthenticated public read.
+
+## Source
+
+- GitHub: [github.com/edgesentry/maridb](https://github.com/edgesentry/maridb)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,29 @@
+site_name: maridb
+site_description: Maritime data layer — vessel, voyage, cargo, and AIS ingestion and transformation pipelines.
+site_url: https://edgesentry.github.io/maridb/
+repo_url: https://github.com/edgesentry/maridb
+repo_name: edgesentry/maridb
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - content.action.edit
+
+nav:
+  - Home: index.md
+  - R2 Buckets: r2-buckets.md


### PR DESCRIPTION
Closes #4

## Summary

- Adds MkDocs Material theme setup matching the documaris docs site
- Publishes to `edgesentry.github.io/maridb/` on push to `main`
- Nav: Home (index.md) + R2 Buckets (r2-buckets.md)

## After merge

Enable GitHub Pages in repo settings → Source: **GitHub Actions** (one-time step).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>