### PR TITLE
feat: upload empty sentinel parquet for 0-row regions; 0 rows = OK in validation

### DIFF
--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1277,8 +1277,25 @@ def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
         except Exception as exc:
             print(f"  [skip] cannot open DB: {exc}", file=sys.stderr)
             continue
+        from datetime import date as _date
+        today_str = _date.today().isoformat()
         if row_count == 0:
-            print("  [skip] ais_positions is empty")
+            # Upload an empty Parquet for today so the validation job can confirm
+            # the upload pipeline ran (file missing = pipeline broken; 0 rows = no vessels).
+            r2_key = f"{bucket}/ais/region={region}/date={today_str}/positions.parquet"
+            empty_table = _duckdb.execute(
+                "SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type "
+                "FROM ais_positions WHERE 1=0"
+            ).to_arrow_table()
+            local_path = staging_dir / f"region={region}" / f"date={today_str}" / "positions.parquet"
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            pq.write_table(empty_table, local_path, compression="snappy")
+            try:
+                pq.write_table(empty_table, r2_key, filesystem=fs, compression="snappy")
+                print(f"  {today_str} (0 rows) -> uploaded empty sentinel to R2")
+                total_uploaded += 1
+            except Exception as exc:
+                print(f"  [warn] failed to upload empty sentinel: {exc}", file=sys.stderr)
             continue
         dates = [
             r[0].strftime("%Y-%m-%d")

--- a/scripts/validate_ais_upload.py
+++ b/scripts/validate_ais_upload.py
@@ -70,11 +70,11 @@ def _validate_region(df: pl.DataFrame, region: str, target_date: str) -> dict:
         "missing_columns": sorted(missing_cols),
     }
 
-    # Row count
-    result["checks"]["row_count"] = {"pass": df.height >= 1, "rows": df.height}
+    # Row count — 0 rows is OK (no vessels in region that day); file missing is the real error
+    result["checks"]["row_count"] = {"pass": True, "rows": df.height}
 
     if df.height == 0:
-        result["pass"] = False
+        result["pass"] = True
         return result
 
     # Null rate for mmsi

--- a/tests/test_validate_ais_upload.py
+++ b/tests/test_validate_ais_upload.py
@@ -63,11 +63,12 @@ class TestValidateRegion:
         assert result["pass"] is False
         assert "lat" in result["checks"]["schema"]["missing_columns"]
 
-    def test_fails_zero_rows(self, mod):
+    def test_passes_zero_rows(self, mod):
         df = pl.DataFrame({"mmsi": [], "timestamp": [], "lat": [], "lon": []})
         result = mod._validate_region(df, "singapore", "2026-04-29")
-        assert result["pass"] is False
-        assert result["checks"]["row_count"]["pass"] is False
+        assert result["pass"] is True
+        assert result["checks"]["row_count"]["pass"] is True
+        assert result["checks"]["row_count"]["rows"] == 0
 
     def test_fails_mmsi_nulls(self, mod):
         df = _make_df(mmsi=[None, "987654321"])


### PR DESCRIPTION
## Summary

### `sync_r2.py push-ais-parquet`
Previously skipped regions with 0 rows entirely. Now uploads an empty Parquet for today's date as a sentinel, so the validation job can confirm the upload pipeline ran regardless of vessel activity.

### `validate_ais_upload.py`
- **File missing → FAIL** (pipeline did not run)
- **File exists, 0 rows → OK** (pipeline ran, no vessels in region that day)

### `tests/test_validate_ais_upload.py`
- `test_fails_zero_rows` → `test_passes_zero_rows`

## Why

Regions like `hornofafrica` or `persiangulf` may have 0 AIS messages on a given day. That's expected. What matters for validation is whether the upload job ran at all — which is now confirmed by the sentinel file's presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)