### PR TITLE
Fix notify_metrics: skip gracefully when backtest report missing

### DIFF
--- a/scripts/notify_metrics.py
+++ b/scripts/notify_metrics.py
@@ -35,8 +35,8 @@ _REGRESSION_THRESHOLD = 0.01  # #507: lowered from 0.02 — catches single-step 
 
 def _load_report() -> dict:
     if not _REPORT_PATH.exists():
-        print(f"Report not found: {_REPORT_PATH}", file=sys.stderr)
-        sys.exit(1)
+        print(f"Report not found: {_REPORT_PATH} — sending pipeline-only metrics email", file=sys.stderr)
+        return {}
     with _REPORT_PATH.open() as f:
         return json.load(f)
 


### PR DESCRIPTION
## Summary

`notify_metrics.py` hard-exited when `backtest_public_integration_summary.json` was not found. In `data-publish.yml`, that file doesn't exist — it's produced by the separate `public-backtest-integration.yml` job.

Return `{}` instead of exiting. The existing guard (`total_known_cases == 0 and not regions`) already handles this — it logs "All regions were skipped" and returns 0 cleanly without sending an email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)