### PR TITLE
fix(#530): retry GFW connection errors with exponential backoff

### DIFF
--- a/pipelines/ingest/eo_gfw.py
+++ b/pipelines/ingest/eo_gfw.py
@@ -127,20 +127,37 @@ def fetch_gfw_detections(
 
     _RETRY_WAIT = 60  # seconds — GFW allows one concurrent report per token
     _MAX_WAITS = 5
+    _CONN_RETRY_WAITS = (30, 60, 120)  # backoff for connection-level errors
 
     token_idx = 0
     wait_count = 0
+    conn_attempt = 0
 
     while True:
         current_token = tokens[token_idx % len(tokens)]
         headers["Authorization"] = f"Bearer {current_token}"
-        resp = httpx.post(
-            f"{GFW_API_BASE}/4wings/report",
-            params=params,
-            json=body,
-            headers=headers,
-            timeout=180,
-        )
+        try:
+            resp = httpx.post(
+                f"{GFW_API_BASE}/4wings/report",
+                params=params,
+                json=body,
+                headers=headers,
+                timeout=300,
+            )
+        except (httpx.RemoteProtocolError, httpx.ReadTimeout, httpx.ConnectError) as exc:
+            if conn_attempt >= len(_CONN_RETRY_WAITS):
+                raise RuntimeError(
+                    f"GFW API connection failed after {conn_attempt} retries: {exc}"
+                ) from exc
+            wait = _CONN_RETRY_WAITS[conn_attempt]
+            print(
+                f"  GFW connection error ({exc}); retrying in {wait}s"
+                f" (attempt {conn_attempt + 1}/{len(_CONN_RETRY_WAITS)}) ...",
+                flush=True,
+            )
+            time.sleep(wait)
+            conn_attempt += 1
+            continue
         if resp.status_code in (401, 403):
             raise PermissionError(
                 f"GFW API returned {resp.status_code}: token lacks access to "


### PR DESCRIPTION
Closes arktrace#530

## Root cause

`fetch_gfw_detections` only retried on HTTP 429. Connection-level errors (`RemoteProtocolError` — "peer closed connection without sending complete message body") were caught in `gfw_ingest.py` and immediately skipped with no retry. The GFW API was dropping connections mid-response under load.

## Fix

Wrap the `httpx.post()` call to catch connection-level exceptions and retry with exponential backoff:

- Catches: `httpx.RemoteProtocolError`, `httpx.ReadTimeout`, `httpx.ConnectError`
- Backoff: 30s → 60s → 120s (3 attempts total)
- Raises `RuntimeError` after all retries exhausted (propagates to `gfw_ingest.py` as a skip, not a silent swallow)
- Raised timeout: 180s → 300s (large bboxes like europe/middleeast produce large responses)

## Verification

Run `GFW EO Ingest` workflow manually — expect `Done. N region(s) fetched, 0 skipped.`