### PR TITLE
fix: resolve watchlist path at runtime to fix public backtest CI

### DIFF
--- a/config/launchagents/io.maridb.aisstream.blacksea.plist
+++ b/config/launchagents/io.maridb.aisstream.blacksea.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/blacksea.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/blacksea.duckdb</string>
     <string>--bbox</string>
         <string>40</string>
     <string>27</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/blacksea.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/blacksea.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/blacksea.log</string>
+  <string>REPLACE_WITH_LOG_DIR/blacksea.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/blacksea.err</string>
+  <string>REPLACE_WITH_LOG_DIR/blacksea.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.aisstream.europe.plist
+++ b/config/launchagents/io.maridb.aisstream.europe.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/europe.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/europe.duckdb</string>
     <string>--bbox</string>
         <string>35</string>
     <string>-10</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/europe.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/europe.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/europe.log</string>
+  <string>REPLACE_WITH_LOG_DIR/europe.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/europe.err</string>
+  <string>REPLACE_WITH_LOG_DIR/europe.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.aisstream.gulfofaden.plist
+++ b/config/launchagents/io.maridb.aisstream.gulfofaden.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/gulfofaden.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/gulfofaden.duckdb</string>
     <string>--bbox</string>
         <string>10</string>
     <string>42</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/gulfofaden.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/gulfofaden.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/gulfofaden.log</string>
+  <string>REPLACE_WITH_LOG_DIR/gulfofaden.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/gulfofaden.err</string>
+  <string>REPLACE_WITH_LOG_DIR/gulfofaden.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.aisstream.gulfofguinea.plist
+++ b/config/launchagents/io.maridb.aisstream.gulfofguinea.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/gulfofguinea.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/gulfofguinea.duckdb</string>
     <string>--bbox</string>
         <string>-5</string>
     <string>0</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/gulfofguinea.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/gulfofguinea.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/gulfofguinea.log</string>
+  <string>REPLACE_WITH_LOG_DIR/gulfofguinea.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/gulfofguinea.err</string>
+  <string>REPLACE_WITH_LOG_DIR/gulfofguinea.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.aisstream.gulfofmexico.plist
+++ b/config/launchagents/io.maridb.aisstream.gulfofmexico.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/gulfofmexico.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/gulfofmexico.duckdb</string>
     <string>--bbox</string>
         <string>17</string>
     <string>-100</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/gulfofmexico.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/gulfofmexico.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/gulfofmexico.log</string>
+  <string>REPLACE_WITH_LOG_DIR/gulfofmexico.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/gulfofmexico.err</string>
+  <string>REPLACE_WITH_LOG_DIR/gulfofmexico.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.aisstream.hornofafrica.plist
+++ b/config/launchagents/io.maridb.aisstream.hornofafrica.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/hornofafrica.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/hornofafrica.duckdb</string>
     <string>--bbox</string>
         <string>-5</string>
     <string>38</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/hornofafrica.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/hornofafrica.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/hornofafrica.log</string>
+  <string>REPLACE_WITH_LOG_DIR/hornofafrica.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/hornofafrica.err</string>
+  <string>REPLACE_WITH_LOG_DIR/hornofafrica.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.aisstream.japansea.plist
+++ b/config/launchagents/io.maridb.aisstream.japansea.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/japansea.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/japansea.duckdb</string>
     <string>--bbox</string>
         <string>25</string>
     <string>115</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/japansea.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/japansea.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/japansea.log</string>
+  <string>REPLACE_WITH_LOG_DIR/japansea.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/japansea.err</string>
+  <string>REPLACE_WITH_LOG_DIR/japansea.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.aisstream.middleeast.plist
+++ b/config/launchagents/io.maridb.aisstream.middleeast.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/middleeast.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/middleeast.duckdb</string>
     <string>--bbox</string>
         <string>12</string>
     <string>32</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/middleeast.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/middleeast.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/middleeast.log</string>
+  <string>REPLACE_WITH_LOG_DIR/middleeast.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/middleeast.err</string>
+  <string>REPLACE_WITH_LOG_DIR/middleeast.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.aisstream.persiangulf.plist
+++ b/config/launchagents/io.maridb.aisstream.persiangulf.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/persiangulf.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/persiangulf.duckdb</string>
     <string>--bbox</string>
         <string>22</string>
     <string>48</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/persiangulf.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/persiangulf.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/persiangulf.log</string>
+  <string>REPLACE_WITH_LOG_DIR/persiangulf.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/persiangulf.err</string>
+  <string>REPLACE_WITH_LOG_DIR/persiangulf.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.aisstream.singapore.plist
+++ b/config/launchagents/io.maridb.aisstream.singapore.plist
@@ -8,15 +8,15 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
     <string>-m</string>
     <string>pipelines.ingest.ais_stream</string>
     <string>--db</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/singapore.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/singapore.duckdb</string>
     <string>--bbox</string>
         <string>-5</string>
     <string>92</string>
@@ -29,18 +29,18 @@
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>AISSTREAM_API_KEY</key>
     <string>REPLACE_WITH_AISSTREAM_API_KEY</string>
     <key>DB_PATH</key>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed/singapore.duckdb</string>
+    <string>REPLACE_WITH_PROJECT_DIR/data/raw/ais/singapore.duckdb</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -53,8 +53,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/singapore.log</string>
+  <string>REPLACE_WITH_LOG_DIR/singapore.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/singapore.err</string>
+  <string>REPLACE_WITH_LOG_DIR/singapore.err</string>
 </dict>
 </plist>

--- a/config/launchagents/io.maridb.r2sync.plist
+++ b/config/launchagents/io.maridb.r2sync.plist
@@ -8,21 +8,23 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/uv</string>
+    <string>REPLACE_WITH_UV_BIN</string>
     <string>run</string>
     <string>--project</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
     <string>python</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/scripts/sync_r2.py</string>
+    <string>REPLACE_WITH_PROJECT_DIR/scripts/sync_r2.py</string>
     <string>push-ais-parquet</string>
     <string>--regions</string>
     <string>japansea,blacksea,middleeast,singapore,europe,gulfofmexico,hornofafrica,persiangulf,gulfofaden,gulfofguinea</string>
     <string>--data-dir</string>
-    <string>/Users/yoheionishi/work/edgesentry/maridb/data/processed</string>
+    <string>REPLACE_WITH_HOME/.maridb/data/raw/ais</string>
+    <string>--staging-dir</string>
+    <string>REPLACE_WITH_HOME/.maridb/data/staging/ais</string>
   </array>
 
   <key>WorkingDirectory</key>
-  <string>/Users/yoheionishi/work/edgesentry/maridb</string>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
 
   <key>EnvironmentVariables</key>
   <dict>
@@ -33,9 +35,9 @@
     <key>S3_BUCKET</key>
     <string>maridb-public</string>
     <key>HOME</key>
-    <string>/Users/yoheionishi</string>
+    <string>REPLACE_WITH_HOME</string>
     <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/yoheionishi/.local/bin:/Users/yoheionishi/.cargo/bin</string>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
     <key>PYTHONUNBUFFERED</key>
     <string>1</string>
   </dict>
@@ -48,8 +50,8 @@
   <true/>
 
   <key>StandardOutPath</key>
-  <string>/Users/yoheionishi/.maridb/r2sync.log</string>
+  <string>REPLACE_WITH_LOG_DIR/r2sync.log</string>
   <key>StandardErrorPath</key>
-  <string>/Users/yoheionishi/.maridb/r2sync.err</string>
+  <string>REPLACE_WITH_LOG_DIR/r2sync.err</string>
 </dict>
 </plist>

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -5,98 +5,129 @@
 ## Overview
 
 ```
-[macOS local]                [Cloudflare R2]              [GitHub Actions]        [arktrace PWA]
+[macOS — always running]       [Cloudflare R2]        [GitHub Actions — daily]   [apps]
 
-AIS stream (live)
-  singapore.duckdb ──┐
-  japansea.duckdb  ──┼── push-ais-parquet ──→ maridb-public/ais/  ──┐
-  blacksea.duckdb  ──┘   (hourly, incremental)                       │
-                                                                      │ pull-ais-parquet
-                                                              data-publish.yml (daily)
-                                                                      │
-                                                              ingest → features → score
-                                                                      │
-                                                              Gate 1: validate
-                                                                      │
-                                                              ┌───────┴────────┐
-                                                              ▼                ▼
-                                                    maridb-public/      maridb-public/
-                                                    features/           score/
-                                                              │
-                                                      Gate 2: validate + R2-to-R2 copy
-                                                              │
-                                                    arktrace-public/    documaris-public/
-                                                    watchlist/          voyage-evidence/
-                                                    features/
-                                                              │
-                                                              ▼
-                                                    DuckDB-WASM reads
-                                                    watchlist.parquet
+LaunchAgent: aisstream
+  raw/ais/singapore.duckdb ─┐
+  raw/ais/japansea.duckdb  ─┤
+  raw/ais/blacksea.duckdb  ─┘
+           │
+           │ LaunchAgent: r2sync (hourly)
+           │ push-ais-parquet
+           ▼
+  staging/ais/region=*/date=*/
+           │
+           │ upload
+           ▼
+     maridb-public/ais/               ←──── pull-ais-parquet (data-publish.yml)
+                                                    │
+                                          downloads/ais/region=*/date=*/
+                                                    │
+                                          _load_ais_from_parquet()
+                                                    │
+                                          processed/ais/{region}.duckdb
+                                                    │
+                                          ingest → features → score
+                                                    │
+                                          Gate 1: validate
+                                                    │
+                                          push to maridb-public/score/
+                                                    │
+                                          Gate 2: validate + distribute
+                                          ┌─────────┴─────────┐
+                                          ▼                   ▼
+                                  arktrace-public/    documaris-public/
+                                  watchlist/          voyage-evidence/
+                                  features/
+                                          │
+                                          ▼
+                                  DuckDB-WASM (browser)
 ```
 
 ---
 
-## Storage format decisions
+## Local directory layout
 
-| Stage | Format | Reason |
-|---|---|---|
-| Local AIS stream | **DuckDB** (`.duckdb` per region) | Streaming writes; SQL aggregation; concurrent read-write supported |
-| R2 intermediate (AIS raw) | **Parquet** (date-partitioned) | Universal; incremental upload by date; no tooling dependency |
-| R2 intermediate (features, scores) | **Parquet** | Readable by polars, DuckDB, DuckDB-WASM without extensions |
-| arktrace PWA | **Parquet** via DuckDB-WASM | Browser-native; selective download; no DuckLake extension needed |
+All local data lives under `~/.maridb/data/` (override with `MARIDB_DATA_DIR` env var).
 
-DuckLake was evaluated and rejected: its incremental-append benefit is matched by date-partitioned Parquet, and DuckLake extensions are not guaranteed in DuckDB-WASM.
+```
+~/.maridb/
+├── data/
+│   ├── raw/
+│   │   └── ais/
+│   │       ├── singapore.duckdb     ← LaunchAgent writes live AIS positions here
+│   │       ├── japansea.duckdb
+│   │       └── blacksea.duckdb      (one file per active region)
+│   │
+│   ├── staging/
+│   │   └── ais/
+│   │       └── region={r}/
+│   │           └── date=YYYY-MM-DD/
+│   │               └── positions.parquet  ← push-ais-parquet writes here before upload
+│   │
+│   ├── downloads/
+│   │   └── ais/
+│   │       └── region={r}/
+│   │           └── date=YYYY-MM-DD/
+│   │               └── positions.parquet  ← pull-ais-parquet downloads from R2 here
+│   │
+│   └── processed/
+│       └── ais/
+│           ├── singapore.duckdb     ← run_pipeline.py working DB (rebuilt from downloads/)
+│           └── japansea.duckdb
+│
+├── env                              ← secrets (git-ignored); sourced by LaunchAgents
+├── singapore.log / singapore.err    ← aisstream LaunchAgent stdout/stderr
+└── r2sync.log / r2sync.err          ← r2sync LaunchAgent stdout/stderr
+```
 
 ---
 
-## Stage 1 — Local AIS stream collection
+## Stage 1 — AIS stream collection (local, always running)
 
-**What:** macOS LaunchAgents continuously write live AIS positions to local DuckDB files.
+**What:** macOS LaunchAgents stream live AIS positions via WebSocket and append rows to DuckDB.
 
-**Who writes:** `pipelines/ingest/ais_stream.py` (via LaunchAgent)
+**Who writes:** `pipelines/ingest/ais_stream.py` via `io.maridb.aisstream.<region>` LaunchAgent
 
-**Output:**
-```
-data/processed/
-  singapore.duckdb    ← ais_positions, vessel_meta tables
-  japansea.duckdb
-  blacksea.duckdb
-```
+**Writes to:** `~/.maridb/data/raw/ais/{region}.duckdb`
+
+**Tables written:** `ais_positions`, `vessel_meta`
 
 **Manage LaunchAgents:**
 ```bash
-# Load 3 regions + r2sync
+# Install (copies and loads all plists for listed regions)
 bash scripts/install_launchagents.sh singapore japansea blacksea
-
-# Unload all
-bash scripts/install_launchagents.sh --unload singapore japansea blacksea
 
 # Check status
 launchctl list | grep io.maridb
+
+# Tail live AIS log
+tail -f ~/.maridb/singapore.log
+
+# Unload all
+bash scripts/install_launchagents.sh --unload singapore japansea blacksea
 ```
 
-Secrets are in `~/.maridb/env` (git-ignored). Templates with `REPLACE_WITH_*` placeholders are in `config/launchagents/`.
+Plist templates with `REPLACE_WITH_*` placeholders live in `config/launchagents/`. Filled-in
+`*.local.plist` files are git-ignored. Secrets come from `~/.maridb/env`.
 
 ---
 
-## Stage 2 — R2 upload (local → maridb-public)
+## Stage 2 — R2 upload (local → maridb-public, hourly)
 
-**What:** Hourly LaunchAgent exports new AIS rows to date-partitioned Parquet and uploads to `maridb-public`.
+**What:** Exports new AIS rows from raw DuckDB to date-partitioned Parquet, stages locally, then uploads to `maridb-public`.
 
-**Who writes:** `scripts/sync_r2.py push-ais-parquet` (via `io.maridb.r2sync` LaunchAgent)
+**Who writes:** `scripts/sync_r2.py push-ais-parquet` via `io.maridb.r2sync` LaunchAgent
+
+**Reads from:** `~/.maridb/data/raw/ais/{region}.duckdb`
+
+**Stages to:** `~/.maridb/data/staging/ais/region={r}/date=YYYY-MM-DD/positions.parquet`
+
+**Uploads to:** `maridb-public/ais/region={r}/date=YYYY-MM-DD/positions.parquet`
 
 **Incremental logic:** checks which `date=YYYY-MM-DD` partitions already exist in R2; only uploads new dates.
 
-**Output on R2:**
-```
-maridb-public/
-  ais/
-    region=singapore/date=2026-04-25/positions.parquet
-    region=japansea/date=2026-04-25/positions.parquet
-    region=blacksea/date=2026-04-25/positions.parquet
-```
-
-**Schema:**
+**Parquet schema:**
 
 | Column | Type | Notes |
 |---|---|---|
@@ -106,7 +137,7 @@ maridb-public/
 | `lon` | DOUBLE | longitude |
 | `sog` | FLOAT | speed over ground (knots) |
 | `cog` | FLOAT | course over ground (degrees) |
-| `nav_status` | TINYINT | AIS navigational status |
+| `nav_status` | TINYINT | AIS navigational status code |
 | `ship_type` | TINYINT | AIS ship type code |
 
 **Manual run:**
@@ -114,26 +145,105 @@ maridb-public/
 source ~/.maridb/env
 uv run python scripts/sync_r2.py push-ais-parquet \
   --regions singapore,japansea,blacksea \
-  --data-dir data/processed
+  --data-dir ~/.maridb/data/raw/ais \
+  --staging-dir ~/.maridb/data/staging/ais
 ```
 
 ---
 
-## Stage 3 — CI pipeline (data-publish.yml)
+## Stage 3 — CI pipeline (data-publish.yml, daily at 01:00 UTC)
 
-**Trigger:** daily 01:00 UTC; manual dispatch.
+**Trigger:** daily 01:00 UTC; or manually via `gh workflow run data-publish.yml`.
 
-**Steps:**
+**All steps run on the CI runner. No local machine needed.**
 
-| Step | Script | Input | Output |
-|---|---|---|---|
-| Pull AIS Parquet | `sync_r2.py pull-ais-parquet` | `maridb-public/ais/` | local `data/processed/ais/` |
-| Ingest (schema, sanctions, vessel registry) | `pipelines/ingest/` | local `.duckdb` + Parquet | local `.duckdb` |
-| Features | `pipelines/features/build_matrix.py` | local `.duckdb` | `vessel_features.parquet` |
-| Score | `pipelines/score/composite.py`, `watchlist.py` | local `.duckdb` | `{region}_watchlist.parquet` |
-| Gate 1 validate + push to maridb-public | `sync_r2.py push` | local Parquet | `maridb-public/features/`, `maridb-public/score/` |
-| Gate 2 distribute | `pipelines/distribute/push.py` | `maridb-public/` | `arktrace-public/`, `documaris-public/` |
-| Notify | `scripts/notify_metrics.py` | pipeline results | email |
+### Step 3a — Download AIS Parquet
+
+```bash
+uv run python scripts/sync_r2.py pull-ais-parquet \
+  --days 60 \
+  --regions singapore,japansea,blacksea
+```
+
+Downloads last 60 days of AIS partitions from `maridb-public/ais/` into the runner's
+`~/.maridb/data/downloads/ais/` (path from `MARIDB_DATA_DIR`).
+
+### Step 3b — Ingest (run_pipeline.py step 1)
+
+`_load_ais_from_parquet()` loads downloaded Parquet into `processed/ais/{region}.duckdb`,
+then the following modules run against that DB:
+
+| Module | What it ingests |
+|---|---|
+| `pipelines/ingest/schema.py` | Creates/migrates DB schema |
+| `pipelines/ingest/sanctions.py` | OFAC SDN + UN Consolidated list |
+| `pipelines/ingest/vessel_registry.py` | IMO/MMSI registry |
+| `pipelines/ingest/gdelt.py` | GDELT news events (last N days) |
+
+**DB written:** `~/.maridb/data/processed/ais/{region}.duckdb`
+
+### Step 3c — Features (run_pipeline.py step 2)
+
+| Module | What it computes |
+|---|---|
+| `pipelines/features/ais_behavior.py` | Gap counts, loitering hours, position jumps |
+| `pipelines/features/identity.py` | Flag/name/owner change counts |
+| `pipelines/features/trade_mismatch.py` | Route vs cargo type mismatch |
+| `pipelines/features/build_matrix.py` | Assembles `vessel_features` table |
+
+**DB written:** `processed/ais/{region}.duckdb` (`vessel_features` table)
+
+### Step 3d — Score (run_pipeline.py step 3)
+
+| Module | What it outputs |
+|---|---|
+| `pipelines/score/mpol_baseline.py` | MPOL ownership risk baseline |
+| `pipelines/score/anomaly.py` | Isolation Forest anomaly scores |
+| `pipelines/score/composite.py` | Final `confidence` + `composite_score` |
+| `pipelines/score/watchlist.py` | `{region}_watchlist.parquet` |
+
+**Files written:**
+```
+data/processed/
+  score/
+    singapore_watchlist.parquet
+    composite_scores.parquet
+    causal_effects.parquet
+```
+
+### Step 3e — Gate 1: validate + push to maridb-public
+
+Validation in `pipelines/storage/validate.py`. Upload aborts on failure.
+
+```bash
+uv run python scripts/sync_r2.py push-watchlists --data-dir data/processed
+```
+
+**Writes to R2:**
+```
+maridb-public/
+  score/
+    singapore_watchlist.parquet
+    composite_scores.parquet
+```
+
+### Step 3f — Gate 2: distribute to app buckets
+
+`pipelines/distribute/push.py` validates then copies to app buckets.
+
+**Writes to R2:**
+```
+arktrace-public/
+  score/
+    singapore_watchlist.parquet
+    composite_scores.parquet
+    causal_effects.parquet
+  ducklake_manifest.json      ← index for DuckDB-WASM browser sync
+```
+
+### Step 3g — Notify
+
+`scripts/notify_metrics.py` emails pipeline metrics (AUROC, Precision@50, known-case coverage).
 
 ---
 
@@ -141,31 +251,23 @@ uv run python scripts/sync_r2.py push-ais-parquet \
 
 ### arktrace PWA
 
-Reads from `arktrace-public` via DuckDB-WASM in the browser.
+Reads watchlists + scores from `arktrace-public` via DuckDB-WASM in the browser.
+`ducklake_manifest.json` tells the Service Worker which files to cache.
 
 ```
 arktrace-public/
-  watchlist/singapore_watchlist.parquet
-  watchlist/japansea_watchlist.parquet
-  features/vessel_features.parquet
-  ais-summaries/latest.parquet
+  score/
+    singapore_watchlist.parquet
+    japansea_watchlist.parquet
+    composite_scores.parquet
+    causal_effects.parquet
+  ducklake_manifest.json
 ```
-
-Files are downloaded on first load, cached by Service Worker, and queried offline via DuckDB-WASM.
 
 ### documaris app
 
-Reads vessel/voyage/cargo from `maridb-public` directly (no copy needed).
-Reads voyage evidence and regulatory KB from `documaris-public`.
-
-```
-maridb-public/vessels/snapshot/
-maridb-public/voyages/snapshot/
-maridb-public/cargo/snapshot/
-
-documaris-public/voyage-evidence/
-documaris-public/regulatory-kb/
-```
+Reads vessel/voyage/cargo directly from `maridb-public` (no copy needed).
+Reads voyage evidence from `documaris-public`.
 
 ---
 
@@ -175,17 +277,21 @@ documaris-public/regulatory-kb/
 
 Implemented in `pipelines/storage/validate.py`. Raises `PipelineValidationError` on failure; upload is aborted.
 
-- Schema check: required columns present with correct types
-- Null check: no nulls in required fields
-- Row count ≥ minimum threshold
+| Check | Failure action |
+|---|---|
+| Required columns present with correct types | Abort upload |
+| No nulls in required fields | Abort upload |
+| Row count ≥ minimum threshold | Abort upload |
 
 ### Gate 2 — before R2-to-R2 copy to app buckets
 
-Implemented in `pipelines/distribute/push.py`. On failure, the previous version in the app bucket remains live.
+Implemented in `pipelines/distribute/push.py`. Previous version in the app bucket remains live on failure.
 
-- Watchlist row count within expected range
-- AIS coverage ≥ threshold for the region
-- Regulatory KB: no silent key deletion
+| Check | Failure action |
+|---|---|
+| Watchlist row count ≥ 1 | Abort copy |
+| `composite_score` column present | Abort copy |
+| Vessel features / AIS summaries present | Warn only (not yet enforced) |
 
 ---
 
@@ -195,16 +301,30 @@ Implemented in `pipelines/distribute/push.py`. On failure, the previous version 
 # Check LaunchAgents
 launchctl list | grep io.maridb
 
-# Manual AIS → R2 upload
-source ~/.maridb/env
-uv run python scripts/sync_r2.py push-ais-parquet --regions singapore,japansea,blacksea --data-dir data/processed
+# Tail live logs
+tail -f ~/.maridb/singapore.log
+tail -f ~/.maridb/r2sync.log
 
-# Manual full pipeline
-uv run python scripts/run_pipeline.py --region singapore --non-interactive
+# Manual: upload today's AIS to R2
+source ~/.maridb/env
+uv run python scripts/sync_r2.py push-ais-parquet \
+  --regions singapore,japansea,blacksea \
+  --data-dir ~/.maridb/data/raw/ais \
+  --staging-dir ~/.maridb/data/staging/ais
+
+# Manual: download 60 days of AIS from R2 (runs before pipeline locally)
+source ~/.maridb/env
+uv run python scripts/sync_r2.py pull-ais-parquet \
+  --regions singapore \
+  --days 60
+
+# Manual: run full pipeline locally for one region
+MARIDB_DATA_DIR=~/.maridb/data \
+  uv run python scripts/run_pipeline.py --region singapore --non-interactive
 
 # Trigger CI manually
 gh workflow run data-publish.yml --repo edgesentry/maridb
 
-# Check CI logs
+# Check recent CI runs
 gh run list --repo edgesentry/maridb --limit 5
 ```

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -33,14 +33,15 @@ class RegionConfig:
     watchlist_key: str
 
 
-# Resolve DB directory from MARIDB_DATA_DIR (set by LaunchAgents and CI) or default.
-# LaunchAgents write to {MARIDB_DATA_DIR}/{region}.duckdb.
-_DB_DIR = Path(
+_MARIDB_DATA = Path(
     os.getenv("MARIDB_DATA_DIR") or os.getenv("DATA_DIR") or (Path.home() / ".maridb" / "data")
 )
+_DB_DIR = _MARIDB_DATA / "processed" / "ais"
+_DOWNLOADS_DIR = _MARIDB_DATA / "downloads" / "ais"
 
 
 def _db(stem: str) -> str:
+    _DB_DIR.mkdir(parents=True, exist_ok=True)
     return str(_DB_DIR / f"{stem}.duckdb")
 
 
@@ -198,9 +199,47 @@ def _seed_dummy_vessels(db_path: str) -> None:
     logger.info("  ✓ seeded %d dummy sanctioned vessels", len(_DUMMY_MMSIS))
 
 
+def _load_ais_from_parquet(region: RegionConfig) -> int:
+    """Load downloaded AIS Parquet partitions into the processed DuckDB. Returns row count."""
+    parquet_glob = _DOWNLOADS_DIR / f"region={region.name}" / "date=*" / "positions.parquet"
+    parquet_files = sorted(_DOWNLOADS_DIR.glob(f"region={region.name}/date=*/positions.parquet"))
+    if not parquet_files:
+        logger.warning("  ⚠ No AIS Parquet partitions found in %s", _DOWNLOADS_DIR / f"region={region.name}")
+        return 0
+
+    con = duckdb.connect(region.db_path)
+    try:
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS ais_positions (
+                mmsi        VARCHAR,
+                timestamp   TIMESTAMPTZ,
+                lat         DOUBLE,
+                lon         DOUBLE,
+                sog         FLOAT,
+                cog         FLOAT,
+                nav_status  INTEGER,
+                ship_type   INTEGER
+            )
+        """)
+        files_str = ", ".join(f"'{p}'" for p in parquet_files)
+        rows = con.execute(f"""
+            INSERT INTO ais_positions
+            SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type
+            FROM read_parquet([{files_str}])
+            WHERE (mmsi, timestamp) NOT IN (SELECT mmsi, timestamp FROM ais_positions)
+        """).rowcount or 0
+    finally:
+        con.close()
+    logger.info("  ✓ ais_positions: loaded %d new rows from %d partition(s)", rows, len(parquet_files))
+    return rows
+
+
 def step_ingest(region: RegionConfig, gdelt_days: int = 3) -> bool:
     logger.info("[1/4] Ingest — AIS, vessel registry, sanctions, GDELT")
     env = {"DB_PATH": region.db_path, "MARIDB_REGION": region.name}
+
+    # Load AIS positions from downloaded Parquet partitions first
+    _load_ais_from_parquet(region)
 
     steps = [
         ([sys.executable, "-m", "pipelines.ingest.schema", "--db", region.db_path], "schema"),

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -33,41 +33,52 @@ class RegionConfig:
     watchlist_key: str
 
 
+# Resolve DB directory from MARIDB_DATA_DIR (set by LaunchAgents and CI) or default.
+# LaunchAgents write to {MARIDB_DATA_DIR}/{region}.duckdb.
+_DB_DIR = Path(
+    os.getenv("MARIDB_DATA_DIR") or os.getenv("DATA_DIR") or (Path.home() / ".maridb" / "data")
+)
+
+
+def _db(stem: str) -> str:
+    return str(_DB_DIR / f"{stem}.duckdb")
+
+
 REGIONS: dict[str, RegionConfig] = {
     "singapore": RegionConfig(
         name="singapore",
         bbox=[-5, 92, 22, 122],
-        db_path=str(Path.home() / ".maridb" / "data" / "singapore.duckdb"),
+        db_path=_db("singapore"),
         watchlist_key="score/singapore_watchlist.parquet",
     ),
     "japansea": RegionConfig(
         name="japansea",
         bbox=[25, 115, 48, 145],
-        db_path=str(Path.home() / ".maridb" / "data" / "japansea.duckdb"),
+        db_path=_db("japansea"),
         watchlist_key="score/japansea_watchlist.parquet",
     ),
     "japan": RegionConfig(
         name="japansea",
         bbox=[25, 115, 48, 145],
-        db_path=str(Path.home() / ".maridb" / "data" / "japansea.duckdb"),
+        db_path=_db("japansea"),
         watchlist_key="score/japansea_watchlist.parquet",
     ),
     "blacksea": RegionConfig(
         name="blacksea",
         bbox=[40, 27, 47, 42],
-        db_path=str(Path.home() / ".maridb" / "data" / "blacksea.duckdb"),
+        db_path=_db("blacksea"),
         watchlist_key="score/blacksea_watchlist.parquet",
     ),
     "europe": RegionConfig(
         name="europe",
         bbox=[35, -10, 65, 30],
-        db_path=str(Path.home() / ".maridb" / "data" / "europe.duckdb"),
+        db_path=_db("europe"),
         watchlist_key="score/europe_watchlist.parquet",
     ),
     "middleeast": RegionConfig(
         name="middleeast",
         bbox=[10, 32, 32, 62],
-        db_path=str(Path.home() / ".maridb" / "data" / "middleeast.duckdb"),
+        db_path=_db("middleeast"),
         watchlist_key="score/middleeast_watchlist.parquet",
     ),
 }

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1237,112 +1237,6 @@ def _ducklake_upload(local_catalog: Path, local_data: Path, bucket: str, fs: obj
     return uploaded
 
 
-def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
-    """Append new ais_positions rows to DuckLake catalog and upload to maridb-public.
-
-    For each region DB:
-      1. Query local .duckdb for rows newer than the catalog's latest timestamp
-      2. Append to DuckLake (catalog.duckdb + data/ Parquet files)
-      3. CHECKPOINT to materialise clean Parquet
-      4. Upload catalog + changed Parquet files to maridb-public/ducklake/
-
-    Layout on R2:
-      maridb-public/ducklake/catalog.duckdb
-      maridb-public/ducklake/data/<table>/<uuid>.parquet
-
-    The local .duckdb remains as the source of truth and is never deleted.
-    """
-    import duckdb as _duckdb
-
-    from pipelines.storage.ducklake import checkpoint, write_table
-
-    data_dir = Path(args.data_dir)
-    catalog_path = data_dir / "ducklake" / "catalog.duckdb"
-    ducklake_data = data_dir / "ducklake" / "data"
-
-    regions: list[str] | None = (
-        [r.strip() for r in args.regions.split(",")] if args.regions else None
-    )
-    candidates = _ais_db_candidates(data_dir, regions)
-    if not candidates:
-        print("No eligible AIS .duckdb files found.", file=sys.stderr)
-        return 1
-
-    total_rows = 0
-    for db_path in candidates:
-        stem = db_path.stem
-        region = next((r for r, p in _REGION_PREFIX.items() if p == stem), stem)
-
-        print(f"\n[{region}] Reading {db_path.name} ...")
-        try:
-            src = _duckdb.connect(str(db_path), read_only=True)
-        except Exception as exc:
-            print(f"  [skip] cannot open DB: {exc}", file=sys.stderr)
-            continue
-
-        # Find the last timestamp already written to the catalog for this region
-        last_ts: str | None = None
-        if catalog_path.exists():
-            try:
-                cat = _duckdb.connect(":memory:")
-                cat.execute("INSTALL ducklake; LOAD ducklake")
-                cat.execute(
-                    f"ATTACH 'ducklake:{catalog_path.resolve()}' AS lake "
-                    f"(DATA_PATH '{ducklake_data.resolve()}')"
-                )
-                row = cat.execute(
-                    "SELECT MAX(timestamp) FROM lake.ais_positions WHERE region = ?",
-                    [region],
-                ).fetchone()
-                last_ts = str(row[0]) if row and row[0] else None
-                cat.close()
-            except Exception:
-                pass
-
-        if last_ts:
-            df = src.execute(
-                "SELECT ?, mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type "
-                "FROM ais_positions WHERE timestamp > ? ORDER BY timestamp",
-                [region, last_ts],
-            ).pl()
-        else:
-            df = src.execute(
-                "SELECT ?, mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type "
-                "FROM ais_positions ORDER BY timestamp",
-                [region],
-            ).pl()
-
-        df = df.rename({"main.?": "region"}) if "main.?" in df.columns else df
-        # DuckDB parameter placeholder lands as column "?" — rename
-        if "?" in df.columns:
-            df = df.rename({"?": "region"})
-
-        src.close()
-
-        if df.is_empty():
-            print(f"  no new rows since {last_ts} — skipping")
-            continue
-
-        print(f"  {len(df):,} new rows (since {last_ts or 'beginning'})")
-        write_table(df, "ais_positions", catalog_path, ducklake_data, replace=False)
-        total_rows += len(df)
-
-    if total_rows == 0:
-        print("\nAll regions up-to-date — nothing to upload.")
-        return 0
-
-    print(f"\nCheckpointing DuckLake ({total_rows:,} new rows) ...")
-    parquet_files = checkpoint(catalog_path, ducklake_data)
-    print(f"  {len(parquet_files)} Parquet file(s) materialised")
-
-    print(f"\nUploading to {os.getenv('S3_BUCKET', _DEFAULT_BUCKET)}/ducklake/ ...")
-    fs = _build_r2_fs()
-    bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
-    n = _ducklake_upload(catalog_path, ducklake_data, bucket, fs)
-    print(f"\nDone. {n} file(s) uploaded.")
-    return 0
-
-
 def cmd_pull_ais_parquet(args: argparse.Namespace) -> int:
     """Download DuckLake catalog + Parquet files from maridb-public/ducklake/.
 
@@ -1405,17 +1299,20 @@ def cmd_pull_ais_parquet(args: argparse.Namespace) -> int:
     print(f"\nDone. {total} file(s) downloaded to {data_dir}/ducklake/")
     return 0
 def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
-    """Export new ais_positions rows to date-partitioned Parquet and upload to maridb-public.
+    """Export new ais_positions rows to date-partitioned Parquet, stage locally, then upload.
+
+    Flow: raw/ais/{region}.duckdb → staging/ais/region=*/date=*/positions.parquet → R2
 
     Incremental by date: only uploads date partitions not already in R2.
-    Layout: maridb-public/ais/region=<region>/date=YYYY-MM-DD/positions.parquet
-    The local .duckdb remains as the source of truth and is never deleted.
+    Staging directory acts as a local mirror before upload; already-staged
+    partitions are re-uploaded if missing from R2.
     """
     import duckdb as _duckdb
     import pyarrow.fs as pafs
     import pyarrow.parquet as pq
 
     data_dir = Path(args.data_dir)
+    staging_dir = Path(args.staging_dir)
     regions: list[str] | None = (
         [r.strip() for r in args.regions.split(",")] if args.regions else None
     )
@@ -1449,35 +1346,40 @@ def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
         ]
         print(f"  {row_count:,} rows across {len(dates)} date(s)")
         r2_prefix = f"{bucket}/ais/region={region}/"
-        existing: set[str] = set()
+        existing_r2: set[str] = set()
         try:
             for info in fs.get_file_info(pafs.FileSelector(r2_prefix, recursive=True)):
                 for part in info.path.split("/"):
                     if part.startswith("date="):
-                        existing.add(part.removeprefix("date="))
+                        existing_r2.add(part.removeprefix("date="))
         except Exception:
             pass
-        to_upload = [d for d in dates if d not in existing]
+        to_upload = [d for d in dates if d not in existing_r2]
         if not to_upload:
             print(f"  all {len(dates)} date(s) already in R2 - skipping")
             con.close()
             continue
-        print(f"  uploading {len(to_upload)} new date(s) ({len(existing)} already in R2) ...")
+        print(f"  staging + uploading {len(to_upload)} new date(s) ({len(existing_r2)} already in R2) ...")
         for date_str in to_upload:
             table = con.execute(
                 "SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type "
                 "FROM ais_positions WHERE CAST(timestamp AS DATE) = ? ORDER BY mmsi, timestamp",
                 [date_str],
             ).to_arrow_table()
+            # Write to staging first
+            local_path = staging_dir / f"region={region}" / f"date={date_str}" / "positions.parquet"
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            pq.write_table(table, local_path, compression="snappy")
+            # Upload from staging to R2
             r2_key = f"{bucket}/ais/region={region}/date={date_str}/positions.parquet"
             try:
                 pq.write_table(table, r2_key, filesystem=fs, compression="snappy")
-                print(f"    {date_str} ({table.num_rows:,} rows) -> {r2_key}")
+                print(f"    {date_str} ({table.num_rows:,} rows) -> staging + {r2_key}")
                 total_uploaded += 1
             except Exception as exc:
                 print(f"    [error] {date_str}: {exc}", file=sys.stderr)
         con.close()
-    print(f"Done. {total_uploaded} partition(s) uploaded to {bucket}/ais/")
+    print(f"Done. {total_uploaded} partition(s) staged to {staging_dir} and uploaded to {bucket}/ais/")
     return 0
 
 
@@ -1725,7 +1627,18 @@ def main() -> int:
         "push-ais-parquet",
         help="Export ais_positions to date-partitioned Parquet and upload to maridb-public/ais/",
     )
-    push_ais_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+    push_ais_p.add_argument(
+        "--data-dir",
+        default=str(Path.home() / ".maridb" / "data" / "raw" / "ais"),
+        metavar="DIR",
+        help="Directory containing raw AIS .duckdb files (default: ~/.maridb/data/raw/ais)",
+    )
+    push_ais_p.add_argument(
+        "--staging-dir",
+        default=str(Path.home() / ".maridb" / "data" / "staging" / "ais"),
+        metavar="DIR",
+        help="Local staging directory for Parquet partitions before upload (default: ~/.maridb/data/staging/ais)",
+    )
     push_ais_p.add_argument(
         "--regions", default=None, metavar="REGIONS",
         help=f"Comma-separated region names (default: all). Known: {', '.join(_REGION_PREFIX)}",
@@ -1735,7 +1648,12 @@ def main() -> int:
         "pull-ais-parquet",
         help="Download AIS date-partitioned Parquet from maridb-public/ais/ to local dir",
     )
-    pull_ais_p.add_argument("--data-dir", default=_DEFAULT_DATA_DIR, metavar="DIR")
+    pull_ais_p.add_argument(
+        "--data-dir",
+        default=str(Path.home() / ".maridb" / "data" / "downloads"),
+        metavar="DIR",
+        help="Local directory to download partitions into (default: ~/.maridb/data/downloads)",
+    )
     pull_ais_p.add_argument("--regions", default=None, metavar="REGIONS")
     pull_ais_p.add_argument("--days", type=int, default=60, metavar="N",
                              help="Download only partitions from the last N days (default: 60)")

--- a/tests/test_sync_r2_ais_parquet.py
+++ b/tests/test_sync_r2_ais_parquet.py
@@ -45,7 +45,9 @@ class TestPushAisParquet:
                     "ship_type TINYINT)")
         con.close()
         # File is < 1 MB so _ais_db_candidates skips it
-        args = argparse.Namespace(data_dir=str(tmp_path), regions="singapore")
+        args = argparse.Namespace(
+            data_dir=str(tmp_path), staging_dir=str(tmp_path / "staging"), regions="singapore"
+        )
         rc = sync_r2.cmd_push_ais_parquet(args)
         assert rc == 1  # no eligible files
 
@@ -58,10 +60,13 @@ class TestPushAisParquet:
 
         written_keys = []
 
-        def fake_write_table(table, r2_key, filesystem, compression):
-            written_keys.append(r2_key)
+        def fake_write_table(table, path, filesystem=None, compression=None):
+            if filesystem is not None:  # only track R2 uploads, not local staging writes
+                written_keys.append(path)
 
-        args = argparse.Namespace(data_dir=str(tmp_path), regions="singapore")
+        args = argparse.Namespace(
+            data_dir=str(tmp_path), staging_dir=str(tmp_path / "staging"), regions="singapore"
+        )
         with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
              patch.object(sync_r2, "_ais_db_candidates", return_value=[db]), \
              patch("pyarrow.parquet.write_table", side_effect=fake_write_table):
@@ -83,10 +88,13 @@ class TestPushAisParquet:
 
         written_keys = []
 
-        def fake_write_table(table, r2_key, filesystem, compression):
-            written_keys.append(r2_key)
+        def fake_write_table(table, path, filesystem=None, compression=None):
+            if filesystem is not None:
+                written_keys.append(path)
 
-        args = argparse.Namespace(data_dir=str(tmp_path), regions="singapore")
+        args = argparse.Namespace(
+            data_dir=str(tmp_path), staging_dir=str(tmp_path / "staging"), regions="singapore"
+        )
         with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
              patch.object(sync_r2, "_ais_db_candidates", return_value=[db]), \
              patch("pyarrow.parquet.write_table", side_effect=fake_write_table):
@@ -96,7 +104,9 @@ class TestPushAisParquet:
         assert not any("date=2026-04-01" in k for k in written_keys)
 
     def test_no_eligible_dbs(self, tmp_path):
-        args = argparse.Namespace(data_dir=str(tmp_path), regions="singapore")
+        args = argparse.Namespace(
+            data_dir=str(tmp_path), staging_dir=str(tmp_path / "staging"), regions="singapore"
+        )
         rc = sync_r2.cmd_push_ais_parquet(args)
         assert rc == 1
 


### PR DESCRIPTION
## Summary

- `WATCHLIST_BY_REGION` was built at module load time — `_watchlist_path()` called `score_path.exists()` before `run_pipeline.py` ran, so it always fell back to the flat (non-existent) path, causing `exit 1`
- Replaced with `_get_watchlist_path(region)` called at the point of use, so `score/` is checked **after** the pipeline writes the watchlist there
- Re-applied `run_pipeline.py` `_DB_DIR → processed/ais/` change that was lost in a merge conflict during #31
- Updated `test_backtest_input_validation.py` to call `_get_watchlist_path` instead of the removed `_watchlist_path`

## Test plan
- [ ] `tests/test_backtest_input_validation.py` — all 3 pass
- [ ] `tests/test_sync_r2_ais_parquet.py` — all 7 pass
- [ ] Public Backtest Integration CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)