### PR TITLE
feat: daily AIS validation + lead-time timezone fix

### DIFF
--- a/scripts/validate_ais_upload.py
+++ b/scripts/validate_ais_upload.py
@@ -20,9 +20,6 @@ import sys
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
-import io
-
-import boto3
 import polars as pl
 
 _DEFAULT_BUCKET = "maridb-public"
@@ -39,23 +36,22 @@ _ACTIVE_REGIONS = [
 _MIN_ACTIVE_REGIONS = 5
 
 
-def _build_s3():
-    return boto3.client(
-        "s3",
-        endpoint_url=os.getenv("S3_ENDPOINT", _DEFAULT_ENDPOINT),
-        aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
-        aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-        region_name=os.getenv("AWS_REGION", "auto"),
-    )
+def _storage_options() -> dict[str, str]:
+    return {
+        "aws_access_key_id": os.environ["AWS_ACCESS_KEY_ID"],
+        "aws_secret_access_key": os.environ["AWS_SECRET_ACCESS_KEY"],
+        "aws_region": os.getenv("AWS_REGION", "auto"),
+        "aws_endpoint_url": os.getenv("S3_ENDPOINT", _DEFAULT_ENDPOINT),
+    }
 
 
-def _read_parquet_from_r2(s3, bucket: str, key: str) -> pl.DataFrame | None:
+def _read_parquet_from_r2(bucket: str, key: str) -> pl.DataFrame | None:
+    uri = f"s3://{bucket}/{key}"
     try:
-        obj = s3.get_object(Bucket=bucket, Key=key)
-        return pl.read_parquet(io.BytesIO(obj["Body"].read()))
-    except s3.exceptions.NoSuchKey:
-        return None
-    except Exception:
+        return pl.read_parquet(uri, storage_options=_storage_options())
+    except Exception as exc:
+        if "NoSuchKey" in str(exc) or "404" in str(exc) or "not found" in str(exc).lower():
+            return None
         raise
 
 
@@ -137,7 +133,6 @@ def main() -> int:
     )
     local_report_path.parent.mkdir(parents=True, exist_ok=True)
 
-    s3 = _build_s3()
     region_results = []
     regions_with_data: list[str] = []
 
@@ -146,7 +141,7 @@ def main() -> int:
     for region in _ALL_REGIONS:
         key = f"ais/region={region}/date={target_date}/positions.parquet"
         try:
-            df = _read_parquet_from_r2(s3, bucket, key)
+            df = _read_parquet_from_r2(bucket, key)
             if df is None:
                 region_results.append({
                     "region": region, "date": target_date, "row_count": 0,
@@ -191,23 +186,21 @@ def main() -> int:
     local_report_path.write_text(json.dumps(report, indent=2))
     print(f"\nReport written to {local_report_path}")
 
-    # Upload to R2
+    # Upload to R2 via polars storage_options (no boto3 needed)
     r2_key = f"validation/ais/{target_date}.json"
     try:
-        import boto3
-        s3 = boto3.client(
-            "s3",
-            endpoint_url=os.getenv("S3_ENDPOINT", _DEFAULT_ENDPOINT),
-            aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
-            aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-            region_name=os.getenv("AWS_REGION", "auto"),
+        import pyarrow as pa
+        import pyarrow.fs as pafs
+        opts = _storage_options()
+        fs = pafs.S3FileSystem(
+            access_key=opts["aws_access_key_id"],
+            secret_key=opts["aws_secret_access_key"],
+            region=opts["aws_region"],
+            endpoint_override=opts["aws_endpoint_url"],
         )
-        s3.put_object(
-            Bucket=bucket,
-            Key=r2_key,
-            Body=json.dumps(report, indent=2).encode(),
-            ContentType="application/json",
-        )
+        body = json.dumps(report, indent=2).encode()
+        with fs.open_output_stream(f"{bucket}/{r2_key}") as f:
+            f.write(body)
         print(f"Report uploaded to R2: {bucket}/{r2_key}")
     except Exception as exc:
         print(f"Warning: failed to upload report to R2: {exc}", file=sys.stderr)

--- a/tests/test_validate_ais_upload.py
+++ b/tests/test_validate_ais_upload.py
@@ -1,0 +1,168 @@
+"""Unit tests for scripts/validate_ais_upload.py.
+
+All tests run offline — no R2 credentials required.
+The _read_parquet_from_r2 and R2 upload functions are monkeypatched.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_df(**overrides) -> pl.DataFrame:
+    """Return a minimal valid AIS positions DataFrame."""
+    now = datetime.now(UTC)
+    data = {
+        "mmsi": ["123456789", "987654321"],
+        "timestamp": [now - timedelta(hours=1), now - timedelta(hours=2)],
+        "lat": [35.0, 1.3],
+        "lon": [139.0, 103.8],
+    }
+    data.update(overrides)
+    return pl.DataFrame(data)
+
+
+@pytest.fixture()
+def mod():
+    """Import validate_ais_upload fresh (avoids env-var side effects)."""
+    if "validate_ais_upload" in sys.modules:
+        del sys.modules["validate_ais_upload"]
+    spec = importlib.util.spec_from_file_location(
+        "validate_ais_upload",
+        Path(__file__).parent.parent / "scripts" / "validate_ais_upload.py",
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _validate_region
+# ---------------------------------------------------------------------------
+
+class TestValidateRegion:
+    def test_passes_clean_data(self, mod):
+        df = _make_df()
+        result = mod._validate_region(df, "singapore", "2026-04-29")
+        assert result["pass"] is True
+
+    def test_fails_missing_column(self, mod):
+        df = _make_df().drop("lat")
+        result = mod._validate_region(df, "singapore", "2026-04-29")
+        assert result["pass"] is False
+        assert "lat" in result["checks"]["schema"]["missing_columns"]
+
+    def test_fails_zero_rows(self, mod):
+        df = pl.DataFrame({"mmsi": [], "timestamp": [], "lat": [], "lon": []})
+        result = mod._validate_region(df, "singapore", "2026-04-29")
+        assert result["pass"] is False
+        assert result["checks"]["row_count"]["pass"] is False
+
+    def test_fails_mmsi_nulls(self, mod):
+        df = _make_df(mmsi=[None, "987654321"])
+        result = mod._validate_region(df, "europe", "2026-04-29")
+        assert result["pass"] is False
+        assert result["checks"]["mmsi_null_rate"]["pass"] is False
+
+    def test_fails_out_of_range_coords(self, mod):
+        df = _make_df(lat=[999.0, 1.3], lon=[139.0, 103.8])
+        result = mod._validate_region(df, "japansea", "2026-04-29")
+        assert result["pass"] is False
+        assert result["checks"]["coordinates"]["out_of_range"] > 0
+
+    def test_fails_stale_timestamps(self, mod):
+        old = datetime.now(UTC) - timedelta(days=5)
+        df = _make_df(timestamp=[old, old])
+        result = mod._validate_region(df, "blacksea", "2026-04-29")
+        assert result["pass"] is False
+        assert result["checks"]["timestamp_recency"]["stale_fraction"] == 1.0
+
+    def test_fails_high_duplicate_rate(self, mod):
+        now = datetime.now(UTC)
+        df = pl.DataFrame({
+            "mmsi": ["123456789"] * 200 + ["999999999"],
+            "timestamp": [now] * 200 + [now],
+            "lat": [35.0] * 201,
+            "lon": [139.0] * 201,
+        })
+        result = mod._validate_region(df, "europe", "2026-04-29")
+        assert result["pass"] is False
+        assert result["checks"]["duplicate_rate"]["duplicate_rate"] > 0.01
+
+
+# ---------------------------------------------------------------------------
+# main() integration (R2 calls monkeypatched)
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    def _run(self, mod, region_data: dict, tmp_path: Path, monkeypatch) -> int:
+        """Run main() with R2 reads and writes monkeypatched."""
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+        monkeypatch.setenv("VALIDATE_DATE", "2026-04-29")
+        monkeypatch.setenv("REPORT_LOCAL_PATH", str(tmp_path / "report.json"))
+
+        def fake_read(bucket, key):
+            region = next(
+                (p.removeprefix("region=") for p in key.split("/") if p.startswith("region=")),
+                None,
+            )
+            return region_data.get(region)
+
+        monkeypatch.setattr(mod, "_read_parquet_from_r2", fake_read)
+
+        # Suppress R2 upload
+        import pyarrow.fs as pafs
+        class _FakeFS:
+            def open_output_stream(self, path):
+                import io
+                return io.BytesIO()
+        monkeypatch.setattr(pafs, "S3FileSystem", lambda **_: _FakeFS())
+
+        return mod.main()
+
+    def test_passes_when_enough_active_regions(self, mod, tmp_path, monkeypatch):
+        good = _make_df()
+        data = {r: good for r in mod._ACTIVE_REGIONS}
+        rc = self._run(mod, data, tmp_path, monkeypatch)
+        assert rc == 0
+
+    def test_fails_when_too_few_active_regions(self, mod, tmp_path, monkeypatch):
+        good = _make_df()
+        # Only 2 active regions have data
+        data = {"japansea": good, "singapore": good}
+        rc = self._run(mod, data, tmp_path, monkeypatch)
+        assert rc == 1
+
+    def test_report_written_to_disk(self, mod, tmp_path, monkeypatch):
+        good = _make_df()
+        data = {r: good for r in mod._ACTIVE_REGIONS}
+        self._run(mod, data, tmp_path, monkeypatch)
+        report_path = tmp_path / "report.json"
+        assert report_path.exists()
+        report = json.loads(report_path.read_text())
+        assert "overall_pass" in report
+        assert report["target_date"] == "2026-04-29"
+
+    def test_missing_region_marked_as_fail(self, mod, tmp_path, monkeypatch):
+        good = _make_df()
+        data = {r: good for r in mod._ACTIVE_REGIONS}
+        self._run(mod, data, tmp_path, monkeypatch)
+        report = json.loads((tmp_path / "report.json").read_text())
+        missing = [r for r in report["region_results"] if r.get("error") == "file not found in R2"]
+        # inactive regions not in data dict should show as missing
+        inactive = set(mod._ALL_REGIONS) - set(mod._ACTIVE_REGIONS)
+        assert all(
+            any(m["region"] == r for m in missing) for r in inactive
+        )


### PR DESCRIPTION
## Summary

- **fix** `scripts/validate_lead_time_ofac.py` — normalise all datetime columns to UTC before `pl.concat`, fixes `SchemaError: failed to determine supertype of datetime[μs, Asia/Singapore] and datetime[μs, Etc/UTC]`
- **feat** `scripts/validate_ais_upload.py` — pulls yesterday's AIS Parquet from `maridb-public/ais/` for all 10 regions, runs 6 sanity checks, writes JSON report to `maridb-public/validation/ais/YYYY-MM-DD.json`; uses `pl.read_parquet` with `storage_options` (no boto3 dependency)
- **feat** `scripts/notify_ais_validation.py` — sends HTML email with per-region pass/fail table
- **ci** `.github/workflows/ais-validate.yml` — runs daily at 03:00 UTC, supports manual `workflow_dispatch` with optional `validate_date` input

## Validation checks

| Check | Pass condition |
|---|---|
| Schema | `mmsi`, `timestamp`, `lat`, `lon` present |
| Row count | ≥ 1 row |
| MMSI null rate | 0% |
| Coordinates | in range, < 5% null |
| Timestamp recency | < 50% rows older than 48h |
| Duplicate rate | < 1% of `(mmsi, timestamp)` pairs |
| Coverage | ≥ 5 active regions passing |

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)