### PR TITLE
Fix: skip distribute step in backtest pipeline runs

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -236,6 +236,8 @@ def main() -> None:
                         help="Skip ingest step (use existing local DuckDB)")
     parser.add_argument("--skip-features", action="store_true")
     parser.add_argument("--skip-score", action="store_true")
+    parser.add_argument("--skip-distribute", action="store_true",
+                        help="Skip Gate 2 distribute step (use when S3 credentials are absent)")
     parser.add_argument("--gdelt-days", type=int, default=3, metavar="N",
                         help="Number of days of GDELT events to ingest (default: 3)")
     parser.add_argument("--seed-dummy", action="store_true",
@@ -256,7 +258,8 @@ def main() -> None:
         steps.append(("features", lambda: step_features(region, seed_dummy=args.seed_dummy)))
     if not args.skip_score:
         steps.append(("score", lambda: step_score(region)))
-    steps.append(("distribute", lambda: step_distribute(region)))
+    if not args.skip_distribute:
+        steps.append(("distribute", lambda: step_distribute(region)))
 
     for name, fn in steps:
         if not fn():

--- a/scripts/run_public_backtest_batch.py
+++ b/scripts/run_public_backtest_batch.py
@@ -75,6 +75,7 @@ def _run_pipeline_for_region(
         cmd.extend(["--stream-duration", str(stream_duration)])
     if seed_dummy:
         cmd.append("--seed-dummy")
+    cmd.append("--skip-distribute")  # backtest only needs scores, not app bucket distribution
     if marine_cadastre_year is not None and region == "persiangulf":
         cmd.extend(["--marine-cadastre-year", str(marine_cadastre_year)])
 


### PR DESCRIPTION
## Summary

The distribute step (`step_distribute`) reads from maridb-public via `_read_from_maridb`, which requires S3 credentials and expects files already uploaded there. During `run_public_backtest_batch.py`, the pipeline runs locally to generate scores — it doesn't need to copy anything to app buckets.

- Add `--skip-distribute` flag to `run_pipeline.py`
- Always pass `--skip-distribute` from `run_public_backtest_batch.py`

## Test plan

- [x] 303 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)