### PR TITLE
Fix seed-demo: guard against empty-schema watchlist parquet

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -185,23 +185,29 @@ jobs:
               import random
               from datetime import date, timedelta
               watchlist_path = demo_dir / "candidate_watchlist.parquet"
+              _empty_sh = pl.DataFrame(schema={"mmsi": pl.Utf8, "score_date": pl.Utf8, "confidence": pl.Float32})
               if watchlist_path.exists():
-                  wl = pl.read_parquet(watchlist_path, columns=["mmsi", "confidence"])
-                  rng = random.Random(42)
-                  anchor = date.today()
-                  days = 30
-                  rows = []
-                  for mmsi, base_conf in zip(wl["mmsi"].to_list(), wl["confidence"].to_list()):
-                      conf = float(base_conf)
-                      for d in range(days):
-                          score_date = (anchor - timedelta(days=days - 1 - d)).isoformat()
-                          conf = max(0.1, min(0.99, conf + rng.uniform(-0.04, 0.04)))
-                          rows.append({"mmsi": mmsi, "score_date": score_date, "confidence": round(conf, 4)})
-                  sh = pl.DataFrame(rows).with_columns(pl.col("confidence").cast(pl.Float32))
-                  sh.write_parquet(dst_sh)
-                  print(f"  score_history.parquet ← generated ({len(sh)} rows)")
+                  wl = pl.read_parquet(watchlist_path)
+                  # Guard: pipeline may produce empty-schema parquet with no columns
+                  if wl.height > 0 and "mmsi" in wl.columns and "confidence" in wl.columns:
+                      rng = random.Random(42)
+                      anchor = date.today()
+                      days = 30
+                      rows = []
+                      for mmsi, base_conf in zip(wl["mmsi"].to_list(), wl["confidence"].to_list()):
+                          conf = float(base_conf)
+                          for d in range(days):
+                              score_date = (anchor - timedelta(days=days - 1 - d)).isoformat()
+                              conf = max(0.1, min(0.99, conf + rng.uniform(-0.04, 0.04)))
+                              rows.append({"mmsi": mmsi, "score_date": score_date, "confidence": round(conf, 4)})
+                      sh = pl.DataFrame(rows).with_columns(pl.col("confidence").cast(pl.Float32))
+                      sh.write_parquet(dst_sh)
+                      print(f"  score_history.parquet ← generated ({len(sh)} rows)")
+                  else:
+                      _empty_sh.write_parquet(dst_sh)
+                      print("  score_history.parquet ← empty schema (watchlist has no candidates)")
               else:
-                  pl.DataFrame(schema={"mmsi": pl.Utf8, "score_date": pl.Utf8, "confidence": pl.Float32}).write_parquet(dst_sh)
+                  _empty_sh.write_parquet(dst_sh)
                   print("  score_history.parquet ← empty schema (no watchlist)")
 
           # validation_metrics.json — derive from backtest report if missing


### PR DESCRIPTION
## Summary

When the pipeline produces no candidates (CI with no live AIS data), `candidate_watchlist.parquet` is written with an empty schema (no columns). Reading `columns=["mmsi", "confidence"]` from it raises `ColumnNotFoundError`.

Guard with `height > 0` and column existence checks before generating `score_history`; fall back to empty schema parquet otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)