### PR TITLE
feat(graph): extend sanctions_distance to 3-hop UBO level

### DIFF
--- a/pipelines/features/ownership_graph.py
+++ b/pipelines/features/ownership_graph.py
@@ -36,6 +36,7 @@ def _compute_sanctions_distance(tables: dict) -> pl.DataFrame:
     0 = vessel directly sanctioned
     1 = owner or manager is sanctioned
     2 = parent company (via CONTROLLED_BY) is sanctioned
+    3 = grandparent / UBO level (CONTROLLED_BY × 2) is sanctioned
     99 = no sanctions connection
     """
     vessels = pl.from_arrow(tables["Vessel"]).select("mmsi")
@@ -69,17 +70,37 @@ def _compute_sanctions_distance(tables: dict) -> pl.DataFrame:
 
     # 2-hop: vessel → company → (CONTROLLED_BY) → sanctioned parent
     two_hop: set[str] = set()
-    if len(cb) and len(ob or mb):
+    if len(cb) and (len(ob) or len(mb)):
         sanctioned_parents = set(
             cb.filter(pl.col("dst_id").is_in(sanctioned_ids))["src_id"].to_list()
         )
-        if sanctioned_parents and (len(ob) or len(mb)):
+        if sanctioned_parents:
             two_hop_vessels = (
                 vessel_companies.filter(pl.col("dst_id").is_in(sanctioned_parents))["src_id"]
                 .unique()
                 .to_list()
             )
             two_hop = set(two_hop_vessels)
+
+    # 3-hop: vessel → company → parent → (CONTROLLED_BY) → sanctioned grandparent (UBO level)
+    three_hop: set[str] = set()
+    if len(cb) and (len(ob) or len(mb)):
+        sanctioned_grandparents = set(
+            cb.filter(pl.col("dst_id").is_in(sanctioned_ids))["src_id"].to_list()
+        )
+        if sanctioned_grandparents:
+            sanctioned_via_grandparent = set(
+                cb.filter(pl.col("dst_id").is_in(sanctioned_grandparents))["src_id"].to_list()
+            )
+            if sanctioned_via_grandparent:
+                three_hop_vessels = (
+                    vessel_companies.filter(
+                        pl.col("dst_id").is_in(sanctioned_via_grandparent)
+                    )["src_id"]
+                    .unique()
+                    .to_list()
+                )
+                three_hop = set(three_hop_vessels)
 
     rows = []
     for mmsi in vessels["mmsi"].to_list():
@@ -89,6 +110,8 @@ def _compute_sanctions_distance(tables: dict) -> pl.DataFrame:
             dist = 1
         elif mmsi in two_hop:
             dist = 2
+        elif mmsi in three_hop:
+            dist = 3
         else:
             dist = MAX_HOPS
         rows.append({"mmsi": mmsi, "sanctions_distance": dist})

--- a/pipelines/score/causal_sanction.py
+++ b/pipelines/score/causal_sanction.py
@@ -237,9 +237,9 @@ def _identify_treatment_groups(
     """
     Return (treated_mmsis, control_mmsis) for a given regime.
 
-    Treated : sanctions_distance ≤ 2 AND vessel in Neo4j graph connected to
+    Treated : sanctions_distance ≤ 3 AND vessel in Neo4j graph connected to
               a sanctions_entities row whose list_source contains the regime
-              substring.
+              substring (distance 3 = UBO / grandparent level).
 
     Control : sanctions_distance = 99 (no graph link to any sanctioned entity).
 
@@ -256,7 +256,7 @@ def _identify_treatment_groups(
             SELECT DISTINCT vf.mmsi
             FROM vessel_features vf
             JOIN vessel_meta vm ON vm.mmsi = vf.mmsi
-            WHERE vf.sanctions_distance <= 2
+            WHERE vf.sanctions_distance <= 3
             """,
         ).fetchall()
         treated = [r[0] for r in treated_rows]

--- a/tests/test_ownership_graph.py
+++ b/tests/test_ownership_graph.py
@@ -10,6 +10,7 @@ import pyarrow as pa
 from pipelines.features.ownership_graph import (
     MAX_HOPS,
     _apply_direct_sanctions_fallback,
+    _compute_sanctions_distance,
     _compute_sts_hub_degree,
 )
 from pipelines.ingest.graph_store import NODE_SCHEMAS, REL_SCHEMAS
@@ -185,3 +186,152 @@ def test_sts_hub_degree_hub_vessel():
     )
     result = _compute_sts_hub_degree(tables)
     assert result.filter(pl.col("mmsi") == "111111111")["sts_hub_degree"][0] == 3
+
+
+# ---------------------------------------------------------------------------
+# _compute_sanctions_distance — UBO traversal (distance 0–3 and 99)
+# ---------------------------------------------------------------------------
+
+
+def _make_distance_tables(
+    vessel_mmsis: list[str],
+    sanctioned_ids: list[str],
+    owned_by: list[tuple[str, str]],
+    managed_by: list[tuple[str, str]],
+    controlled_by: list[tuple[str, str]],
+) -> dict:
+    """Build minimal tables dict for _compute_sanctions_distance tests."""
+    vessel_table = pa.table(
+        {"mmsi": vessel_mmsis, "imo": [""] * len(vessel_mmsis), "name": [""] * len(vessel_mmsis)},
+        schema=NODE_SCHEMAS["Vessel"],
+    )
+    sb_table = pa.table(
+        {"src_id": sanctioned_ids, "dst_id": ["regime"] * len(sanctioned_ids),
+         "list": [""] * len(sanctioned_ids), "date": [""] * len(sanctioned_ids)},
+        schema=REL_SCHEMAS["SANCTIONED_BY"],
+    )
+    ob_table = pa.table(
+        {"src_id": [r[0] for r in owned_by], "dst_id": [r[1] for r in owned_by],
+         "since": [""] * len(owned_by), "until": [""] * len(owned_by)},
+        schema=REL_SCHEMAS["OWNED_BY"],
+    ) if owned_by else pa.table(
+        {"src_id": [], "dst_id": [], "since": [], "until": []},
+        schema=REL_SCHEMAS["OWNED_BY"],
+    )
+    mb_table = pa.table(
+        {"src_id": [r[0] for r in managed_by], "dst_id": [r[1] for r in managed_by],
+         "since": [""] * len(managed_by), "until": [""] * len(managed_by)},
+        schema=REL_SCHEMAS["MANAGED_BY"],
+    ) if managed_by else pa.table(
+        {"src_id": [], "dst_id": [], "since": [], "until": []},
+        schema=REL_SCHEMAS["MANAGED_BY"],
+    )
+    cb_table = pa.table(
+        {"src_id": [r[0] for r in controlled_by], "dst_id": [r[1] for r in controlled_by]},
+        schema=REL_SCHEMAS["CONTROLLED_BY"],
+    ) if controlled_by else pa.table(
+        {"src_id": [], "dst_id": []}, schema=REL_SCHEMAS["CONTROLLED_BY"]
+    )
+    return {
+        "Vessel": vessel_table,
+        "SANCTIONED_BY": sb_table,
+        "OWNED_BY": ob_table,
+        "MANAGED_BY": mb_table,
+        "CONTROLLED_BY": cb_table,
+    }
+
+
+def test_sanctions_distance_direct():
+    """A vessel whose MMSI is directly in SANCTIONED_BY gets distance 0."""
+    tables = _make_distance_tables(
+        vessel_mmsis=["111111111"],
+        sanctioned_ids=["111111111"],
+        owned_by=[], managed_by=[], controlled_by=[],
+    )
+    result = _compute_sanctions_distance(tables)
+    assert result.filter(pl.col("mmsi") == "111111111")["sanctions_distance"][0] == 0
+
+
+def test_sanctions_distance_one_hop_owned_by():
+    """A vessel owned by a sanctioned company gets distance 1."""
+    tables = _make_distance_tables(
+        vessel_mmsis=["222222222"],
+        sanctioned_ids=["company-A"],
+        owned_by=[("222222222", "company-A")],
+        managed_by=[], controlled_by=[],
+    )
+    result = _compute_sanctions_distance(tables)
+    assert result.filter(pl.col("mmsi") == "222222222")["sanctions_distance"][0] == 1
+
+
+def test_sanctions_distance_one_hop_managed_by():
+    """A vessel managed by a sanctioned company gets distance 1."""
+    tables = _make_distance_tables(
+        vessel_mmsis=["333333333"],
+        sanctioned_ids=["company-B"],
+        owned_by=[],
+        managed_by=[("333333333", "company-B")],
+        controlled_by=[],
+    )
+    result = _compute_sanctions_distance(tables)
+    assert result.filter(pl.col("mmsi") == "333333333")["sanctions_distance"][0] == 1
+
+
+def test_sanctions_distance_two_hop():
+    """A vessel owned by a company whose parent is sanctioned gets distance 2."""
+    tables = _make_distance_tables(
+        vessel_mmsis=["444444444"],
+        sanctioned_ids=["parent-corp"],
+        owned_by=[("444444444", "child-corp")],
+        managed_by=[],
+        controlled_by=[("child-corp", "parent-corp")],
+    )
+    result = _compute_sanctions_distance(tables)
+    assert result.filter(pl.col("mmsi") == "444444444")["sanctions_distance"][0] == 2
+
+
+def test_sanctions_distance_three_hop_ubo():
+    """A vessel linked to a sanctioned grandparent (UBO) via two CONTROLLED_BY hops
+    gets distance 3."""
+    tables = _make_distance_tables(
+        vessel_mmsis=["555555555"],
+        sanctioned_ids=["grandparent-corp"],
+        owned_by=[("555555555", "child-corp")],
+        managed_by=[],
+        controlled_by=[
+            ("child-corp", "parent-corp"),      # child → parent
+            ("parent-corp", "grandparent-corp"), # parent → grandparent (sanctioned)
+        ],
+    )
+    result = _compute_sanctions_distance(tables)
+    assert result.filter(pl.col("mmsi") == "555555555")["sanctions_distance"][0] == 3
+
+
+def test_sanctions_distance_no_connection():
+    """A vessel with no graph link to any sanctioned entity gets distance 99."""
+    tables = _make_distance_tables(
+        vessel_mmsis=["666666666"],
+        sanctioned_ids=["unrelated-entity"],
+        owned_by=[("666666666", "clean-corp")],
+        managed_by=[],
+        controlled_by=[],
+    )
+    result = _compute_sanctions_distance(tables)
+    assert result.filter(pl.col("mmsi") == "666666666")["sanctions_distance"][0] == MAX_HOPS
+
+
+def test_sanctions_distance_priority_closer_wins():
+    """When a vessel qualifies for multiple distances, the minimum (closest) wins."""
+    # vessel is both distance-1 (managed by sanctioned) and distance-3 (UBO chain)
+    tables = _make_distance_tables(
+        vessel_mmsis=["777777777"],
+        sanctioned_ids=["company-direct", "grandparent-corp"],
+        owned_by=[("777777777", "child-corp")],
+        managed_by=[("777777777", "company-direct")],
+        controlled_by=[
+            ("child-corp", "parent-corp"),
+            ("parent-corp", "grandparent-corp"),
+        ],
+    )
+    result = _compute_sanctions_distance(tables)
+    assert result.filter(pl.col("mmsi") == "777777777")["sanctions_distance"][0] == 1


### PR DESCRIPTION
## Summary

Extends ownership graph traversal from 2 hops to 3 hops to capture vessels linked to sanctioned entities at the UBO (Ultimate Beneficial Owner) / grandparent level.

| Distance | Meaning |
|---|---|
| 0 | Vessel directly sanctioned |
| 1 | Owner / manager sanctioned |
| 2 | Parent company sanctioned |
| **3** | **Grandparent / UBO sanctioned ← new** |
| 99 | No connection |

- 3-hop follows `CONTROLLED_BY × 2` from the vessel's direct company
- DiD treatment group threshold updated `≤ 2 → ≤ 3` in `causal_sanction.py`
- `composite.py` graph_risk_score formula (`1 - distance/5`) already handles distance 3 correctly (score = 0.4) — no change needed
- 7 new unit tests added covering all distance levels, no-connection, and priority (closest wins)
- All 17 tests pass

Part of edgesentry/arktrace#516. Issue edgesentry/arktrace#534 tracks the remaining macro-event covariates item.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)