### PR TITLE
feat: export vessel_meta to R2 alongside ais_positions (fixes #42)

### DIFF
--- a/pipelines/storage/schemas.py
+++ b/pipelines/storage/schemas.py
@@ -69,6 +69,19 @@ class VoyageEvidenceSchema(pa.DataFrameModel):
         coerce = True
 
 
+class VesselMetaSchema(pa.DataFrameModel):
+    """Schema for vessel_meta snapshot uploaded to maridb-public/vessel_meta/."""
+
+    mmsi: Series[str] = pa.Field(nullable=False, description="Maritime Mobile Service Identity")
+    imo: Series[str] = pa.Field(nullable=True, description="IMO vessel number")
+    name: Series[str] = pa.Field(nullable=True, description="Vessel name")
+    flag: Series[str] = pa.Field(nullable=True, description="Flag state (ISO 2-letter code)")
+    ship_type: Series[int] = pa.Field(nullable=True, ge=0, description="AIS ship type code")
+
+    class Config:
+        coerce = True
+
+
 class SanctionsEntitiesSchema(pa.DataFrameModel):
     """Schema for the sanctions entities ingest table."""
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -204,10 +204,12 @@ def _seed_dummy_vessels(db_path: str) -> None:
 
 
 def _load_ais_from_parquet(region: RegionConfig) -> int:
-    """Load downloaded AIS Parquet partitions into the processed DuckDB. Returns row count."""
+    """Load downloaded AIS positions + vessel_meta into the processed DuckDB."""
     parquet_files = sorted(_DOWNLOADS_DIR.glob(f"region={region.name}/date=*/positions.parquet"))
-    if not parquet_files:
-        logger.warning("  ⚠ No AIS Parquet partitions found in %s", _DOWNLOADS_DIR / f"region={region.name}")
+    vm_parquet = _DOWNLOADS_DIR.parent / "vessel_meta" / f"region={region.name}.parquet"
+
+    if not parquet_files and not vm_parquet.exists():
+        logger.warning("  ⚠ No AIS data found for %s in %s", region.name, _DOWNLOADS_DIR)
         return 0
 
     con = duckdb.connect(region.db_path)
@@ -224,18 +226,41 @@ def _load_ais_from_parquet(region: RegionConfig) -> int:
                 ship_type   INTEGER
             )
         """)
-        files_str = ", ".join(f"'{p}'" for p in parquet_files)
-        before = con.execute("SELECT COUNT(*) FROM ais_positions").fetchone()[0]
-        con.execute(f"""
-            INSERT INTO ais_positions
-            SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type
-            FROM read_parquet([{files_str}])
-            WHERE (mmsi, timestamp) NOT IN (SELECT mmsi, timestamp FROM ais_positions)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS vessel_meta (
+                mmsi        VARCHAR,
+                imo         VARCHAR,
+                name        VARCHAR,
+                flag        VARCHAR,
+                ship_type   INTEGER
+            )
         """)
-        rows = con.execute("SELECT COUNT(*) FROM ais_positions").fetchone()[0] - before
+        rows = 0
+        if parquet_files:
+            files_str = ", ".join(f"'{p}'" for p in parquet_files)
+            before = con.execute("SELECT COUNT(*) FROM ais_positions").fetchone()[0]
+            con.execute(f"""
+                INSERT INTO ais_positions
+                SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type
+                FROM read_parquet([{files_str}])
+                WHERE (mmsi, timestamp) NOT IN (SELECT mmsi, timestamp FROM ais_positions)
+            """)
+            rows = con.execute("SELECT COUNT(*) FROM ais_positions").fetchone()[0] - before
+            logger.info("  ✓ ais_positions: loaded %d new rows from %d partition(s)", rows, len(parquet_files))
+
+        if vm_parquet.exists():
+            con.execute(f"""
+                INSERT OR REPLACE INTO vessel_meta
+                SELECT mmsi, imo, name, flag, ship_type
+                FROM read_parquet('{vm_parquet}')
+                WHERE mmsi IS NOT NULL
+            """)
+            vm_count = con.execute("SELECT COUNT(*) FROM vessel_meta").fetchone()[0]
+            logger.info("  ✓ vessel_meta: %d vessels loaded from %s", vm_count, vm_parquet.name)
+        else:
+            logger.warning("  ⚠ vessel_meta: not found at %s", vm_parquet)
     finally:
         con.close()
-    logger.info("  ✓ ais_positions: loaded %d new rows from %d partition(s)", rows, len(parquet_files))
     return rows
 
 

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1237,67 +1237,6 @@ def _ducklake_upload(local_catalog: Path, local_data: Path, bucket: str, fs: obj
     return uploaded
 
 
-def cmd_pull_ais_parquet(args: argparse.Namespace) -> int:
-    """Download DuckLake catalog + Parquet files from maridb-public/ducklake/.
-
-    Downloads catalog.duckdb and any Parquet files not already present locally.
-    Consumers can then either:
-      - ATTACH the catalog: ATTACH 'ducklake:<path>/catalog.duckdb' AS lake
-      - Read Parquet directly: pl.read_parquet('<data-dir>/ducklake/data/**/*.parquet')
-
-    Layout on disk:
-      <data-dir>/ducklake/catalog.duckdb
-      <data-dir>/ducklake/data/<table>/<uuid>.parquet
-    """
-    import pyarrow.fs as pafs
-    import pyarrow.parquet as pq
-
-    data_dir = Path(args.data_dir)
-    catalog_local = data_dir / "ducklake" / "catalog.duckdb"
-    data_local = data_dir / "ducklake" / "data"
-    catalog_local.parent.mkdir(parents=True, exist_ok=True)
-    data_local.mkdir(parents=True, exist_ok=True)
-
-    bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
-    fs = _build_r2_fs()
-    total = 0
-
-    # Always pull catalog (small, contains latest metadata)
-    r2_catalog = f"{bucket}/{_DUCKLAKE_AIS_CATALOG}"
-    try:
-        with fs.open_input_file(r2_catalog) as src:  # type: ignore[attr-defined]
-            catalog_local.write_bytes(src.read())
-        print(f"  catalog ← {r2_catalog}")
-        total += 1
-    except Exception as exc:
-        print(f"No DuckLake catalog found in R2 ({exc}). Run push-ais-parquet first.",
-              file=sys.stderr)
-        return 1
-
-    # Pull Parquet files not already present locally
-    r2_data_prefix = f"{bucket}/{_DUCKLAKE_AIS_DATA}/"
-    try:
-        selector = pafs.FileSelector(r2_data_prefix, recursive=True)
-        remote_files = fs.get_file_info(selector)
-    except Exception as exc:
-        print(f"Error listing {r2_data_prefix}: {exc}", file=sys.stderr)
-        return 1
-
-    for info in remote_files:
-        if info.type != pafs.FileType.File or not info.path.endswith(".parquet"):
-            continue
-        rel = info.path.removeprefix(f"{bucket}/{_DUCKLAKE_AIS_DATA}/")
-        local_path = data_local / rel
-        if local_path.exists() and local_path.stat().st_size == info.size:
-            continue
-        local_path.parent.mkdir(parents=True, exist_ok=True)
-        table = pq.read_table(info.path, filesystem=fs)
-        pq.write_table(table, local_path, compression="snappy")
-        print(f"  data/{rel} ({table.num_rows:,} rows)")
-        total += 1
-
-    print(f"\nDone. {total} file(s) downloaded to {data_dir}/ducklake/")
-    return 0
 def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
     """Export new ais_positions rows to date-partitioned Parquet, stage locally, then upload.
 
@@ -1360,29 +1299,58 @@ def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
         to_upload = [d for d in dates if d not in existing_r2]
         if not to_upload:
             print(f"  all {len(dates)} date(s) already in R2 - skipping")
-            con.close()
-            continue
-        print(f"  staging + uploading {len(to_upload)} new date(s) ({len(existing_r2)} already in R2) ...")
-        for date_str in to_upload:
-            table = con.execute(
-                "SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type "
-                "FROM ais_positions WHERE CAST(timestamp AS DATE) = ? ORDER BY mmsi, timestamp",
-                [date_str],
+        else:
+            print(f"  staging + uploading {len(to_upload)} new date(s) ({len(existing_r2)} already in R2) ...")
+            for date_str in to_upload:
+                table = con.execute(
+                    "SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type "
+                    "FROM ais_positions WHERE CAST(timestamp AS DATE) = ? ORDER BY mmsi, timestamp",
+                    [date_str],
+                ).to_arrow_table()
+                local_path = staging_dir / f"region={region}" / f"date={date_str}" / "positions.parquet"
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                pq.write_table(table, local_path, compression="snappy")
+                r2_key = f"{bucket}/ais/region={region}/date={date_str}/positions.parquet"
+                try:
+                    pq.write_table(table, r2_key, filesystem=fs, compression="snappy")
+                    print(f"    {date_str} ({table.num_rows:,} rows) -> staging + {r2_key}")
+                    total_uploaded += 1
+                except Exception as exc:
+                    print(f"    [error] {date_str}: {exc}", file=sys.stderr)
+
+        # Always push vessel_meta (full snapshot — overwrite on every run)
+        try:
+            vm_count = con.execute("SELECT COUNT(*) FROM vessel_meta").fetchone()[0]
+            vm_table = con.execute(
+                "SELECT mmsi, imo, name, flag, ship_type FROM vessel_meta WHERE mmsi IS NOT NULL"
             ).to_arrow_table()
-            # Write to staging first
-            local_path = staging_dir / f"region={region}" / f"date={date_str}" / "positions.parquet"
-            local_path.parent.mkdir(parents=True, exist_ok=True)
-            pq.write_table(table, local_path, compression="snappy")
-            # Upload from staging to R2
-            r2_key = f"{bucket}/ais/region={region}/date={date_str}/positions.parquet"
+        except Exception as exc:
+            print(f"  [skip] vessel_meta: could not read ({exc})", file=sys.stderr)
+            vm_count = 0
+            vm_table = None
+        if vm_count > 0 and vm_table is not None:
+            # Validate schema before upload
             try:
-                pq.write_table(table, r2_key, filesystem=fs, compression="snappy")
-                print(f"    {date_str} ({table.num_rows:,} rows) -> staging + {r2_key}")
+                import polars as _pl
+                from pipelines.storage.schemas import VesselMetaSchema
+                VesselMetaSchema.validate(_pl.from_arrow(vm_table))
+            except Exception as exc:
+                print(f"  [skip] vessel_meta validation failed: {exc}", file=sys.stderr)
+                con.close()
+                continue
+            vm_r2_key = f"{bucket}/vessel_meta/region={region}.parquet"
+            try:
+                pq.write_table(vm_table, vm_r2_key, filesystem=fs, compression="snappy")
+                print(f"  vessel_meta ({vm_count:,} vessels) -> {vm_r2_key}")
                 total_uploaded += 1
             except Exception as exc:
-                print(f"    [error] {date_str}: {exc}", file=sys.stderr)
+                print(f"  [error] vessel_meta: {exc}", file=sys.stderr)
+        else:
+            if vm_table is not None:
+                print(f"  vessel_meta: empty — skipping")
+
         con.close()
-    print(f"Done. {total_uploaded} partition(s) staged to {staging_dir} and uploaded to {bucket}/ais/")
+    print(f"Done. {total_uploaded} file(s) uploaded to {bucket}")
     return 0
 
 
@@ -1437,7 +1405,38 @@ def cmd_pull_ais_parquet(args: argparse.Namespace) -> int:
             total += 1
         except Exception as exc:
             print(f"  [error] {region}/{date_str}: {exc}", file=sys.stderr)
-    print(f"Done. {total} partition(s) downloaded to {data_dir}/ais/")
+
+    # Also pull vessel_meta snapshots for each requested region
+    regions_to_pull = list(regions_filter) if regions_filter else None
+    if regions_to_pull is None:
+        # infer from what exists on R2
+        try:
+            vm_infos = fs.get_file_info(pafs.FileSelector(f"{bucket}/vessel_meta/", recursive=False))
+            regions_to_pull = [
+                Path(i.path).stem.removeprefix("region=")
+                for i in vm_infos
+                if i.type == pafs.FileType.File and i.path.endswith(".parquet")
+            ]
+        except Exception:
+            regions_to_pull = []
+    for region in (regions_to_pull or []):
+        r2_key = f"{bucket}/vessel_meta/region={region}.parquet"
+        local_vm = data_dir / "vessel_meta" / f"region={region}.parquet"
+        try:
+            infos = fs.get_file_info([r2_key])
+            if infos[0].type != pafs.FileType.File:
+                continue
+            if local_vm.exists() and local_vm.stat().st_size == infos[0].size:
+                continue
+            local_vm.parent.mkdir(parents=True, exist_ok=True)
+            vm_table = pq.read_table(r2_key, filesystem=fs)
+            pq.write_table(vm_table, local_vm, compression="snappy")
+            print(f"  vessel_meta/{region} ({vm_table.num_rows:,} vessels) -> {local_vm}")
+            total += 1
+        except Exception as exc:
+            print(f"  [warn] vessel_meta/{region}: {exc}", file=sys.stderr)
+
+    print(f"Done. {total} file(s) downloaded.")
     return 0
 
 

--- a/tests/test_sync_r2_ais_parquet.py
+++ b/tests/test_sync_r2_ais_parquet.py
@@ -14,8 +14,8 @@ import pytest
 import scripts.sync_r2 as sync_r2
 
 
-def _make_duckdb(path: Path, n_rows: int = 5) -> Path:
-    """Create a minimal DuckDB with ais_positions rows."""
+def _make_duckdb(path: Path, n_rows: int = 5, with_vessel_meta: bool = False) -> Path:
+    """Create a minimal DuckDB with ais_positions (and optionally vessel_meta) rows."""
     import duckdb
     from datetime import UTC, datetime, timedelta
 
@@ -30,6 +30,18 @@ def _make_duckdb(path: Path, n_rows: int = 5) -> Path:
     rows = [(f"24000{i:04d}", base + timedelta(hours=i), 1.3, 103.8, 12.0, 180.0, 0, 70)
             for i in range(n_rows)]
     con.executemany("INSERT INTO ais_positions VALUES (?, ?, ?, ?, ?, ?, ?, ?)", rows)
+
+    if with_vessel_meta:
+        con.execute("""
+            CREATE TABLE vessel_meta (
+                mmsi VARCHAR, imo VARCHAR, name VARCHAR, flag VARCHAR, ship_type INTEGER
+            )
+        """)
+        for i in range(n_rows):
+            con.execute(
+                "INSERT INTO vessel_meta VALUES (?, ?, ?, ?, ?)",
+                [f"24000{i:04d}", f"900000{i}", f"VESSEL {i}", "SG", 70],
+            )
     con.close()
     return path
 
@@ -111,6 +123,170 @@ class TestPushAisParquet:
         assert rc == 1
 
 
+class TestVesselMetaPush:
+    def test_pushes_vessel_meta_when_present(self, tmp_path):
+        """push-ais-parquet uploads vessel_meta.parquet to maridb-public/vessel_meta/."""
+        db = _make_duckdb(tmp_path / "singapore.duckdb", n_rows=10, with_vessel_meta=True)
+
+        mock_fs = MagicMock()
+        mock_fs.get_file_info.return_value = []
+
+        written_keys = []
+
+        def fake_write_table(table, path, filesystem=None, compression=None):
+            if filesystem is not None:
+                written_keys.append(path)
+
+        args = argparse.Namespace(
+            data_dir=str(tmp_path), staging_dir=str(tmp_path / "staging"), regions="singapore"
+        )
+        with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
+             patch.object(sync_r2, "_ais_db_candidates", return_value=[db]), \
+             patch("pyarrow.parquet.write_table", side_effect=fake_write_table):
+            rc = sync_r2.cmd_push_ais_parquet(args)
+
+        assert rc == 0
+        vm_keys = [k for k in written_keys if "vessel_meta" in k]
+        assert len(vm_keys) == 1
+        assert vm_keys[0] == "maridb-public/vessel_meta/region=singapore.parquet"
+
+    def test_skips_vessel_meta_when_empty(self, tmp_path):
+        """push-ais-parquet skips vessel_meta upload when table is empty."""
+        db = _make_duckdb(tmp_path / "singapore.duckdb", n_rows=10, with_vessel_meta=False)
+
+        mock_fs = MagicMock()
+        mock_fs.get_file_info.return_value = []
+
+        written_keys = []
+
+        def fake_write_table(table, path, filesystem=None, compression=None):
+            if filesystem is not None:
+                written_keys.append(path)
+
+        args = argparse.Namespace(
+            data_dir=str(tmp_path), staging_dir=str(tmp_path / "staging"), regions="singapore"
+        )
+        with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
+             patch.object(sync_r2, "_ais_db_candidates", return_value=[db]), \
+             patch("pyarrow.parquet.write_table", side_effect=fake_write_table):
+            rc = sync_r2.cmd_push_ais_parquet(args)
+
+        assert rc == 0
+        assert not any("vessel_meta" in k for k in written_keys)
+
+    def test_skips_vessel_meta_on_schema_validation_failure(self, tmp_path):
+        """push-ais-parquet skips vessel_meta upload when schema validation fails."""
+        import duckdb
+        db = tmp_path / "singapore.duckdb"
+        con = duckdb.connect(str(db))
+        con.execute("""
+            CREATE TABLE ais_positions (
+                mmsi VARCHAR, timestamp TIMESTAMPTZ, lat DOUBLE, lon DOUBLE,
+                sog FLOAT, cog FLOAT, nav_status TINYINT, ship_type TINYINT
+            )
+        """)
+        from datetime import UTC, datetime
+        con.execute("INSERT INTO ais_positions VALUES (?,?,?,?,?,?,?,?)",
+                    ["123456789", datetime(2026,4,1,tzinfo=UTC), 1.3, 103.8, 12.0, 180.0, 0, 70])
+        # vessel_meta missing required mmsi column → validation should fail
+        con.execute("CREATE TABLE vessel_meta (bad_col VARCHAR)")
+        con.execute("INSERT INTO vessel_meta VALUES ('oops')")
+        con.close()
+
+        mock_fs = MagicMock()
+        mock_fs.get_file_info.return_value = []
+        written_keys = []
+
+        def fake_write_table(table, path, filesystem=None, compression=None):
+            if filesystem is not None:
+                written_keys.append(path)
+
+        args = argparse.Namespace(
+            data_dir=str(tmp_path), staging_dir=str(tmp_path / "staging"), regions="singapore"
+        )
+        with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
+             patch.object(sync_r2, "_ais_db_candidates", return_value=[db]), \
+             patch("pyarrow.parquet.write_table", side_effect=fake_write_table):
+            rc = sync_r2.cmd_push_ais_parquet(args)
+
+        # rc may be 0 (positions skipped due to date filter) or non-zero; key check is no vm upload
+        assert not any("vessel_meta" in k for k in written_keys)
+
+
+class TestVesselMetaPull:
+    def test_downloads_vessel_meta(self, tmp_path):
+        """pull-ais-parquet downloads vessel_meta parquet for each region."""
+        import pyarrow.fs as pafs
+
+        mock_fs = MagicMock()
+        pos_info = MagicMock()
+        pos_info.path = "maridb-public/ais/region=singapore/date=2026-04-25/positions.parquet"
+        pos_info.size = 512
+        pos_info.type = pafs.FileType.File
+
+        vm_info = MagicMock()
+        vm_info.path = "maridb-public/vessel_meta/region=singapore.parquet"
+        vm_info.size = 256
+        vm_info.type = pafs.FileType.File
+
+        # get_file_info: first call lists ais/, second call checks vm file exists
+        mock_fs.get_file_info.side_effect = [
+            [pos_info],           # listing ais/
+            [vm_info],            # checking vessel_meta file info
+        ]
+
+        pos_table = pa.table({
+            "mmsi": ["123456789"], "timestamp": pa.array([0], type=pa.timestamp("us", tz="UTC")),
+            "lat": [1.3], "lon": [103.8], "sog": [12.0], "cog": [180.0],
+            "nav_status": [0], "ship_type": [70],
+        })
+        vm_table = pa.table({
+            "mmsi": ["123456789"], "imo": ["9000001"], "name": ["TEST VESSEL"],
+            "flag": ["SG"], "ship_type": [70],
+        })
+
+        read_calls = []
+
+        def fake_read_table(path, filesystem=None):
+            read_calls.append(path)
+            if "vessel_meta" in path:
+                return vm_table
+            return pos_table
+
+        with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
+             patch("pyarrow.parquet.read_table", side_effect=fake_read_table), \
+             patch("pyarrow.parquet.write_table"):
+            args = argparse.Namespace(data_dir=str(tmp_path), regions="singapore", days=60)
+            rc = sync_r2.cmd_pull_ais_parquet(args)
+
+        assert rc == 0
+        assert any("vessel_meta" in p for p in read_calls)
+
+    def test_skips_vessel_meta_already_present(self, tmp_path):
+        """pull-ais-parquet skips vessel_meta if local file matches remote size."""
+        import pyarrow.fs as pafs
+
+        local_vm = tmp_path / "vessel_meta" / "region=singapore.parquet"
+        local_vm.parent.mkdir(parents=True)
+        local_vm.write_bytes(b"x" * 256)
+
+        mock_fs = MagicMock()
+        mock_fs.get_file_info.side_effect = [
+            [],       # no positions
+            [MagicMock(type=pafs.FileType.File, size=256,
+                       path="maridb-public/vessel_meta/region=singapore.parquet")],
+        ]
+
+        with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
+             patch("pyarrow.parquet.read_table") as mock_read:
+            args = argparse.Namespace(data_dir=str(tmp_path), regions="singapore", days=60)
+            sync_r2.cmd_pull_ais_parquet(args)
+
+        # vessel_meta should not be re-downloaded (same size)
+        vm_reads = [c for c in mock_read.call_args_list if "vessel_meta" in str(c)]
+        assert len(vm_reads) == 0
+
+
 class TestPullAisParquet:
     def test_downloads_new_partitions(self, tmp_path):
         """pull-ais-parquet downloads partitions not yet present locally."""
@@ -136,22 +312,25 @@ class TestPullAisParquet:
 
     def test_skips_existing_local(self, tmp_path):
         """pull-ais-parquet skips partitions already present with matching size."""
+        import pyarrow.fs as pafs
+
         local = tmp_path / "ais" / "region=singapore" / "date=2026-04-25"
         local.mkdir(parents=True)
         (local / "positions.parquet").write_bytes(b"x" * 512)
 
         mock_fs = MagicMock()
-        import pyarrow.fs as pafs
-
         remote_info = MagicMock()
         remote_info.path = "maridb-public/ais/region=singapore/date=2026-04-25/positions.parquet"
-        remote_info.size = 512  # same size -> skip
+        remote_info.size = 512  # same size → skip
         remote_info.type = pafs.FileType.File
-        mock_fs.get_file_info.return_value = [remote_info]
+        not_found = MagicMock()
+        not_found.type = pafs.FileType.NotFound
+        # First call: list ais/; subsequent calls: vessel_meta not found
+        mock_fs.get_file_info.side_effect = [[remote_info], [not_found]]
 
         with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
              patch("pyarrow.parquet.read_table") as mock_read:
-            args = argparse.Namespace(data_dir=str(tmp_path), regions=None, days=60)
+            args = argparse.Namespace(data_dir=str(tmp_path), regions="singapore", days=60)
             rc = sync_r2.cmd_pull_ais_parquet(args)
 
         mock_read.assert_not_called()
@@ -159,18 +338,20 @@ class TestPullAisParquet:
 
     def test_filters_by_days(self, tmp_path):
         """pull-ais-parquet skips partitions older than --days."""
-        mock_fs = MagicMock()
         import pyarrow.fs as pafs
 
+        mock_fs = MagicMock()
         old_info = MagicMock()
         old_info.path = "maridb-public/ais/region=singapore/date=2020-01-01/positions.parquet"
         old_info.size = 1024
         old_info.type = pafs.FileType.File
-        mock_fs.get_file_info.return_value = [old_info]
+        not_found = MagicMock()
+        not_found.type = pafs.FileType.NotFound
+        mock_fs.get_file_info.side_effect = [[old_info], [not_found]]
 
         with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
              patch("pyarrow.parquet.read_table") as mock_read:
-            args = argparse.Namespace(data_dir=str(tmp_path), regions=None, days=30)
+            args = argparse.Namespace(data_dir=str(tmp_path), regions="singapore", days=30)
             rc = sync_r2.cmd_pull_ais_parquet(args)
 
         mock_read.assert_not_called()


### PR DESCRIPTION
## Problem

`vessel_meta` (vessel name, IMO, flag, ship type from AIS Type 5 messages) was never exported to R2. CI pipelines started with 0 vessel_meta rows → identity features (flag/name/owner changes) missing → maridb precision 0.272 vs arktrace 0.308.

## Changes

**R2 layout:**
```
maridb-public/vessel_meta/region={stem}.parquet   ← new, full snapshot per region
maridb-public/ais/region={r}/date=*/positions.parquet  ← unchanged
```

**`sync_r2.py push-ais-parquet`**: after uploading positions, exports `vessel_meta` table as a full snapshot (overwritten on every run since vessel identity accumulates)

**`sync_r2.py pull-ais-parquet`**: also downloads `vessel_meta/region={r}.parquet` → `downloads/vessel_meta/region={r}.parquet`

**`run_pipeline.py _load_ais_from_parquet`**: loads both `ais_positions` and `vessel_meta` from downloads into `processed/ais/{region}.duckdb`

Also removes the leftover duplicate DuckLake `cmd_pull_ais_parquet` definition.

## Expected outcome

- Identity features computed in CI → improved watchlist precision
- `vessel_meta` rows > 0 in pipeline validation

## Note

Currently only 10-14 vessels per region (seeded dummies) — real vessel metadata accumulates as LaunchAgents receive AIS Type 5 messages over time.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)