### PR TITLE
fix: handle missing AIS data gracefully in pipeline

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -205,7 +205,6 @@ def _seed_dummy_vessels(db_path: str) -> None:
 
 def _load_ais_from_parquet(region: RegionConfig) -> int:
     """Load downloaded AIS Parquet partitions into the processed DuckDB. Returns row count."""
-    parquet_glob = _DOWNLOADS_DIR / f"region={region.name}" / "date=*" / "positions.parquet"
     parquet_files = sorted(_DOWNLOADS_DIR.glob(f"region={region.name}/date=*/positions.parquet"))
     if not parquet_files:
         logger.warning("  ⚠ No AIS Parquet partitions found in %s", _DOWNLOADS_DIR / f"region={region.name}")
@@ -226,12 +225,14 @@ def _load_ais_from_parquet(region: RegionConfig) -> int:
             )
         """)
         files_str = ", ".join(f"'{p}'" for p in parquet_files)
-        rows = con.execute(f"""
+        before = con.execute("SELECT COUNT(*) FROM ais_positions").fetchone()[0]
+        con.execute(f"""
             INSERT INTO ais_positions
             SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type
             FROM read_parquet([{files_str}])
             WHERE (mmsi, timestamp) NOT IN (SELECT mmsi, timestamp FROM ais_positions)
-        """).rowcount or 0
+        """)
+        rows = con.execute("SELECT COUNT(*) FROM ais_positions").fetchone()[0] - before
     finally:
         con.close()
     logger.info("  ✓ ais_positions: loaded %d new rows from %d partition(s)", rows, len(parquet_files))
@@ -286,9 +287,9 @@ def step_features(region: RegionConfig, seed_dummy: bool = False) -> bool:
         _seed_dummy_vessels(region.db_path)
 
     return _validate_step(region.db_path, [
-        ("vessel_features",      "SELECT count(*) FROM vessel_features",                                      1, True),
-        ("vessel_features.mmsi", "SELECT count(*) FROM vessel_features WHERE mmsi IS NOT NULL",              1, True),
-        ("anomaly_scores",       "SELECT count(*) FROM vessel_features WHERE ais_gap_count_30d IS NOT NULL", 1, True),
+        ("vessel_features",      "SELECT count(*) FROM vessel_features",                                      1, False),
+        ("vessel_features.mmsi", "SELECT count(*) FROM vessel_features WHERE mmsi IS NOT NULL",              1, False),
+        ("anomaly_scores",       "SELECT count(*) FROM vessel_features WHERE ais_gap_count_30d IS NOT NULL", 1, False),
     ])
 
 

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1327,7 +1327,10 @@ def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
 
     for db_path in candidates:
         stem = db_path.stem
-        region = next((r for r, p in _REGION_PREFIX.items() if p == stem), stem)
+        # Use stem as the canonical region name in R2 paths so push and pull are consistent.
+        # _REGION_PREFIX maps display names (e.g. "japan") to file stems (e.g. "japansea");
+        # the R2 partition key must match the stem so pull-ais-parquet can find the files.
+        region = stem
         print(f"[{region}] Reading {db_path.name} ...")
         try:
             con = _duckdb.connect(str(db_path), read_only=True)


### PR DESCRIPTION
## Summary

Three bugs fixed:

**1. `push-ais-parquet` used wrong region name on R2** (`region=japan` instead of `region=japansea`)
- `_REGION_PREFIX` maps display names to stems (`"japan" → "japansea"`); push used the key, pull used the stem → they never matched
- Fix: use `stem` directly as the R2 region name so push and pull are consistent
- japansea data was sitting on R2 as `region=japan` — now re-uploaded to `region=japansea`

**2. `_load_ais_from_parquet` reported `-1 new rows`**
- DuckDB `.rowcount` returns -1 for complex `INSERT ... WHERE NOT IN` 
- Fix: count rows before/after the insert

**3. `step_features` validation aborted pipeline when no AIS data**
- `vessel_features` had `required=True` — any region without AIS data (e.g. no LaunchAgent, or `--days` window misses old data) caused hard exit
- Fix: `required=False` — produces warning + empty watchlist instead of aborting

## Test plan
- [ ] `data-publish.yml` pipeline passes for all regions including japansea
- [ ] `push-ais-parquet` correctly uploads to `region=japansea`

🤖 Generated with [Claude Code](https://claude.com/claude-code)