### PR TITLE
ci: add push-arktrace step to data-publish.yml (#47)

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -279,6 +279,13 @@ jobs:
           AWS_REGION: auto
         run: uv run python scripts/sync_r2.py push-watchlists
 
+      - name: Distribute to arktrace-public
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+        run: uv run python scripts/sync_r2.py push-arktrace
+
       - name: Lead time validation (#268)
         run: |
           uv run python scripts/validate_lead_time_ofac.py \
@@ -310,3 +317,4 @@ jobs:
             data/processed/*.json
           if-no-files-found: warn
           retention-days: 7
+


### PR DESCRIPTION
## Summary

- Adds a **Distribute to arktrace-public** step at the end of `data-publish.yml`, immediately after `push-watchlists`
- Calls `sync_r2.py push-arktrace`, which copies `{region}_watchlist.parquet` and shared score Parquets from `maridb-public/score/` → `arktrace-public/score/`, and writes both `manifest.json` and `ducklake_manifest.json` (legacy alias, same content) to `arktrace-public/`

## Why

The arktrace scheduled CI is paused, so `arktrace-public` is no longer receiving fresh data. maridb now outperforms the old arktrace pipeline (P@50 0.3160 vs 0.3080), so the arktrace PWA should consume maridb-generated scores directly. This step makes maridb's daily run the single source of truth for arktrace's data.

## Manifest strategy

| Phase | Written by maridb | arktrace reads |
|---|---|---|
| Now (this PR) | `manifest.json` + `ducklake_manifest.json` | `ducklake_manifest.json` |
| After arktrace migrates | `manifest.json` + `ducklake_manifest.json` | `manifest.json` |
| Cleanup | `manifest.json` only | `manifest.json` |

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)