### PR TITLE
fix: active regions showing 0/5 (none) — read from day_results[-1]

### DIFF
--- a/scripts/notify_ais_validation.py
+++ b/scripts/notify_ais_validation.py
@@ -56,8 +56,13 @@ def main() -> int:
     report = json.loads(_REPORT_PATH.read_text())
     target_date = report.get("most_recent_date", report.get("target_date", "unknown"))
     overall_pass = report.get("overall_pass", False)
-    coverage = report.get("coverage_check", {})
-    active_passing = report.get("active_regions_passing", [])
+
+    # active_regions_passing, coverage_check, and region_results live inside
+    # each day_result, not at the top level — use the most recent day
+    day_results = report.get("day_results", [])
+    most_recent_day = day_results[-1] if day_results else {}
+    coverage = most_recent_day.get("coverage_check", {})
+    active_passing = most_recent_day.get("active_regions_passing", [])
 
     run_id = os.getenv("GITHUB_RUN_ID", "")
     repo = os.getenv("GITHUB_REPOSITORY", "edgesentry/maridb")
@@ -70,7 +75,7 @@ def main() -> int:
     subject = f"{status_icon} maridb AIS validation — {target_date} ({'PASS' if overall_pass else 'FAIL'})"
 
     region_rows = ""
-    for r in report.get("region_results", []):
+    for r in most_recent_day.get("region_results", []):
         color = _row_color(r.get("pass", False))
         checks = r.get("checks", {})
         err = r.get("error", "")

--- a/tests/test_notify_ais_validation.py
+++ b/tests/test_notify_ais_validation.py
@@ -16,7 +16,8 @@ def _load_notify():
 
 
 def _make_day_result(date="2026-05-02", active_passing=None, required=5, region_results=None):
-    active_passing = active_passing or ["japansea", "singapore", "europe", "blacksea", "middleeast", "gulfofguinea"]
+    if active_passing is None:
+        active_passing = ["japansea", "singapore", "europe", "blacksea", "middleeast", "gulfofguinea"]
     return {
         "date": date,
         "pass": True,

--- a/tests/test_notify_ais_validation.py
+++ b/tests/test_notify_ais_validation.py
@@ -154,6 +154,17 @@ def test_subject_uses_target_date_as_fallback(tmp_path, monkeypatch):
     assert "unknown" not in subjects[0]
 
 
+def _decode_body(raw_msg: str) -> str:
+    """Extract and decode the HTML body from a raw MIME message string."""
+    import email
+    msg = email.message_from_string(raw_msg)
+    for part in msg.walk():
+        if part.get_content_type() == "text/html":
+            payload = part.get_payload(decode=True)
+            return payload.decode("utf-8") if payload else ""
+    return raw_msg
+
+
 def _fake_smtp_capture(bodies):
     class FakeSMTP:
         def __init__(self, *a, **kw): pass
@@ -162,7 +173,7 @@ def _fake_smtp_capture(bodies):
         def starttls(self): pass
         def login(self, *a): pass
         def sendmail(self, _from, _to, msg):
-            bodies.append(msg)
+            bodies.append(_decode_body(msg))
     return FakeSMTP
 
 

--- a/tests/test_notify_ais_validation.py
+++ b/tests/test_notify_ais_validation.py
@@ -1,4 +1,4 @@
-"""Tests for notify_ais_validation.py — subject line date extraction."""
+"""Tests for notify_ais_validation.py — subject line date and active region display."""
 import importlib.util
 import json
 from pathlib import Path
@@ -15,16 +15,25 @@ def _load_notify():
     return mod
 
 
+def _make_day_result(date="2026-05-02", active_passing=None, required=5, region_results=None):
+    active_passing = active_passing or ["japansea", "singapore", "europe", "blacksea", "middleeast", "gulfofguinea"]
+    return {
+        "date": date,
+        "pass": True,
+        "active_regions_passing": active_passing,
+        "coverage_check": {"pass": True, "active_passing": len(active_passing), "required": required},
+        "region_results": region_results or [],
+    }
+
+
 def _make_report(**kwargs):
+    day = _make_day_result()
     base = {
         "overall_pass": True,
         "most_recent_date": "2026-05-02",
         "validate_days": 3,
         "days_passing": 2,
-        "active_regions_passing": ["japansea", "singapore"],
-        "coverage_check": {"pass": True, "active_passing": 2, "required": 5},
-        "region_results": [],
-        "day_results": [],
+        "day_results": [day],
     }
     base.update(kwargs)
     return base
@@ -143,3 +152,89 @@ def test_subject_uses_target_date_as_fallback(tmp_path, monkeypatch):
     assert subjects
     assert "2026-04-30" in subjects[0]
     assert "unknown" not in subjects[0]
+
+
+def _fake_smtp_capture(bodies):
+    class FakeSMTP:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def starttls(self): pass
+        def login(self, *a): pass
+        def sendmail(self, _from, _to, msg):
+            bodies.append(msg)
+    return FakeSMTP
+
+
+def _set_smtp_env(monkeypatch):
+    monkeypatch.setenv("NOTIFY_EMAIL", "test@example.com")
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "587")
+    monkeypatch.setenv("SMTP_USER", "user@example.com")
+    monkeypatch.setenv("SMTP_PASSWORD", "secret")
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "edgesentry/maridb")
+
+
+def test_active_regions_read_from_day_results(tmp_path, monkeypatch):
+    """Active regions must come from day_results[-1], not the top level."""
+    day = _make_day_result(
+        active_passing=["japansea", "singapore", "europe", "blacksea", "middleeast", "gulfofguinea"],
+        required=5,
+    )
+    report = _make_report(day_results=[day])
+    report_path = tmp_path / "ais_validation_report.json"
+    report_path.write_text(json.dumps(report))
+
+    mod = _load_notify()
+    monkeypatch.setattr(mod, "_REPORT_PATH", report_path)
+    _set_smtp_env(monkeypatch)
+
+    bodies = []
+    with patch("smtplib.SMTP", _fake_smtp_capture(bodies)):
+        mod.main()
+
+    assert bodies
+    body = bodies[0]
+    assert "6/5" in body, f"expected 6/5 in email body, got:\n{body[:500]}"
+    assert "none" not in body.lower().split("active regions passing")[1][:50]
+
+
+def test_active_regions_not_none_when_populated(tmp_path, monkeypatch):
+    """Email must not show '(none)' when active regions are present."""
+    day = _make_day_result(active_passing=["japansea", "singapore", "europe"])
+    report = _make_report(day_results=[day])
+    report_path = tmp_path / "ais_validation_report.json"
+    report_path.write_text(json.dumps(report))
+
+    mod = _load_notify()
+    monkeypatch.setattr(mod, "_REPORT_PATH", report_path)
+    _set_smtp_env(monkeypatch)
+
+    bodies = []
+    with patch("smtplib.SMTP", _fake_smtp_capture(bodies)):
+        mod.main()
+
+    assert bodies
+    assert "japansea" in bodies[0]
+    assert "singapore" in bodies[0]
+    assert "(none)" not in bodies[0]
+
+
+def test_active_regions_shows_none_when_empty(tmp_path, monkeypatch):
+    """Email must show '(none)' when no active regions pass."""
+    day = _make_day_result(active_passing=[])
+    report = _make_report(day_results=[day], overall_pass=False)
+    report_path = tmp_path / "ais_validation_report.json"
+    report_path.write_text(json.dumps(report))
+
+    mod = _load_notify()
+    monkeypatch.setattr(mod, "_REPORT_PATH", report_path)
+    _set_smtp_env(monkeypatch)
+
+    bodies = []
+    with patch("smtplib.SMTP", _fake_smtp_capture(bodies)):
+        mod.main()
+
+    assert bodies
+    assert "none" in bodies[0].lower()


### PR DESCRIPTION
## Root cause

`active_regions_passing`, `coverage_check`, and `region_results` are nested inside each `day_results[n]` in the report JSON — not at the top level. The notify script was reading them from the top level, getting empty defaults, and showing `0/5 (none)`.

## Fix

Read from `day_results[-1]` (the most recent day):

```python
# Before
coverage = report.get("coverage_check", {})
active_passing = report.get("active_regions_passing", [])
# region_results read from report.get("region_results", [])

# After
day_results = report.get("day_results", [])
most_recent_day = day_results[-1] if day_results else {}
coverage = most_recent_day.get("coverage_check", {})
active_passing = most_recent_day.get("active_regions_passing", [])
# region_results read from most_recent_day
```

## Tests added

- `test_active_regions_read_from_day_results` — regression test; verifies `6/5` appears in body
- `test_active_regions_not_none_when_populated` — verifies region names appear, no `(none)`
- `test_active_regions_shows_none_when_empty` — verifies `(none)` appears when truly empty