### PR TITLE
fix: resolve all REPLACE_WITH_* placeholders in install_launchagents.sh

### DIFF
--- a/scripts/install_launchagents.sh
+++ b/scripts/install_launchagents.sh
@@ -76,11 +76,19 @@ process_region() {
   fi
 
   # Generate .local.plist with real secrets and resolved paths
+  UV_BIN="$(command -v uv || echo /opt/homebrew/bin/uv)"
+  DATA_DIR="$HOME/.maridb"
+  LOG_DIR="$HOME/.maridb"
+  mkdir -p "$DATA_DIR/data/raw/ais" "$LOG_DIR"
   sed \
     -e "s|REPLACE_WITH_AISSTREAM_API_KEY|$AISSTREAM_API_KEY|g" \
     -e "s|REPLACE_WITH_AWS_ACCESS_KEY_ID|${AWS_ACCESS_KEY_ID:-}|g" \
     -e "s|REPLACE_WITH_AWS_SECRET_ACCESS_KEY|${AWS_SECRET_ACCESS_KEY:-}|g" \
-    -e "s|REPLACE_WITH_PROJECT_DIR|$HOME/.maridb|g" \
+    -e "s|REPLACE_WITH_PROJECT_DIR/data/raw/ais|$DATA_DIR/data/raw/ais|g" \
+    -e "s|REPLACE_WITH_PROJECT_DIR|$REPO_DIR|g" \
+    -e "s|REPLACE_WITH_UV_BIN|$UV_BIN|g" \
+    -e "s|REPLACE_WITH_HOME|$HOME|g" \
+    -e "s|REPLACE_WITH_LOG_DIR|$LOG_DIR|g" \
     "$template" > "$local_plist"
 
   mkdir -p "$HOME/.maridb"


### PR DESCRIPTION
## Problem

`install_launchagents.sh` left multiple placeholders unexpanded in generated `.local.plist` files, causing agents to fail with exit code 78 (executable not found) or exit code 1 (module not found):

- `REPLACE_WITH_UV_BIN` — left as literal string, LaunchAgent could not find the executable
- `REPLACE_WITH_HOME` — left in PATH and log paths
- `REPLACE_WITH_LOG_DIR` — stdout/stderr paths were literal, no log files created
- `REPLACE_WITH_PROJECT_DIR` — used for both `--project` (repo path) and `--db` (data path), but both were being set to `~/.maridb`, causing `ModuleNotFoundError: No module named 'pipelines'`

## Fix

- `REPLACE_WITH_UV_BIN` → resolved via `command -v uv`
- `REPLACE_WITH_HOME` → `$HOME`
- `REPLACE_WITH_LOG_DIR` → `$HOME/.maridb`
- Split `REPLACE_WITH_PROJECT_DIR` resolution:
  - `REPLACE_WITH_PROJECT_DIR/data/raw/ais` → `$HOME/.maridb/data/raw/ais` (data directory)
  - `REPLACE_WITH_PROJECT_DIR` → `$REPO_DIR` (the actual maridb repo, needed for `uv --project`)

## Result

All three agents (singapore, blacksea, middleeast) now start cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)