### PR TITLE
feat: OSINT watchlist report script + weekly GHA cron (closes #86)

### DIFF
--- a/.github/workflows/osint-report.yml
+++ b/.github/workflows/osint-report.yml
@@ -1,0 +1,80 @@
+name: OSINT Watchlist Report
+
+# Generates a structured OSINT report from the latest candidate_watchlist.parquet
+# and opens a GitHub Issue so the team stays current without manual effort.
+# Case B in docs/osint-workflow-design.md.
+#
+# Schedule: Monday 07:00 UTC — after sanctions-refresh (00:30) and
+#           data-publish (01:00) have both completed and pushed fresh watchlists.
+
+on:
+  schedule:
+    - cron: '0 7 * * 1'  # weekly Monday 07:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: osint-report
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Generate OSINT report & open issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    env:
+      MARIDB_DATA_DIR: data/processed
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Pull watchlists from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+        run: |
+          uv run python scripts/sync_r2.py pull-watchlists \
+            || { echo "::error::Failed to pull watchlists from R2"; exit 1; }
+
+      - name: Generate OSINT report
+        id: report
+        run: |
+          uv run python scripts/generate_osint_report.py \
+            --watchlist data/processed/candidate_watchlist.parquet \
+            --top 50 \
+            --out /tmp/osint_report.md
+          echo "report_path=/tmp/osint_report.md" >> "$GITHUB_OUTPUT"
+
+      - name: Open GitHub Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          title="[OSINT Check] Watchlist — $(date -u +%Y-%m-%d)"
+          gh issue create \
+            --title "$title" \
+            --body-file /tmp/osint_report.md \
+            --label "osint" \
+            --repo "$GITHUB_REPOSITORY" \
+            || echo "::warning::Could not create issue (label may not exist — create 'osint' label to enable)"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: osint-report-${{ github.run_id }}
+          path: /tmp/osint_report.md
+          retention-days: 30

--- a/.github/workflows/osint-report.yml
+++ b/.github/workflows/osint-report.yml
@@ -1,8 +1,7 @@
 name: OSINT Watchlist Report
 
 # Generates a structured OSINT report from the latest candidate_watchlist.parquet
-# and opens a GitHub Issue so the team stays current without manual effort.
-# Case B in docs/osint-workflow-design.md.
+# and emails it to NOTIFY_EMAIL. Case B in docs/osint-workflow-design.md.
 #
 # Schedule: Monday 07:00 UTC — after sanctions-refresh (00:30) and
 #           data-publish (01:00) have both completed and pushed fresh watchlists.
@@ -20,12 +19,11 @@ concurrency:
 
 jobs:
   report:
-    name: Generate OSINT report & open issue
+    name: Generate OSINT report & email
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
-      issues: write
     env:
       MARIDB_DATA_DIR: data/processed
 
@@ -50,26 +48,21 @@ jobs:
           uv run python scripts/sync_r2.py pull-watchlists \
             || { echo "::error::Failed to pull watchlists from R2"; exit 1; }
 
-      - name: Generate OSINT report
-        id: report
+      - name: Generate report & send email
+        env:
+          NOTIFY_EMAIL: ${{ vars.NOTIFY_EMAIL }}
+          SMTP_HOST: ${{ vars.SMTP_HOST }}
+          SMTP_PORT: ${{ vars.SMTP_PORT }}
+          SMTP_USER: ${{ vars.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           uv run python scripts/generate_osint_report.py \
             --watchlist data/processed/candidate_watchlist.parquet \
             --top 50 \
-            --out /tmp/osint_report.md
-          echo "report_path=/tmp/osint_report.md" >> "$GITHUB_OUTPUT"
-
-      - name: Open GitHub Issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          title="[OSINT Check] Watchlist — $(date -u +%Y-%m-%d)"
-          gh issue create \
-            --title "$title" \
-            --body-file /tmp/osint_report.md \
-            --label "osint" \
-            --repo "$GITHUB_REPOSITORY" \
-            || echo "::warning::Could not create issue (label may not exist — create 'osint' label to enable)"
+            --out /tmp/osint_report.md \
+            --email
 
       - name: Upload report artifact
         if: always()

--- a/scripts/generate_osint_report.py
+++ b/scripts/generate_osint_report.py
@@ -1,0 +1,252 @@
+"""Generate a structured OSINT watchlist report from candidate_watchlist.parquet.
+
+Replaces the removed osint_watchlist_check.py with a pure data-transformation
+step that has no LLM dependency. Intended to be consumed by a GitHub Actions
+weekly cron (Case B in docs/osint-workflow-design.md).
+
+What this script does
+---------------------
+- Reads candidate_watchlist.parquet (local or from a provided path)
+- Selects top-N vessels by confidence score
+- Flags vessels where sanctions_distance == 0 (directly sanctioned)
+- Detects ITU-unallocated MMSIs (stateless vessels)
+- Generates MarineTraffic / VesselFinder / OFAC search URLs per vessel
+- Writes a structured Markdown report
+
+Usage
+-----
+    uv run python scripts/generate_osint_report.py
+    uv run python scripts/generate_osint_report.py --top 50 --out report.md
+    uv run python scripts/generate_osint_report.py --watchlist data/processed/candidate_watchlist.parquet
+
+Environment variables
+---------------------
+MARIDB_DATA_DIR  Directory containing candidate_watchlist.parquet
+                 (default: ~/.maridb/data or data/processed if that exists)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+import polars as pl
+
+# ---------------------------------------------------------------------------
+# ITU Maritime Identification Digits (MID) — complete allocation table.
+# Any 9-digit MMSI whose first 3 digits are NOT in this set is considered
+# unallocated / stateless.  Source: ITU List of Ship Stations and Maritime
+# Mobile Service Identity Assignments (Table of MIDs).
+# ---------------------------------------------------------------------------
+_ALLOCATED_MIDS: frozenset[str] = frozenset(
+    {
+        # Europe (200–299)
+        "201", "202", "203", "204", "205", "206", "207", "208",
+        "209", "210", "211", "212", "213", "214", "215", "216",
+        "218", "219", "220", "224", "225", "226", "227", "228",
+        "229", "230", "231", "232", "233", "234", "235", "236",
+        "237", "238", "239", "240", "241", "242", "243", "244",
+        "245", "246", "247", "248", "249", "250", "251", "252",
+        "253", "254", "255", "256", "257", "258", "259", "261",
+        "262", "263", "264", "265", "266", "267", "268", "269",
+        "270", "271", "272", "273", "274", "275", "276", "277",
+        "278", "279", "281",
+        # Americas (300–399)
+        "301", "303", "304", "305", "306", "307", "308", "309",
+        "310", "311", "312", "316", "319", "321", "323", "325",
+        "327", "329", "330", "331", "332", "333", "334", "336",
+        "338", "339", "341", "343", "345", "347", "348", "350",
+        "351", "352", "353", "354", "355", "356", "357", "358",
+        "359", "361", "362", "364", "366", "367", "368", "369",
+        "370", "371", "372", "373", "374", "375", "376", "377",
+        "378", "379",
+        # Asia / Middle East (400–499)
+        "401", "403", "405", "408", "410", "412", "413", "414",
+        "416", "417", "419", "422", "423", "425", "428", "431",
+        "432", "433", "434", "436", "437", "438", "440", "441",
+        "443", "445", "447", "450", "451", "453", "455", "457",
+        "459", "461", "463", "466", "468", "470", "471", "472",
+        "473", "477",
+        # Asia-Pacific / Oceania (500–599)
+        "501", "503", "506", "508", "510", "511", "512", "514",
+        "515", "516", "518", "520", "523", "525", "529", "531",
+        "533", "536", "538", "540", "542", "544", "546", "548",
+        "553", "555", "557", "559", "561", "563", "564", "565",
+        "566", "567", "570", "572", "574", "576", "577", "578",
+        # Africa (600–699)
+        "601", "603", "605", "607", "608", "609", "611", "613",
+        "616", "618", "619", "621", "622", "624", "625", "626",
+        "627", "629", "630", "631", "632", "633", "634", "635",
+        "636", "637", "638", "642", "644", "645", "647", "649",
+        "650", "654", "655", "656", "657", "659", "660", "661",
+        "662", "663", "664", "665", "666", "667", "668", "669",
+        "670", "671", "672", "674", "675", "676", "677", "678",
+        "679",
+        # Americas South (700–799)
+        "701", "710", "720", "725", "730", "735", "740", "745",
+        "750", "755", "760", "765", "770", "775",
+    }
+)
+
+
+def _is_stateless(mmsi: str) -> bool:
+    """Return True if the MMSI's MID prefix is not in the ITU allocation table."""
+    if not mmsi or len(mmsi) != 9 or not mmsi.isdigit():
+        return False
+    return mmsi[:3] not in _ALLOCATED_MIDS
+
+
+def _mt_url(mmsi: str) -> str:
+    return f"https://www.marinetraffic.com/en/ais/details/ships/mmsi:{mmsi}"
+
+
+def _vf_url(mmsi: str) -> str:
+    return f"https://www.vesselfinder.com/vessels/details/{mmsi}"
+
+
+def _ofac_url(name: str) -> str:
+    q = name.replace(" ", "+") if name and name != "Unknown" else "unknown"
+    return f"https://sanctionssearch.ofac.treas.gov/?q={q}"
+
+
+def _resolve_watchlist_path(cli_path: str | None) -> Path:
+    if cli_path:
+        return Path(cli_path).resolve()
+    data_dir_env = os.getenv("MARIDB_DATA_DIR")
+    if data_dir_env:
+        p = Path(data_dir_env) / "candidate_watchlist.parquet"
+        if p.exists():
+            return p
+    local = Path("data/processed/candidate_watchlist.parquet")
+    if local.exists():
+        return local.resolve()
+    return Path.home() / ".maridb" / "data" / "candidate_watchlist.parquet"
+
+
+def generate_report(df: pl.DataFrame, top_n: int) -> str:
+    """Return a Markdown OSINT report string for the top-N watchlist candidates."""
+    today = date.today().isoformat()
+    top = df.sort("confidence", descending=True).head(top_n)
+
+    rows = top.to_dicts()
+    for i, row in enumerate(rows):
+        row["_rank"] = i + 1
+        mmsi = str(row.get("mmsi", "") or "")
+        name = str(row.get("vessel_name", "") or "Unknown")
+        row["_stateless"] = _is_stateless(mmsi)
+        row["_mid"] = mmsi[:3] if mmsi else "—"
+        row["_mt"] = f"[MT]({_mt_url(mmsi)})" if mmsi else "—"
+        row["_vf"] = f"[VF]({_vf_url(mmsi)})" if mmsi else "—"
+        row["_ofac"] = f"[OFAC]({_ofac_url(name)})"
+
+    sanctioned = [r for r in rows if r.get("sanctions_distance") == 0]
+    stateless = [r for r in rows if r["_stateless"]]
+
+    lines: list[str] = [
+        f"## sanctions_distance=0 ({len(sanctioned)} vessels)",
+        "",
+        "| Rank | MMSI | IMO | Name | Flag | Conf | Links |",
+        "|------|------|-----|------|------|------|-------|",
+    ]
+    for r in sanctioned:
+        conf = f"{r.get('confidence', 0):.3f}"
+        lines.append(
+            f"| {r['_rank']} | {r.get('mmsi', '—')} | {r.get('imo', '—') or '—'} "
+            f"| {r.get('vessel_name', 'Unknown') or 'Unknown'} "
+            f"| {r.get('flag', '—') or '—'} | {conf} "
+            f"| {r['_mt']} {r['_vf']} {r['_ofac']} |"
+        )
+    if not sanctioned:
+        lines.append("_No directly sanctioned vessels in top-N._")
+
+    lines += [
+        "",
+        f"## Stateless MMSIs — ITU unallocated ({len(stateless)} vessels)",
+        "",
+        "| Rank | MMSI | Name | Conf | MID | Note |",
+        "|------|------|------|------|-----|------|",
+    ]
+    for r in stateless:
+        conf = f"{r.get('confidence', 0):.3f}"
+        lines.append(
+            f"| {r['_rank']} | {r.get('mmsi', '—')} "
+            f"| {r.get('vessel_name', 'Unknown') or 'Unknown'} "
+            f"| {conf} | {r['_mid']} | ⚠ ITU unallocated |"
+        )
+    if not stateless:
+        lines.append("_No stateless MMSIs detected in top-N._")
+
+    lines += [
+        "",
+        f"## Top-{top_n} watchlist ({today})",
+        "",
+        "| Rank | MMSI | IMO | Name | Flag | Conf | SD | Links |",
+        "|------|------|-----|------|------|------|-----|-------|",
+    ]
+    for r in rows:
+        conf = f"{r.get('confidence', 0):.3f}"
+        sd = r.get("sanctions_distance", "—")
+        sd_str = str(int(sd)) if sd is not None and str(sd) != "nan" else "—"
+        stateless_marker = " ⚠" if r["_stateless"] else ""
+        lines.append(
+            f"| {r['_rank']} | {r.get('mmsi', '—')}{stateless_marker} "
+            f"| {r.get('imo', '—') or '—'} "
+            f"| {r.get('vessel_name', 'Unknown') or 'Unknown'} "
+            f"| {r.get('flag', '—') or '—'} | {conf} | {sd_str} "
+            f"| {r['_mt']} {r['_vf']} |"
+        )
+
+    header = [
+        f"# [OSINT Check] Watchlist — {today}",
+        "",
+        f"Top-{top_n} candidates from `candidate_watchlist.parquet`.",
+        "Analysts: click links to verify on MarineTraffic / VesselFinder / OFAC.",
+        f"Stateless MMSIs (⚠) have unallocated ITU MID prefixes — likely spoofed identity.",
+        "",
+    ]
+    return "\n".join(header + lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate OSINT watchlist report")
+    parser.add_argument("--watchlist", help="Path to candidate_watchlist.parquet")
+    parser.add_argument("--top", type=int, default=50, help="Top-N vessels (default: 50)")
+    parser.add_argument("--out", help="Output file path (default: stdout)")
+    args = parser.parse_args()
+
+    watchlist_path = _resolve_watchlist_path(args.watchlist)
+    if not watchlist_path.exists():
+        print(f"[error] Watchlist not found: {watchlist_path}", file=sys.stderr)
+        print(
+            "  Pull from R2 first:  uv run python scripts/sync_r2.py pull-watchlists",
+            file=sys.stderr,
+        )
+        return 1
+
+    df = pl.read_parquet(watchlist_path)
+    if df.height == 0:
+        print("[warn] Watchlist is empty — no candidates to report.", file=sys.stderr)
+        return 0
+
+    required = {"mmsi", "confidence", "sanctions_distance"}
+    missing = required - set(df.columns)
+    if missing:
+        print(f"[error] Watchlist missing columns: {missing}", file=sys.stderr)
+        return 1
+
+    report = generate_report(df, top_n=args.top)
+
+    if args.out:
+        Path(args.out).write_text(report)
+        print(f"Report written to {args.out}")
+    else:
+        sys.stdout.write(report)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_osint_report.py
+++ b/scripts/generate_osint_report.py
@@ -11,26 +11,36 @@ What this script does
 - Flags vessels where sanctions_distance == 0 (directly sanctioned)
 - Detects ITU-unallocated MMSIs (stateless vessels)
 - Generates MarineTraffic / VesselFinder / OFAC search URLs per vessel
-- Writes a structured Markdown report
+- Writes a structured Markdown report and optionally emails it
 
 Usage
 -----
     uv run python scripts/generate_osint_report.py
     uv run python scripts/generate_osint_report.py --top 50 --out report.md
-    uv run python scripts/generate_osint_report.py --watchlist data/processed/candidate_watchlist.parquet
+    uv run python scripts/generate_osint_report.py --email
 
 Environment variables
 ---------------------
 MARIDB_DATA_DIR  Directory containing candidate_watchlist.parquet
                  (default: ~/.maridb/data or data/processed if that exists)
+NOTIFY_EMAIL     Recipient address (required for --email)
+SMTP_HOST        SMTP server hostname  (default: smtp.gmail.com)
+SMTP_PORT        SMTP server port      (default: 587)
+SMTP_USER        Sender address / login
+SMTP_PASSWORD    SMTP password / app-password
+GITHUB_RUN_ID    Injected automatically by GitHub Actions
+GITHUB_REPOSITORY Injected automatically by GitHub Actions
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+import smtplib
 import sys
 from datetime import date
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 from pathlib import Path
 
 import polars as pl
@@ -210,11 +220,60 @@ def generate_report(df: pl.DataFrame, top_n: int) -> str:
     return "\n".join(header + lines) + "\n"
 
 
+def _send_email(subject: str, markdown_body: str) -> bool:
+    """Send the report as a plain-text email. Returns True on success."""
+    recipient = os.getenv("NOTIFY_EMAIL")
+    if not recipient:
+        print("NOTIFY_EMAIL not set — skipping email.", file=sys.stderr)
+        return False
+
+    smtp_host = os.getenv("SMTP_HOST", "smtp.gmail.com")
+    smtp_port = int(os.getenv("SMTP_PORT", "587"))
+    smtp_user = os.getenv("SMTP_USER", "")
+    smtp_password = os.getenv("SMTP_PASSWORD", "")
+
+    if not smtp_user or not smtp_password:
+        print("SMTP_USER / SMTP_PASSWORD not set — skipping email.", file=sys.stderr)
+        return False
+
+    run_id = os.getenv("GITHUB_RUN_ID", "")
+    repo = os.getenv("GITHUB_REPOSITORY", "edgesentry/indago")
+    run_url = (
+        f"https://github.com/{repo}/actions/runs/{run_id}"
+        if run_id
+        else f"https://github.com/{repo}/actions"
+    )
+
+    html_body = (
+        "<html><body><pre style='font-family:monospace;font-size:13px'>"
+        + markdown_body.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        + "</pre>"
+        + f"<p><a href='{run_url}'>View CI run →</a></p>"
+        + "</body></html>"
+    )
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = smtp_user
+    msg["To"] = recipient
+    msg.attach(MIMEText(markdown_body, "plain"))
+    msg.attach(MIMEText(html_body, "html"))
+
+    print(f"Sending email to {recipient} via {smtp_host}:{smtp_port} …")
+    with smtplib.SMTP(smtp_host, smtp_port) as server:
+        server.starttls()
+        server.login(smtp_user, smtp_password)
+        server.sendmail(smtp_user, recipient, msg.as_string())
+    print(f"Email sent: {subject}")
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Generate OSINT watchlist report")
     parser.add_argument("--watchlist", help="Path to candidate_watchlist.parquet")
     parser.add_argument("--top", type=int, default=50, help="Top-N vessels (default: 50)")
     parser.add_argument("--out", help="Output file path (default: stdout)")
+    parser.add_argument("--email", action="store_true", help="Send report by email (reads SMTP env vars)")
     args = parser.parse_args()
 
     watchlist_path = _resolve_watchlist_path(args.watchlist)
@@ -244,6 +303,10 @@ def main() -> int:
         print(f"Report written to {args.out}")
     else:
         sys.stdout.write(report)
+
+    if args.email:
+        today = date.today().isoformat()
+        _send_email(f"[OSINT Check] Watchlist — {today}", report)
 
     return 0
 

--- a/tests/test_generate_osint_report.py
+++ b/tests/test_generate_osint_report.py
@@ -1,0 +1,176 @@
+import polars as pl
+import pytest
+
+from scripts.generate_osint_report import (
+    _ALLOCATED_MIDS,
+    _is_stateless,
+    _mt_url,
+    _ofac_url,
+    _vf_url,
+    generate_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# ITU MID helpers
+# ---------------------------------------------------------------------------
+
+
+def test_allocated_mids_not_empty():
+    assert len(_ALLOCATED_MIDS) > 100
+
+
+@pytest.mark.parametrize(
+    "mmsi,expected",
+    [
+        ("412171000", False),  # China
+        ("563123456", False),  # Singapore
+        ("351234567", False),  # Panama
+        ("273456789", False),  # Russia
+        ("636001234", False),  # Liberia
+        ("400789012", True),   # 400 — unallocated
+        ("800000001", True),   # 800 — unallocated
+        ("100000000", True),   # 100 — unallocated
+        ("000000000", True),   # all-zeros — prefix "000" is unallocated
+        ("", False),           # empty
+        ("12345678", False),   # only 8 digits
+        ("ABCDEFGHI", False),  # non-numeric
+    ],
+)
+def test_is_stateless(mmsi, expected):
+    assert _is_stateless(mmsi) == expected
+
+
+# ---------------------------------------------------------------------------
+# URL builders
+# ---------------------------------------------------------------------------
+
+
+def test_mt_url_contains_mmsi():
+    assert "123456789" in _mt_url("123456789")
+
+
+def test_vf_url_contains_mmsi():
+    assert "123456789" in _vf_url("123456789")
+
+
+def test_ofac_url_encodes_spaces():
+    url = _ofac_url("SHADOW TANKER")
+    assert "SHADOW+TANKER" in url
+
+
+def test_ofac_url_unknown_vessel():
+    url = _ofac_url("Unknown")
+    assert "unknown" in url.lower()
+
+
+# ---------------------------------------------------------------------------
+# generate_report
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_watchlist():
+    return pl.DataFrame(
+        {
+            "mmsi": ["312171000", "400789012", "563456789", "273111222"],
+            "imo": ["9354521", "", "9123456", "9876543"],
+            "vessel_name": ["ANHONA", "GHOST SHIP", "REAL VESSEL", "PETROVSKY"],
+            "vessel_type": ["Tanker", "Unknown", "Cargo", "Tanker"],
+            "flag": ["BZ", "", "SG", "RU"],
+            "confidence": [0.566, 0.700, 0.489, 0.610],
+            "sanctions_distance": [0, 99, 2, 0],
+        }
+    )
+
+
+def test_report_is_string(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    assert isinstance(report, str)
+    assert len(report) > 0
+
+
+def test_report_header(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    assert "[OSINT Check] Watchlist" in report
+
+
+def test_sanctioned_section_count(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    # ANHONA (SD=0) and PETROVSKY (SD=0) — 2 sanctioned vessels
+    assert "sanctions_distance=0 (2 vessels)" in report
+    assert "ANHONA" in report
+    assert "PETROVSKY" in report
+
+
+def test_stateless_section_count(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    # GHOST SHIP has MID 400 (unallocated)
+    assert "ITU unallocated (1 vessels)" in report
+    assert "GHOST SHIP" in report
+    assert "400" in report
+
+
+def test_stateless_marker_in_full_table(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    # Stateless vessels are marked with ⚠ in the full table
+    lines = [l for l in report.splitlines() if "400789012" in l]
+    assert any("⚠" in l for l in lines)
+
+
+def test_allocated_vessels_have_no_marker(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    lines = [l for l in report.splitlines() if "563456789" in l]
+    # ⚠ must not appear on the allocated-MMSI row
+    assert all("⚠" not in l for l in lines)
+
+
+def test_links_present(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    assert "marinetraffic.com" in report
+    assert "vesselfinder.com" in report
+    assert "sanctionssearch.ofac.treas.gov" in report
+
+
+def test_top_n_limits_rows(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=2)
+    # Only the top-2 by confidence should appear in the full table
+    # GHOST SHIP (0.700) and PETROVSKY (0.610) are top-2
+    assert "GHOST SHIP" in report
+    assert "PETROVSKY" in report
+    assert "ANHONA" not in report
+    assert "REAL VESSEL" not in report
+
+
+def test_empty_sanctions_section():
+    df = pl.DataFrame(
+        {
+            "mmsi": ["563456789"],
+            "imo": ["9123456"],
+            "vessel_name": ["CLEAN VESSEL"],
+            "vessel_type": ["Cargo"],
+            "flag": ["SG"],
+            "confidence": [0.4],
+            "sanctions_distance": [5],
+        }
+    )
+    report = generate_report(df, top_n=50)
+    assert "sanctions_distance=0 (0 vessels)" in report
+    assert "No directly sanctioned vessels" in report
+
+
+def test_empty_stateless_section():
+    df = pl.DataFrame(
+        {
+            "mmsi": ["563456789"],
+            "imo": ["9123456"],
+            "vessel_name": ["CLEAN VESSEL"],
+            "vessel_type": ["Cargo"],
+            "flag": ["SG"],
+            "confidence": [0.4],
+            "sanctions_distance": [5],
+        }
+    )
+    report = generate_report(df, top_n=50)
+    assert "ITU unallocated (0 vessels)" in report
+    assert "No stateless MMSIs" in report


### PR DESCRIPTION
## Summary

- Adds `scripts/generate_osint_report.py` — pure Python, no LLM dependency, replaces the removed `osint_watchlist_check.py`
- Adds `.github/workflows/osint-report.yml` — weekly Monday 07:00 UTC cron that pulls the latest watchlist from R2, runs the script, and opens a GitHub Issue

## What the script does

- Reads `candidate_watchlist.parquet` (local or from `MARIDB_DATA_DIR`)
- Selects top-N vessels by confidence (default 50)
- Flags `sanctions_distance == 0` vessels with MarineTraffic / VesselFinder / OFAC links
- Detects ITU-unallocated MMSIs using the full ITU MID allocation table (stateless vessels marked ⚠ in the full table)
- Outputs structured Markdown in the format specified in `docs/osint-workflow-design.md`

## Test plan

- [x] `uv run python -c "import scripts.generate_osint_report"` — import clean
- [x] Stateless MMSI assertions: MID 400 (unallocated) flagged, MID 412/563/351 (allocated) not flagged
- [x] `sanctions_distance=0` section correctly populated (fixed `0 or 99` bug)
- [x] Full watchlist table renders with ⚠ markers and clickable links
- [x] 516 existing tests pass, 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)