### PR TITLE
feat: upload empty sentinel for today even when region has historical data

### DIFF
--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1314,6 +1314,23 @@ def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
         except Exception:
             pass
         to_upload = [d for d in dates if d not in existing_r2]
+        # If today has no rows yet, upload an empty sentinel so validation
+        # can confirm the pipeline ran for this region.
+        if today_str not in existing_r2 and today_str not in dates:
+            empty_table = con.execute(
+                "SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type "
+                "FROM ais_positions WHERE 1=0"
+            ).to_arrow_table()
+            local_path = staging_dir / f"region={region}" / f"date={today_str}" / "positions.parquet"
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            pq.write_table(empty_table, local_path, compression="snappy")
+            r2_key = f"{bucket}/ais/region={region}/date={today_str}/positions.parquet"
+            try:
+                pq.write_table(empty_table, r2_key, filesystem=fs, compression="snappy")
+                print(f"  {today_str} (0 rows) -> uploaded empty sentinel to R2")
+                total_uploaded += 1
+            except Exception as exc:
+                print(f"  [warn] failed to upload empty sentinel: {exc}", file=sys.stderr)
         if not to_upload:
             print(f"  all {len(dates)} date(s) already in R2 - skipping")
         else:

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1283,7 +1283,7 @@ def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
             # Upload an empty Parquet for today so the validation job can confirm
             # the upload pipeline ran (file missing = pipeline broken; 0 rows = no vessels).
             r2_key = f"{bucket}/ais/region={region}/date={today_str}/positions.parquet"
-            empty_table = _duckdb.execute(
+            empty_table = con.execute(
                 "SELECT mmsi, timestamp, lat, lon, sog, cog, nav_status, ship_type "
                 "FROM ais_positions WHERE 1=0"
             ).to_arrow_table()

--- a/tests/test_sync_r2_ais_parquet.py
+++ b/tests/test_sync_r2_ais_parquet.py
@@ -122,6 +122,73 @@ class TestPushAisParquet:
         rc = sync_r2.cmd_push_ais_parquet(args)
         assert rc == 1
 
+    def test_uploads_sentinel_when_db_empty(self, tmp_path):
+        """push-ais-parquet uploads an empty sentinel for today when DB has 0 rows."""
+        import duckdb
+        from datetime import date
+
+        db = tmp_path / "singapore.duckdb"
+        con = duckdb.connect(str(db))
+        con.execute("""
+            CREATE TABLE ais_positions (
+                mmsi VARCHAR, timestamp TIMESTAMPTZ, lat DOUBLE, lon DOUBLE,
+                sog FLOAT, cog FLOAT, nav_status TINYINT, ship_type TINYINT
+            )
+        """)
+        con.close()
+
+        mock_fs = MagicMock()
+        mock_fs.get_file_info.return_value = []
+        written_keys = []
+
+        def fake_write_table(table, path, filesystem=None, compression=None):
+            if filesystem is not None:
+                written_keys.append((path, table.num_rows))
+
+        today = date.today().isoformat()
+        args = argparse.Namespace(
+            data_dir=str(tmp_path), staging_dir=str(tmp_path / "staging"), regions="singapore"
+        )
+        with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
+             patch.object(sync_r2, "_ais_db_candidates", return_value=[db]), \
+             patch("pyarrow.parquet.write_table", side_effect=fake_write_table):
+            rc = sync_r2.cmd_push_ais_parquet(args)
+
+        assert rc == 0
+        sentinel_keys = [k for k, rows in written_keys if f"date={today}" in k and rows == 0]
+        assert len(sentinel_keys) == 1, f"expected 1 sentinel, got {written_keys}"
+
+    def test_uploads_sentinel_when_today_missing_from_r2(self, tmp_path):
+        """push-ais-parquet uploads empty sentinel for today even if DB has older rows."""
+        from datetime import date
+
+        db = _make_duckdb(tmp_path / "singapore.duckdb", n_rows=5)  # rows on 2026-04-01
+
+        mock_fs = MagicMock()
+        # Simulate R2 already having 2026-04-01 but NOT today
+        existing_info = MagicMock()
+        existing_info.path = "maridb-public/ais/region=singapore/date=2026-04-01/positions.parquet"
+        mock_fs.get_file_info.return_value = [existing_info]
+
+        written_keys = []
+
+        def fake_write_table(table, path, filesystem=None, compression=None):
+            if filesystem is not None:
+                written_keys.append((path, table.num_rows))
+
+        today = date.today().isoformat()
+        args = argparse.Namespace(
+            data_dir=str(tmp_path), staging_dir=str(tmp_path / "staging"), regions="singapore"
+        )
+        with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs), \
+             patch.object(sync_r2, "_ais_db_candidates", return_value=[db]), \
+             patch("pyarrow.parquet.write_table", side_effect=fake_write_table):
+            rc = sync_r2.cmd_push_ais_parquet(args)
+
+        assert rc == 0
+        sentinel_keys = [k for k, rows in written_keys if f"date={today}" in k and rows == 0]
+        assert len(sentinel_keys) == 1, f"expected 1 today sentinel, got {written_keys}"
+
 
 class TestVesselMetaPush:
     def test_pushes_vessel_meta_when_present(self, tmp_path):


### PR DESCRIPTION
## Problem

The previous sentinel upload only triggered when a region's DuckDB was completely empty (`row_count == 0`). Regions with historical data but no new rows today were silently skipped, leaving today's date partition absent from R2 and causing the validation job to fail.

## Fix

After uploading historical date partitions, check if today's date is already in R2. If not, upload an empty Parquet sentinel regardless of whether the DB has older rows.

```
[gulfofmexico] Reading gulfofmexico.duckdb ...
  2026-04-30 (0 rows) -> uploaded empty sentinel to R2
[persiangulf] Reading persiangulf.duckdb ...
  2026-04-30 (0 rows) -> uploaded empty sentinel to R2
[gulfofaden] Reading gulfofaden.duckdb ...
  2026-04-30 (0 rows) -> uploaded empty sentinel to R2
Done. 12 file(s) uploaded to maridb-public
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)