### PR TITLE
fix: normalise datetime columns to UTC before concat in _load_watchlist

### DIFF
--- a/scripts/validate_lead_time_ofac.py
+++ b/scripts/validate_lead_time_ofac.py
@@ -142,7 +142,17 @@ def _load_watchlist(paths: list[Path]) -> pl.DataFrame:
     parts = []
     for p in paths:
         if p.exists():
-            parts.append(pl.read_parquet(p))
+            df = pl.read_parquet(p)
+            # Normalise all datetime columns to UTC so concat doesn't fail on
+            # timezone mismatches (e.g. Asia/Singapore vs Etc/UTC).
+            for col in df.columns:
+                if df[col].dtype == pl.Datetime or (
+                    hasattr(df[col].dtype, "time_zone") and df[col].dtype.time_zone
+                ):
+                    df = df.with_columns(
+                        pl.col(col).dt.convert_time_zone("UTC")
+                    )
+            parts.append(df)
     if not parts:
         return pl.DataFrame()
     combined = pl.concat(parts, how="vertical_relaxed")


### PR DESCRIPTION
## Problem

`validate_lead_time_ofac.py` crashes when concatenating watchlists from multiple regions:

```
polars.exceptions.SchemaError: failed to determine supertype of
datetime[μs, Asia/Singapore] and datetime[μs, Etc/UTC]
```

The `last_seen` column has different timezones across regions (e.g. `Asia/Singapore` for singapore, `Etc/UTC` for others). Polars `vertical_relaxed` concat does not coerce timezone mismatches.

## Fix

In `_load_watchlist`, convert all timezone-aware datetime columns to UTC before appending to `parts`, so all DataFrames share the same dtype when concatenated.

Closes #24 (lead time validation step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)