### PR TITLE
Fix: remove --bbox from ais_behavior invocation

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -176,12 +176,7 @@ def step_features(region: RegionConfig, seed_dummy: bool = False) -> bool:
     env = {"DB_PATH": region.db_path}
 
     steps = [
-        (
-            [sys.executable, "-m", "pipelines.features.ais_behavior",
-             "--db", region.db_path,
-             "--bbox", *[str(x) for x in region.bbox]],
-            "ais_behavior",
-        ),
+        ([sys.executable, "-m", "pipelines.features.ais_behavior", "--db", region.db_path], "ais_behavior"),
         ([sys.executable, "-m", "pipelines.features.identity", "--db", region.db_path], "identity"),
         ([sys.executable, "-m", "pipelines.features.trade_mismatch", "--db", region.db_path], "trade_mismatch"),
         ([sys.executable, "-m", "pipelines.features.build_matrix", "--db", region.db_path], "build_matrix"),


### PR DESCRIPTION
## Summary

`run_pipeline.py` was passing `--bbox` to `pipelines.features.ais_behavior` but that module's argparse does not define `--bbox` — bbox filtering happens at AIS stream ingestion time, not feature computation time.

## Test plan

- [x] 303 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)