### PR TITLE
Fix P0: add composite_score alias to unblock full pipeline cascade

### DIFF
--- a/pipelines/score/composite.py
+++ b/pipelines/score/composite.py
@@ -610,6 +610,8 @@ def compute_composite_scores(
             "cluster_label",
             "baseline_noise_score",
         ]
+    ).with_columns(
+        pl.col("confidence").alias("composite_score")
     ).sort("confidence", descending=True)
 
 


### PR DESCRIPTION
## Root cause (maridb#24)

`compute_composite_scores()` outputs `confidence` but Gate 2 (`push.py`), Gate 1 (`validate.py`), and all tests check for `composite_score`. This caused Gate 2 to reject every watchlist, blocking the entire cascade.

## Fix

Add `composite_score` as an alias for `confidence` in the composite scorer output — same values, both column names now present.

## Cascade unblocked

- ✅ Gate 2 passes → region watchlists copied to `data/processed/score/`
- ✅ `watchlists.zip` gets all 6 region files
- ✅ Backtest evaluates real vessels → AUROC / precision / recall
- ✅ DuckLake checkpoint materialises `composite_scores` Parquet
- ✅ `demo.zip` has real data
- ✅ Metrics email sends with backtest results

## Test plan

- [x] 303 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)