### PR TITLE
fix: ais validate day_pass logic and active-region display

### DIFF
--- a/scripts/validate_ais_upload.py
+++ b/scripts/validate_ais_upload.py
@@ -164,10 +164,8 @@ def _validate_date(fs, bucket: str, target_date: str, is_recent: bool) -> dict:
     active_passing = [r for r in regions_passing if r in _ACTIVE_REGIONS]
     coverage_pass = len(active_passing) >= _MIN_ACTIVE_REGIONS
 
-    day_pass = coverage_pass and all(
-        r["pass"] for r in region_results if r["region"] in _ACTIVE_REGIONS
-    )
-    print(f"  → {'PASS' if day_pass else 'FAIL'} ({len(active_passing)}/{_MIN_ACTIVE_REGIONS} active regions)")
+    day_pass = coverage_pass
+    print(f"  → {'PASS' if day_pass else 'FAIL'} ({len(active_passing)}/{len(_ACTIVE_REGIONS)} active regions)")
 
     return {
         "date": target_date,


### PR DESCRIPTION
## Problem

Two bugs in `scripts/validate_ais_upload.py`:

1. **`day_pass` was too strict** — it required **all** active regions to pass via `and all(...)`, which contradicted the purpose of `_MIN_ACTIVE_REGIONS = 5`. On 2026-04-28, 5/6 active regions passed (≥ threshold) but `singapore` was missing, so `all()` returned False and the day was marked FAIL despite meeting the coverage requirement.

2. **Confusing summary line** — denominator used `_MIN_ACTIVE_REGIONS` (5) instead of the total active region count (6), printing `5/5 → FAIL` which looks like it should pass.

## Fix

```python
# Before
day_pass = coverage_pass and all(
    r["pass"] for r in region_results if r["region"] in _ACTIVE_REGIONS
)
print(f"  → {'PASS' if day_pass else 'FAIL'} ({len(active_passing)}/{_MIN_ACTIVE_REGIONS} active regions)")

# After
day_pass = coverage_pass
print(f"  → {'PASS' if day_pass else 'FAIL'} ({len(active_passing)}/{len(_ACTIVE_REGIONS)} active regions)")
```

## Expected output after fix (replaying 2026-04-28–30)

```
[2026-04-28]  → PASS (5/6 active regions)   ← was FAIL (5/5)
[2026-04-29]  → FAIL (3/6 active regions)   ← correct, only 3 active passing
[2026-04-30]  → PASS (6/6 active regions)   ← unchanged
Overall: PASS (2/3 days passing)             ← was FAIL
```