### PR TITLE
feat: daily AIS upload validation — validate, upload to R2, email report (#57)

### DIFF
--- a/.github/workflows/ais-validate.yml
+++ b/.github/workflows/ais-validate.yml
@@ -1,0 +1,69 @@
+name: Daily AIS Upload Validation
+
+on:
+  schedule:
+    - cron: '0 3 * * *'   # 03:00 UTC daily (after r2sync at 02:00)
+  workflow_dispatch:
+    inputs:
+      validate_date:
+        description: 'Date to validate (YYYY-MM-DD, default: yesterday)'
+        required: false
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Validate AIS uploads & notify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run AIS upload validation
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+          VALIDATE_DATE: ${{ inputs.validate_date }}
+        run: |
+          uv run python scripts/validate_ais_upload.py
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+        id: validate
+        continue-on-error: true
+
+      - name: Send validation email
+        if: always()
+        env:
+          NOTIFY_EMAIL: ${{ vars.NOTIFY_EMAIL }}
+          SMTP_HOST: ${{ vars.SMTP_HOST }}
+          SMTP_PORT: ${{ vars.SMTP_PORT }}
+          SMTP_USER: ${{ vars.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          VALIDATE_DATE: ${{ inputs.validate_date }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: uv run python scripts/notify_ais_validation.py
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: ais-validation-report-${{ github.run_id }}
+          path: data/processed/ais_validation_report.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Fail if validation failed
+        if: steps.validate.outcome == 'failure'
+        run: exit 1

--- a/scripts/notify_ais_validation.py
+++ b/scripts/notify_ais_validation.py
@@ -1,0 +1,127 @@
+"""Send email summary after daily AIS upload validation.
+
+Reads data/processed/ais_validation_report.json and sends a formatted HTML email.
+
+Environment variables
+---------------------
+NOTIFY_EMAIL, SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD
+VALIDATE_DATE      Target date (injected by GHA)
+GITHUB_RUN_ID, GITHUB_REPOSITORY
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import smtplib
+import sys
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+
+_REPORT_PATH = Path("data/processed/ais_validation_report.json")
+
+
+def _row_color(passed: bool) -> str:
+    return "#d4edda" if passed else "#f8d7da"
+
+
+def _check_cell(check: dict) -> str:
+    if check.get("pass"):
+        return "✅"
+    details = " | ".join(
+        f"{k}={v}" for k, v in check.items() if k not in ("pass",) and v not in ([], {}, None, "")
+    )
+    return f"❌ {details}"
+
+
+def main() -> int:
+    recipient = os.getenv("NOTIFY_EMAIL")
+    if not recipient:
+        print("NOTIFY_EMAIL not set — skipping.")
+        return 0
+
+    smtp_host = os.getenv("SMTP_HOST", "smtp.gmail.com")
+    smtp_port = int(os.getenv("SMTP_PORT", "587"))
+    smtp_user = os.getenv("SMTP_USER", "")
+    smtp_password = os.getenv("SMTP_PASSWORD", "")
+    if not smtp_user or not smtp_password:
+        print("SMTP credentials not set — skipping.", file=sys.stderr)
+        return 0
+
+    if not _REPORT_PATH.exists():
+        print(f"Report not found at {_REPORT_PATH} — skipping.", file=sys.stderr)
+        return 1
+
+    report = json.loads(_REPORT_PATH.read_text())
+    target_date = report.get("target_date", "unknown")
+    overall_pass = report.get("overall_pass", False)
+    coverage = report.get("coverage_check", {})
+    active_passing = report.get("active_regions_passing", [])
+
+    run_id = os.getenv("GITHUB_RUN_ID", "")
+    repo = os.getenv("GITHUB_REPOSITORY", "edgesentry/maridb")
+    run_url = (
+        f"https://github.com/{repo}/actions/runs/{run_id}"
+        if run_id else f"https://github.com/{repo}/actions"
+    )
+
+    status_icon = "✅" if overall_pass else "❌"
+    subject = f"{status_icon} maridb AIS validation — {target_date} ({'PASS' if overall_pass else 'FAIL'})"
+
+    region_rows = ""
+    for r in report.get("region_results", []):
+        color = _row_color(r.get("pass", False))
+        checks = r.get("checks", {})
+        err = r.get("error", "")
+        region_rows += f"""
+        <tr style="background:{color}">
+          <td>{r['region']}</td>
+          <td>{r.get('row_count', 0):,}</td>
+          <td>{_check_cell(checks.get('schema', {}))}</td>
+          <td>{_check_cell(checks.get('mmsi_null_rate', {}))}</td>
+          <td>{_check_cell(checks.get('coordinates', {}))}</td>
+          <td>{_check_cell(checks.get('timestamp_recency', {}))}</td>
+          <td>{_check_cell(checks.get('duplicate_rate', {}))}</td>
+          <td>{'❌ ' + err if err else ('✅' if r.get('pass') else '❌')}</td>
+        </tr>"""
+
+    html = f"""<html><body style="font-family:sans-serif;max-width:760px">
+<h2>maridb — Daily AIS Upload Validation</h2>
+<p><strong>Date:</strong> {target_date}<br>
+<strong>Overall:</strong> {status_icon} {'PASS' if overall_pass else 'FAIL'}<br>
+<strong>Active regions passing:</strong> {len(active_passing)}/{coverage.get('required', 5)}
+({', '.join(active_passing) or 'none'})</p>
+
+<h3>Per-Region Results</h3>
+<table border="1" cellpadding="5" cellspacing="0" style="border-collapse:collapse;font-size:13px">
+  <tr style="background:#343a40;color:white">
+    <th>Region</th><th>Rows</th><th>Schema</th>
+    <th>MMSI nulls</th><th>Coords</th><th>Recency</th><th>Duplicates</th><th>Status</th>
+  </tr>
+  {region_rows}
+</table>
+
+<p style="margin-top:16px">
+  <a href="s3://maridb-public/validation/ais/{target_date}.json">📄 Full report in R2</a> &nbsp;|&nbsp;
+  <a href="{run_url}">View CI run →</a>
+</p>
+</body></html>"""
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = smtp_user
+    msg["To"] = recipient
+    msg.attach(MIMEText(html, "html"))
+
+    print(f"Sending to {recipient} …")
+    with smtplib.SMTP(smtp_host, smtp_port) as server:
+        server.starttls()
+        server.login(smtp_user, smtp_password)
+        server.sendmail(smtp_user, recipient, msg.as_string())
+    print(f"Sent: {subject}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_ais_upload.py
+++ b/scripts/validate_ais_upload.py
@@ -1,0 +1,211 @@
+"""Daily validation of AIS Parquet files uploaded to maridb-public/ais/.
+
+Reads yesterday's partition for each region from R2, runs sanity checks,
+writes a JSON report to R2 at validation/ais/YYYY-MM-DD.json, and exits
+non-zero if any region fails a required check.
+
+Environment variables
+---------------------
+AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION  R2 credentials
+S3_BUCKET          Override bucket name (default: maridb-public)
+VALIDATE_DATE      Override target date ISO string (default: yesterday)
+REPORT_LOCAL_PATH  Local path to write report JSON (default: data/processed/ais_validation_report.json)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+import polars as pl
+import pyarrow.fs as pafs
+import pyarrow.parquet as pq
+
+_DEFAULT_BUCKET = "maridb-public"
+_DEFAULT_ENDPOINT = "https://6923ee6d0b3c2d3c15e0d98acda7bc4c.r2.cloudflarestorage.com"
+
+_REQUIRED_COLUMNS = {"mmsi", "timestamp", "lat", "lon"}
+_ALL_REGIONS = [
+    "japansea", "blacksea", "middleeast", "singapore", "europe",
+    "gulfofmexico", "hornofafrica", "persiangulf", "gulfofaden", "gulfofguinea",
+]
+_ACTIVE_REGIONS = [
+    "japansea", "singapore", "europe", "blacksea", "middleeast", "gulfofguinea",
+]
+_MIN_ACTIVE_REGIONS = 5
+
+
+def _build_fs() -> pafs.S3FileSystem:
+    return pafs.S3FileSystem(
+        access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        region=os.getenv("AWS_REGION", "auto"),
+        endpoint_override=os.getenv("S3_ENDPOINT", _DEFAULT_ENDPOINT),
+    )
+
+
+def _validate_region(df: pl.DataFrame, region: str, target_date: str) -> dict:
+    result: dict = {"region": region, "date": target_date, "row_count": df.height, "checks": {}}
+
+    # Schema
+    missing_cols = _REQUIRED_COLUMNS - set(df.columns)
+    result["checks"]["schema"] = {
+        "pass": len(missing_cols) == 0,
+        "missing_columns": sorted(missing_cols),
+    }
+
+    # Row count
+    result["checks"]["row_count"] = {"pass": df.height >= 1, "rows": df.height}
+
+    if df.height == 0:
+        result["pass"] = False
+        return result
+
+    # Null rate for mmsi
+    mmsi_nulls = df["mmsi"].null_count() if "mmsi" in df.columns else df.height
+    result["checks"]["mmsi_null_rate"] = {
+        "pass": mmsi_nulls == 0,
+        "null_count": mmsi_nulls,
+    }
+
+    # Coordinate range
+    if "lat" in df.columns and "lon" in df.columns:
+        bad_coords = df.filter(
+            (pl.col("lat") < -90) | (pl.col("lat") > 90) |
+            (pl.col("lon") < -180) | (pl.col("lon") > 180)
+        ).height
+        lat_nulls = df["lat"].null_count()
+        lon_nulls = df["lon"].null_count()
+        null_rate = (lat_nulls + lon_nulls) / (2 * df.height)
+        result["checks"]["coordinates"] = {
+            "pass": bad_coords == 0 and null_rate < 0.05,
+            "out_of_range": bad_coords,
+            "null_rate": round(null_rate, 4),
+        }
+
+    # Timestamp recency (within last 48 hours from now)
+    if "timestamp" in df.columns:
+        try:
+            ts_col = df["timestamp"]
+            if ts_col.dtype == pl.Utf8:
+                ts_col = ts_col.str.to_datetime(time_unit="us", time_zone="UTC")
+            elif hasattr(ts_col.dtype, "time_zone") and ts_col.dtype.time_zone:
+                ts_col = ts_col.dt.convert_time_zone("UTC")
+            cutoff = datetime.now(UTC) - timedelta(hours=48)
+            stale = (ts_col < cutoff).sum()
+            result["checks"]["timestamp_recency"] = {
+                "pass": stale / df.height < 0.5,
+                "stale_fraction": round(stale / df.height, 4),
+            }
+        except Exception as exc:
+            result["checks"]["timestamp_recency"] = {"pass": False, "error": str(exc)}
+
+    # Duplicate rate
+    if "mmsi" in df.columns and "timestamp" in df.columns:
+        total = df.height
+        unique = df.select(["mmsi", "timestamp"]).unique().height
+        dup_rate = (total - unique) / total
+        result["checks"]["duplicate_rate"] = {
+            "pass": dup_rate < 0.01,
+            "duplicate_rate": round(dup_rate, 4),
+        }
+
+    result["pass"] = all(c.get("pass", True) for c in result["checks"].values())
+    return result
+
+
+def main() -> int:
+    bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
+    target_date = os.getenv("VALIDATE_DATE") or (date.today() - timedelta(days=1)).isoformat()
+    local_report_path = Path(
+        os.getenv("REPORT_LOCAL_PATH", "data/processed/ais_validation_report.json")
+    )
+    local_report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fs = _build_fs()
+    region_results = []
+    regions_with_data: list[str] = []
+
+    print(f"Validating AIS uploads for {target_date} in {bucket}/ais/ ...")
+
+    for region in _ALL_REGIONS:
+        key = f"{bucket}/ais/region={region}/date={target_date}/positions.parquet"
+        try:
+            info = fs.get_file_info(key)
+            if info.type == pafs.FileType.NotFound:
+                region_results.append({
+                    "region": region, "date": target_date, "row_count": 0,
+                    "checks": {}, "pass": False, "error": "file not found in R2",
+                })
+                print(f"  {region:20s} MISSING")
+                continue
+            table = pq.read_table(key, filesystem=fs)
+            df = pl.from_arrow(table)
+            result = _validate_region(df, region, target_date)
+            region_results.append(result)
+            status = "OK" if result["pass"] else "FAIL"
+            print(f"  {region:20s} {status:4s}  rows={result['row_count']:,}")
+            if result["pass"]:
+                regions_with_data.append(region)
+        except Exception as exc:
+            region_results.append({
+                "region": region, "date": target_date, "row_count": 0,
+                "checks": {}, "pass": False, "error": str(exc),
+            })
+            print(f"  {region:20s} ERROR: {exc}")
+
+    # Region coverage check
+    active_passing = [r for r in regions_with_data if r in _ACTIVE_REGIONS]
+    coverage_pass = len(active_passing) >= _MIN_ACTIVE_REGIONS
+
+    report = {
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "target_date": target_date,
+        "regions_passing": regions_with_data,
+        "active_regions_passing": active_passing,
+        "coverage_check": {
+            "pass": coverage_pass,
+            "active_passing": len(active_passing),
+            "required": _MIN_ACTIVE_REGIONS,
+        },
+        "region_results": region_results,
+        "overall_pass": coverage_pass and all(
+            r["pass"] for r in region_results if r["region"] in _ACTIVE_REGIONS
+        ),
+    }
+
+    # Write local report
+    local_report_path.write_text(json.dumps(report, indent=2))
+    print(f"\nReport written to {local_report_path}")
+
+    # Upload to R2
+    r2_key = f"validation/ais/{target_date}.json"
+    try:
+        import boto3
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=os.getenv("S3_ENDPOINT", _DEFAULT_ENDPOINT),
+            aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+            aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+            region_name=os.getenv("AWS_REGION", "auto"),
+        )
+        s3.put_object(
+            Bucket=bucket,
+            Key=r2_key,
+            Body=json.dumps(report, indent=2).encode(),
+            ContentType="application/json",
+        )
+        print(f"Report uploaded to R2: {bucket}/{r2_key}")
+    except Exception as exc:
+        print(f"Warning: failed to upload report to R2: {exc}", file=sys.stderr)
+
+    overall = report["overall_pass"]
+    print(f"\nOverall: {'PASS' if overall else 'FAIL'}")
+    return 0 if overall else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **`scripts/validate_ais_upload.py`** — pulls yesterday's AIS Parquet from `maridb-public/ais/region={r}/date={d}/positions.parquet` for all 10 regions, runs sanity checks, writes JSON report to `maridb-public/validation/ais/YYYY-MM-DD.json`
- **`scripts/notify_ais_validation.py`** — sends HTML email with per-region pass/fail table
- **`.github/workflows/ais-validate.yml`** — runs daily at 03:00 UTC (1 hour after r2sync), supports `workflow_dispatch` with optional `validate_date` input

## Checks per region

| Check | Pass condition |
|---|---|
| Schema | `mmsi`, `timestamp`, `lat`, `lon` all present |
| Row count | ≥ 1 row |
| MMSI null rate | 0% |
| Coordinates | in range, < 5% null |
| Timestamp recency | < 50% of rows older than 48h |
| Duplicate rate | < 1% of `(mmsi, timestamp)` pairs |
| Coverage | ≥ 5 active regions passing |

## R2 output

`maridb-public/validation/ais/YYYY-MM-DD.json` — retained indefinitely for trend analysis.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)