### PR TITLE
fix: rename composite_score → confidence in validation layer

### DIFF
--- a/pipelines/distribute/push.py
+++ b/pipelines/distribute/push.py
@@ -73,7 +73,7 @@ def push_arktrace_watchlist(region: str) -> bool:
         logger.error("Watchlist not found in maridb-public: %s", source_key)
         return False
 
-    result = _validate(df, required_columns=["mmsi", "composite_score"], min_rows=1)
+    result = _validate(df, required_columns=["mmsi", "confidence"], min_rows=1)
     if not result.ok:
         logger.warning("Watchlist (%s) failed Gate 2 — skipping: %s", region, result.errors)
         return True

--- a/pipelines/storage/schemas.py
+++ b/pipelines/storage/schemas.py
@@ -20,13 +20,9 @@ class WatchlistSchema(pa.DataFrameModel):
     """Gate 1 + Gate 2 schema for region watchlist Parquet files."""
 
     mmsi: Series[str] = pa.Field(nullable=False, description="Maritime Mobile Service Identity")
-    composite_score: Series[float] = pa.Field(
-        ge=0.0, le=1.0, nullable=False,
-        description="Alias for confidence; used by Gate 2 validation",
-    )
     confidence: Series[float] = pa.Field(
         ge=0.0, le=1.0, nullable=False,
-        description="Primary composite confidence score",
+        description="Composite confidence score (renamed from composite_score)",
     )
 
     class Config:

--- a/pipelines/storage/validate.py
+++ b/pipelines/storage/validate.py
@@ -31,9 +31,9 @@ SPECS: dict[str, ValidationSpec] = {
         no_nulls_in=["mmsi"],
     ),
     "watchlist": ValidationSpec(
-        required_columns=["mmsi", "composite_score"],
+        required_columns=["mmsi", "confidence"],
         min_rows=1,
-        no_nulls_in=["mmsi", "composite_score"],
+        no_nulls_in=["mmsi", "confidence"],
     ),
     "ais_positions": ValidationSpec(
         required_columns=["mmsi", "timestamp", "lat", "lon"],

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -345,11 +345,11 @@ def step_score(region: RegionConfig) -> bool:
             wl = pl.read_parquet(watchlist_path)
             if wl.height == 0:
                 logger.warning("  ⚠ validate [watchlist]: 0 rows written")
-            elif "composite_score" not in wl.columns:
-                logger.error("  ✗ validate [watchlist]: missing composite_score column")
+            elif "confidence" not in wl.columns:
+                logger.error("  ✗ validate [watchlist]: missing confidence column")
                 return False
             else:
-                logger.info("  ✓ validate [watchlist]: %d candidates, composite_score present", wl.height)
+                logger.info("  ✓ validate [watchlist]: %d candidates, confidence present", wl.height)
         except Exception as e:
             logger.error("  ✗ validate [watchlist]: %s", e)
             return False

--- a/tests/test_score_smoke.py
+++ b/tests/test_score_smoke.py
@@ -8,7 +8,7 @@ from pipelines.storage.validate import PipelineValidationError, validate_output
 
 class TestGate1Validation:
     def test_rejects_empty_dataframe(self):
-        df = pl.DataFrame({"mmsi": [], "composite_score": []})
+        df = pl.DataFrame({"mmsi": [], "confidence": []})
         with pytest.raises(PipelineValidationError, match="row count"):
             validate_output(df, "watchlist")
 
@@ -18,12 +18,12 @@ class TestGate1Validation:
             validate_output(df, "watchlist")
 
     def test_rejects_null_in_required_column(self):
-        df = pl.DataFrame({"mmsi": [None], "composite_score": [0.5]})
+        df = pl.DataFrame({"mmsi": [None], "confidence": [0.5]})
         with pytest.raises(PipelineValidationError, match="null values"):
             validate_output(df, "watchlist")
 
     def test_accepts_valid_watchlist(self):
-        df = pl.DataFrame({"mmsi": ["123456789"], "composite_score": [0.72]})
+        df = pl.DataFrame({"mmsi": ["123456789"], "confidence": [0.72]})
         validate_output(df, "watchlist")  # should not raise
 
     def test_accepts_valid_vessel_features(self):
@@ -61,15 +61,15 @@ class TestGate2Distribute:
         from pipelines.distribute.push import _validate
 
         df = pl.DataFrame({"mmsi": ["123"]})
-        result = _validate(df, required_columns=["mmsi", "composite_score"])
+        result = _validate(df, required_columns=["mmsi", "confidence"])
         assert not result.ok
 
     def test_push_accepts_valid_watchlist(self, tmp_path, monkeypatch):
         monkeypatch.setenv("DATA_DIR", str(tmp_path))
         from pipelines.distribute.push import _validate
 
-        df = pl.DataFrame({"mmsi": ["123456789"], "composite_score": [0.72]})
-        result = _validate(df, required_columns=["mmsi", "composite_score"])
+        df = pl.DataFrame({"mmsi": ["123456789"], "confidence": [0.72]})
+        result = _validate(df, required_columns=["mmsi", "confidence"])
         assert result.ok
 
     def test_local_distribute_watchlist(self, tmp_path, monkeypatch):
@@ -79,7 +79,7 @@ class TestGate2Distribute:
         # Write watchlist to maridb-public location (DATA_DIR/score/...)
         source_dir = tmp_path / "score"
         source_dir.mkdir()
-        df = pl.DataFrame({"mmsi": ["123456789"], "composite_score": [0.72]})
+        df = pl.DataFrame({"mmsi": ["123456789"], "confidence": [0.72]})
         df.write_parquet(source_dir / "singapore_watchlist.parquet")
 
         from pipelines.distribute.push import push_arktrace_watchlist


### PR DESCRIPTION
Fixes CI failure: `validate [watchlist]: missing composite_score column`

## Root cause
`composite.py` (synced from arktrace in #79) outputs `confidence` as the canonical score column name. The validation layer in indago still expected the old name `composite_score`.

## Changes
- `scripts/run_pipeline.py`: validation check `composite_score` → `confidence`
- `pipelines/storage/validate.py`: watchlist ValidationSpec updated
- `pipelines/storage/schemas.py`: `WatchlistSchema` — removed duplicate `composite_score` field, `confidence` is now the single canonical column
- `pipelines/distribute/push.py`: Gate 2 required columns updated
- `tests/test_score_smoke.py`: fixture DataFrames updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)