### PR TITLE
fix: gfw-ingest continue-on-error per region for 429/503 resilience

### DIFF
--- a/.github/workflows/gfw-ingest.yml
+++ b/.github/workflows/gfw-ingest.yml
@@ -33,12 +33,18 @@ jobs:
     name: Fetch ${{ matrix.region }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true  # 429/503 on one region must not block the push job
     permissions:
       contents: read
     strategy:
-      max-parallel: 2  # GFW API allows max 2 concurrent requests
+      max-parallel: 2  # GFW allows max 2 concurrent requests per account
+      fail-fast: false
       # Secrets cannot be referenced in matrix values — use token_num (1/2/3)
       # and resolve the actual secret in the step env block below.
+      # Token assignment keeps same-token regions in separate parallel slots:
+      #   token 1 → singapore, blacksea  (run in different rounds)
+      #   token 2 → japan, middleeast    (run in different rounds)
+      #   token 3 → europe
       matrix:
         include:
           - region: singapore
@@ -51,7 +57,6 @@ jobs:
             token_num: 1
           - region: middleeast
             token_num: 2
-      fail-fast: false
     env:
       MARIDB_DATA_DIR: data/processed
 


### PR DESCRIPTION
## Problem

When GFW API returns 429 or 503 on any region, the ingest job fails and the downstream push job is blocked from uploading data from regions that succeeded.

`fail-fast: false` only prevents sibling job cancellation — it doesn't prevent the `needs: ingest` push job from being skipped when ingest jobs fail.

## Fix

Add `continue-on-error: true` to the ingest job. This marks individual region failures as warnings, allowing the push job (which has `if: always()`) to run and upload whatever parquets were successfully fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)