### PR TITLE
fix: limit gfw-ingest to 2 concurrent API requests

### DIFF
--- a/.github/workflows/gfw-ingest.yml
+++ b/.github/workflows/gfw-ingest.yml
@@ -36,6 +36,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      max-parallel: 2  # GFW API allows max 2 concurrent requests
       # Secrets cannot be referenced in matrix values — use token_num (1/2/3)
       # and resolve the actual secret in the step env block below.
       matrix:


### PR DESCRIPTION
GFW API returns 503 when more than 2 regions fetch simultaneously. All 5 matrix jobs were running in parallel, hitting the concurrency limit.

Add `max-parallel: 2` — regions now run 2 at a time (2 → 2 → 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)