### PR TITLE
fix: vessel_meta INSERT fails without PRIMARY KEY

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -250,10 +250,11 @@ def _load_ais_from_parquet(region: RegionConfig) -> int:
 
         if vm_parquet.exists():
             con.execute(f"""
-                INSERT OR REPLACE INTO vessel_meta
+                INSERT INTO vessel_meta
                 SELECT mmsi, imo, name, flag, ship_type
                 FROM read_parquet('{vm_parquet}')
                 WHERE mmsi IS NOT NULL
+                  AND mmsi NOT IN (SELECT mmsi FROM vessel_meta)
             """)
             vm_count = con.execute("SELECT COUNT(*) FROM vessel_meta").fetchone()[0]
             logger.info("  ✓ vessel_meta: %d vessels loaded from %s", vm_count, vm_parquet.name)


### PR DESCRIPTION
## Problem

`INSERT OR REPLACE INTO vessel_meta` requires a PRIMARY KEY or UNIQUE constraint. `vessel_meta` has neither → DuckDB `BinderException` → all 5 pipelines fail immediately on ingest.

## Fix

Replace with `INSERT ... WHERE mmsi NOT IN (SELECT mmsi FROM vessel_meta)` — deduplicates on mmsi without requiring a constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)