### PR TITLE
fix: vessel name fallback, flag from MID, HTML email formatting

### DIFF
--- a/scripts/generate_osint_report.py
+++ b/scripts/generate_osint_report.py
@@ -10,8 +10,9 @@ What this script does
 - Selects top-N vessels by confidence score
 - Flags vessels where sanctions_distance == 0 (directly sanctioned)
 - Detects ITU-unallocated MMSIs (stateless vessels)
+- Derives flag from MMSI MID prefix when registry data is absent
 - Generates MarineTraffic / VesselFinder / OFAC search URLs per vessel
-- Writes a structured Markdown report and optionally emails it
+- Writes a structured Markdown report and sends an HTML email
 
 Usage
 -----
@@ -21,14 +22,14 @@ Usage
 
 Environment variables
 ---------------------
-MARIDB_DATA_DIR  Directory containing candidate_watchlist.parquet
-                 (default: ~/.maridb/data or data/processed if that exists)
-NOTIFY_EMAIL     Recipient address (required for --email)
-SMTP_HOST        SMTP server hostname  (default: smtp.gmail.com)
-SMTP_PORT        SMTP server port      (default: 587)
-SMTP_USER        Sender address / login
-SMTP_PASSWORD    SMTP password / app-password
-GITHUB_RUN_ID    Injected automatically by GitHub Actions
+MARIDB_DATA_DIR   Directory containing candidate_watchlist.parquet
+                  (default: ~/.maridb/data or data/processed if that exists)
+NOTIFY_EMAIL      Recipient address (required for --email)
+SMTP_HOST         SMTP server hostname  (default: smtp.gmail.com)
+SMTP_PORT         SMTP server port      (default: 587)
+SMTP_USER         Sender address / login
+SMTP_PASSWORD     SMTP password / app-password
+GITHUB_RUN_ID     Injected automatically by GitHub Actions
 GITHUB_REPOSITORY Injected automatically by GitHub Actions
 """
 
@@ -101,12 +102,88 @@ _ALLOCATED_MIDS: frozenset[str] = frozenset(
     }
 )
 
+# MID prefix → ISO 3166-1 alpha-2 flag code. Used to fill in flag when
+# vessel_meta has no registry entry (vessel_name falls back to MMSI).
+_MID_TO_FLAG: dict[str, str] = {
+    "201": "AL", "202": "AD", "203": "AT", "204": "PT", "205": "BE",
+    "206": "BY", "207": "BG", "208": "PT", "209": "CY", "210": "CY", "211": "DE",
+    "212": "CY", "213": "GE", "214": "MD", "215": "MT", "216": "NL",
+    "218": "DE", "219": "DK", "220": "DK", "224": "ES", "225": "ES",
+    "226": "FR", "227": "FR", "228": "FR", "229": "MT", "230": "FI",
+    "231": "FO", "232": "GB", "233": "GB", "234": "GB", "235": "GB",
+    "236": "GI", "237": "GR", "238": "HR", "239": "GR", "240": "GR",
+    "241": "GR", "242": "MA", "243": "HU", "244": "NL", "245": "NL",
+    "246": "NL", "247": "IT", "248": "MT", "249": "MT", "250": "IE",
+    "251": "IS", "252": "LI", "253": "LU", "254": "MC", "255": "PT",
+    "256": "MT", "257": "NO", "258": "NO", "259": "NO", "261": "PL",
+    "262": "ME", "263": "PT", "264": "RO", "265": "SE", "266": "SE",
+    "267": "SK", "268": "SM", "269": "CH", "270": "CZ", "271": "TR",
+    "272": "UA", "273": "RU", "274": "MK", "275": "LV", "276": "EE",
+    "277": "LT", "278": "SI", "279": "RS", "281": "BA",
+    "301": "AI", "303": "US", "304": "AG", "305": "AG", "306": "AN",
+    "307": "AW", "308": "BS", "309": "BS", "310": "BM", "311": "BS",
+    "312": "BZ", "316": "CA", "319": "KY", "321": "CU", "323": "DO",
+    "325": "SV", "327": "GT", "329": "GP", "330": "GD", "331": "GL",
+    "332": "HN", "333": "JM", "334": "MQ", "336": "MX", "338": "US",
+    "339": "MX", "341": "NI", "343": "PA", "345": "PR", "347": "KN",
+    "348": "VI", "350": "PA", "351": "PA", "352": "PA", "353": "PA",
+    "354": "PA", "355": "PA", "356": "PA", "357": "PA", "358": "PR",
+    "359": "SH", "361": "PM", "362": "TT", "364": "TC", "366": "US",
+    "367": "US", "368": "US", "369": "US", "370": "PA", "371": "PA",
+    "372": "PA", "373": "PA", "374": "PA", "375": "VC", "376": "VC",
+    "377": "VC", "378": "VG", "379": "VI",
+    "401": "AF", "403": "SA", "405": "BD", "408": "BH", "410": "BT",
+    "412": "CN", "413": "CN", "414": "CN", "416": "TW", "417": "LK",
+    "419": "IN", "422": "IR", "423": "AZ", "425": "IQ", "428": "IL",
+    "431": "JP", "432": "JP", "433": "JP", "434": "TM", "436": "KZ",
+    "437": "UZ", "438": "JO", "440": "KR", "441": "KR", "443": "PS",
+    "445": "KP", "447": "KW", "450": "LB", "451": "KG", "453": "MO",
+    "455": "MV", "457": "MN", "459": "NP", "461": "OM", "463": "PK",
+    "466": "QA", "468": "SY", "470": "AE", "471": "AE", "472": "TJ",
+    "473": "YE", "477": "HK",
+    "501": "AQ", "503": "AU", "506": "MM", "508": "BN", "510": "FM",
+    "511": "PW", "512": "NZ", "514": "KH", "515": "KH", "516": "CX",
+    "518": "CK", "520": "FJ", "523": "CC", "525": "ID", "529": "KI",
+    "531": "LA", "533": "MY", "536": "MP", "538": "MH", "540": "NC",
+    "542": "NU", "544": "NR", "546": "PF", "548": "PH", "553": "PG",
+    "555": "PN", "557": "SB", "559": "WS", "561": "WS", "563": "SG",
+    "564": "SG", "565": "SG", "566": "SG", "567": "SG", "570": "TH",
+    "572": "TO", "574": "VN", "576": "VN", "577": "VU", "578": "WF",
+    "601": "ZA", "603": "AO", "605": "DZ", "607": "TF", "608": "AC",
+    "609": "BI", "611": "BJ", "613": "CM", "616": "CD", "618": "CG",
+    "619": "KM", "621": "DJ", "622": "EG", "624": "ET", "625": "ER",
+    "626": "GA", "627": "GH", "629": "GM", "630": "GW", "631": "GQ",
+    "632": "GN", "633": "BF", "634": "KE", "635": "TF", "636": "LR",
+    "637": "LR", "638": "SS", "642": "LY", "644": "LS", "645": "MU",
+    "647": "MG", "649": "ML", "650": "MZ", "654": "MR", "655": "MW",
+    "656": "NE", "657": "NG", "659": "NA", "660": "RE", "661": "RW",
+    "662": "SD", "663": "SN", "664": "SC", "665": "SH", "666": "SO",
+    "667": "SL", "668": "ST", "669": "SZ", "670": "TD", "671": "TG",
+    "672": "TN", "674": "TZ", "675": "UG", "676": "CD", "677": "TZ",
+    "678": "ZM", "679": "ZW",
+    "701": "AR", "710": "BR", "720": "BO", "725": "CL", "730": "CO",
+    "735": "EC", "740": "FK", "745": "GF", "750": "GY", "755": "PY",
+    "760": "PE", "765": "SR", "770": "UY", "775": "VE",
+}
+
 
 def _is_stateless(mmsi: str) -> bool:
     """Return True if the MMSI's MID prefix is not in the ITU allocation table."""
     if not mmsi or len(mmsi) != 9 or not mmsi.isdigit():
         return False
     return mmsi[:3] not in _ALLOCATED_MIDS
+
+
+def _flag_from_mid(mmsi: str) -> str:
+    """Derive ISO flag code from the MMSI MID prefix, or '' if unknown."""
+    if not mmsi or len(mmsi) < 3:
+        return ""
+    return _MID_TO_FLAG.get(mmsi[:3], "")
+
+
+def _has_real_name(vessel_name: str, mmsi: str) -> bool:
+    """Return False when vessel_name is just the MMSI fallback (no registry entry)."""
+    return bool(vessel_name) and vessel_name != mmsi and not vessel_name.isdigit()
 
 
 def _mt_url(mmsi: str) -> str:
@@ -118,7 +195,7 @@ def _vf_url(mmsi: str) -> str:
 
 
 def _ofac_url(name: str) -> str:
-    q = name.replace(" ", "+") if name and name != "Unknown" else "unknown"
+    q = name.replace(" ", "+")
     return f"https://sanctionssearch.ofac.treas.gov/?q={q}"
 
 
@@ -136,24 +213,46 @@ def _resolve_watchlist_path(cli_path: str | None) -> Path:
     return Path.home() / ".maridb" / "data" / "candidate_watchlist.parquet"
 
 
-def generate_report(df: pl.DataFrame, top_n: int) -> str:
-    """Return a Markdown OSINT report string for the top-N watchlist candidates."""
-    today = date.today().isoformat()
+def _enrich_rows(df: pl.DataFrame, top_n: int) -> list[dict]:
+    """Sort, slice, and add computed display fields to each row dict."""
     top = df.sort("confidence", descending=True).head(top_n)
-
     rows = top.to_dicts()
     for i, row in enumerate(rows):
-        row["_rank"] = i + 1
         mmsi = str(row.get("mmsi", "") or "")
-        name = str(row.get("vessel_name", "") or "Unknown")
+        raw_name = str(row.get("vessel_name", "") or "")
+        raw_flag = str(row.get("flag", "") or "")
+
+        real_name = _has_real_name(raw_name, mmsi)
+        # Fall back to MID-derived flag when registry has no entry
+        flag = raw_flag if raw_flag else _flag_from_mid(mmsi)
+
+        row["_rank"] = i + 1
+        row["_mmsi"] = mmsi
+        row["_name"] = raw_name if real_name else "—"
+        row["_flag"] = flag or "—"
+        row["_real_name"] = real_name
         row["_stateless"] = _is_stateless(mmsi)
         row["_mid"] = mmsi[:3] if mmsi else "—"
-        row["_mt"] = f"[MT]({_mt_url(mmsi)})" if mmsi else "—"
-        row["_vf"] = f"[VF]({_vf_url(mmsi)})" if mmsi else "—"
-        row["_ofac"] = f"[OFAC]({_ofac_url(name)})"
+        row["_mt_url"] = _mt_url(mmsi) if mmsi else ""
+        row["_vf_url"] = _vf_url(mmsi) if mmsi else ""
+        # OFAC link only when we have a real vessel name to search
+        row["_ofac_url"] = _ofac_url(raw_name) if real_name else ""
+    return rows
+
+
+def generate_report(df: pl.DataFrame, top_n: int) -> str:
+    """Return a Markdown OSINT report for the top-N watchlist candidates."""
+    today = date.today().isoformat()
+    rows = _enrich_rows(df, top_n)
 
     sanctioned = [r for r in rows if r.get("sanctions_distance") == 0]
     stateless = [r for r in rows if r["_stateless"]]
+
+    def _md_links(r: dict) -> str:
+        parts = [f"[MT]({r['_mt_url']})", f"[VF]({r['_vf_url']})"]
+        if r["_ofac_url"]:
+            parts.append(f"[OFAC]({r['_ofac_url']})")
+        return " ".join(parts)
 
     lines: list[str] = [
         f"## sanctions_distance=0 ({len(sanctioned)} vessels)",
@@ -162,12 +261,10 @@ def generate_report(df: pl.DataFrame, top_n: int) -> str:
         "|------|------|-----|------|------|------|-------|",
     ]
     for r in sanctioned:
-        conf = f"{r.get('confidence', 0):.3f}"
         lines.append(
-            f"| {r['_rank']} | {r.get('mmsi', '—')} | {r.get('imo', '—') or '—'} "
-            f"| {r.get('vessel_name', 'Unknown') or 'Unknown'} "
-            f"| {r.get('flag', '—') or '—'} | {conf} "
-            f"| {r['_mt']} {r['_vf']} {r['_ofac']} |"
+            f"| {r['_rank']} | {r['_mmsi']} | {r.get('imo') or '—'} "
+            f"| {r['_name']} | {r['_flag']} | {r.get('confidence', 0):.3f} "
+            f"| {_md_links(r)} |"
         )
     if not sanctioned:
         lines.append("_No directly sanctioned vessels in top-N._")
@@ -180,11 +277,9 @@ def generate_report(df: pl.DataFrame, top_n: int) -> str:
         "|------|------|------|------|-----|------|",
     ]
     for r in stateless:
-        conf = f"{r.get('confidence', 0):.3f}"
         lines.append(
-            f"| {r['_rank']} | {r.get('mmsi', '—')} "
-            f"| {r.get('vessel_name', 'Unknown') or 'Unknown'} "
-            f"| {conf} | {r['_mid']} | ⚠ ITU unallocated |"
+            f"| {r['_rank']} | {r['_mmsi']} | {r['_name']} "
+            f"| {r.get('confidence', 0):.3f} | {r['_mid']} | ⚠ ITU unallocated |"
         )
     if not stateless:
         lines.append("_No stateless MMSIs detected in top-N._")
@@ -197,16 +292,14 @@ def generate_report(df: pl.DataFrame, top_n: int) -> str:
         "|------|------|-----|------|------|------|-----|-------|",
     ]
     for r in rows:
-        conf = f"{r.get('confidence', 0):.3f}"
-        sd = r.get("sanctions_distance", "—")
+        sd = r.get("sanctions_distance")
         sd_str = str(int(sd)) if sd is not None and str(sd) != "nan" else "—"
-        stateless_marker = " ⚠" if r["_stateless"] else ""
+        marker = " ⚠" if r["_stateless"] else ""
+        links = f"[MT]({r['_mt_url']}) [VF]({r['_vf_url']})"
         lines.append(
-            f"| {r['_rank']} | {r.get('mmsi', '—')}{stateless_marker} "
-            f"| {r.get('imo', '—') or '—'} "
-            f"| {r.get('vessel_name', 'Unknown') or 'Unknown'} "
-            f"| {r.get('flag', '—') or '—'} | {conf} | {sd_str} "
-            f"| {r['_mt']} {r['_vf']} |"
+            f"| {r['_rank']} | {r['_mmsi']}{marker} | {r.get('imo') or '—'} "
+            f"| {r['_name']} | {r['_flag']} | {r.get('confidence', 0):.3f} "
+            f"| {sd_str} | {links} |"
         )
 
     header = [
@@ -214,14 +307,160 @@ def generate_report(df: pl.DataFrame, top_n: int) -> str:
         "",
         f"Top-{top_n} candidates from `candidate_watchlist.parquet`.",
         "Analysts: click links to verify on MarineTraffic / VesselFinder / OFAC.",
-        f"Stateless MMSIs (⚠) have unallocated ITU MID prefixes — likely spoofed identity.",
+        "Stateless MMSIs (⚠) have unallocated ITU MID prefixes — likely spoofed identity.",
         "",
     ]
     return "\n".join(header + lines) + "\n"
 
 
-def _send_email(subject: str, markdown_body: str) -> bool:
-    """Send the report as a plain-text email. Returns True on success."""
+# ---------------------------------------------------------------------------
+# HTML email rendering
+# ---------------------------------------------------------------------------
+
+_CSS = """
+body { font-family: -apple-system, Arial, sans-serif; font-size: 14px; color: #1a1a1a; margin: 0; padding: 20px; background: #f5f5f5; }
+.card { background: #fff; border-radius: 6px; padding: 20px 24px; margin-bottom: 20px; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+h1 { font-size: 18px; margin: 0 0 4px; }
+h2 { font-size: 15px; margin: 0 0 12px; border-bottom: 1px solid #e5e5e5; padding-bottom: 6px; }
+.meta { color: #666; font-size: 12px; margin-bottom: 20px; }
+table { border-collapse: collapse; width: 100%; font-size: 13px; }
+th { background: #f0f0f0; text-align: left; padding: 7px 10px; white-space: nowrap; }
+td { padding: 6px 10px; border-bottom: 1px solid #eee; vertical-align: middle; }
+tr:hover td { background: #fafafa; }
+a { color: #0066cc; text-decoration: none; }
+a:hover { text-decoration: underline; }
+.badge-sanctioned { background: #fde8e8; color: #b91c1c; border-radius: 3px; padding: 1px 5px; font-size: 11px; font-weight: 600; }
+.badge-stateless { background: #fff3cd; color: #92400e; border-radius: 3px; padding: 1px 5px; font-size: 11px; font-weight: 600; }
+.conf { font-weight: 600; }
+.none { color: #aaa; }
+.ci-link { color: #666; font-size: 12px; }
+"""
+
+
+def _e(s: str) -> str:
+    """Minimal HTML escaping."""
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _link(url: str, label: str) -> str:
+    return f'<a href="{_e(url)}">{_e(label)}</a>'
+
+
+def _html_links(r: dict) -> str:
+    parts = [_link(r["_mt_url"], "MT"), _link(r["_vf_url"], "VF")]
+    if r["_ofac_url"]:
+        parts.append(_link(r["_ofac_url"], "OFAC"))
+    return " · ".join(parts)
+
+
+def generate_html_email(df: pl.DataFrame, top_n: int, run_url: str) -> str:
+    """Return a fully styled HTML email body."""
+    today = date.today().isoformat()
+    rows = _enrich_rows(df, top_n)
+    sanctioned = [r for r in rows if r.get("sanctions_distance") == 0]
+    stateless = [r for r in rows if r["_stateless"]]
+
+    def _td(val: str, cls: str = "") -> str:
+        attr = f' class="{cls}"' if cls else ""
+        return f"<td{attr}>{val}</td>"
+
+    def _sanctioned_rows() -> str:
+        if not sanctioned:
+            return '<tr><td colspan="7" class="none">No directly sanctioned vessels in top-N.</td></tr>'
+        out = []
+        for r in sanctioned:
+            conf = f"{r.get('confidence', 0):.3f}"
+            out.append(
+                "<tr>"
+                + _td(str(r["_rank"]))
+                + _td(_e(r["_mmsi"]))
+                + _td(_e(r.get("imo") or "—"))
+                + _td(_e(r["_name"]))
+                + _td(_e(r["_flag"]))
+                + _td(conf, "conf")
+                + _td(_html_links(r))
+                + "</tr>"
+            )
+        return "".join(out)
+
+    def _stateless_rows() -> str:
+        if not stateless:
+            return '<tr><td colspan="5" class="none">No stateless MMSIs detected in top-N.</td></tr>'
+        out = []
+        for r in stateless:
+            conf = f"{r.get('confidence', 0):.3f}"
+            badge = f'<span class="badge-stateless">⚠ {_e(r["_mid"])}</span>'
+            out.append(
+                "<tr>"
+                + _td(str(r["_rank"]))
+                + _td(_e(r["_mmsi"]))
+                + _td(_e(r["_name"]))
+                + _td(conf, "conf")
+                + _td(badge)
+                + "</tr>"
+            )
+        return "".join(out)
+
+    def _full_table_rows() -> str:
+        out = []
+        for r in rows:
+            sd = r.get("sanctions_distance")
+            sd_str = str(int(sd)) if sd is not None and str(sd) != "nan" else "—"
+            conf = f"{r.get('confidence', 0):.3f}"
+            mmsi_cell = _e(r["_mmsi"])
+            if r["_stateless"]:
+                mmsi_cell += ' <span class="badge-stateless">⚠</span>'
+            if r.get("sanctions_distance") == 0:
+                mmsi_cell += ' <span class="badge-sanctioned">SDN</span>'
+            nav_links = _link(r["_mt_url"], "MT") + " · " + _link(r["_vf_url"], "VF")
+            out.append(
+                "<tr>"
+                + _td(str(r["_rank"]))
+                + f"<td>{mmsi_cell}</td>"
+                + _td(_e(r.get("imo") or "—"))
+                + _td(_e(r["_name"]))
+                + _td(_e(r["_flag"]))
+                + _td(conf, "conf")
+                + _td(sd_str)
+                + _td(nav_links)
+                + "</tr>"
+            )
+        return "".join(out)
+
+    return f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>{_CSS}</style></head>
+<body>
+<div class="card">
+  <h1>[OSINT Check] Watchlist — {_e(today)}</h1>
+  <p class="meta">Top-{top_n} candidates · {_e(today)} · <a class="ci-link" href="{_e(run_url)}">View CI run →</a></p>
+
+  <h2>sanctions_distance=0 — {len(sanctioned)} vessel{"s" if len(sanctioned) != 1 else ""}</h2>
+  <table>
+    <tr><th>#</th><th>MMSI</th><th>IMO</th><th>Name</th><th>Flag</th><th>Conf</th><th>Links</th></tr>
+    {_sanctioned_rows()}
+  </table>
+</div>
+
+<div class="card">
+  <h2>Stateless MMSIs — ITU unallocated — {len(stateless)} vessel{"s" if len(stateless) != 1 else ""}</h2>
+  <table>
+    <tr><th>#</th><th>MMSI</th><th>Name</th><th>Conf</th><th>MID</th></tr>
+    {_stateless_rows()}
+  </table>
+</div>
+
+<div class="card">
+  <h2>Full top-{top_n} watchlist</h2>
+  <table>
+    <tr><th>#</th><th>MMSI</th><th>IMO</th><th>Name</th><th>Flag</th><th>Conf</th><th>SD</th><th>Links</th></tr>
+    {_full_table_rows()}
+  </table>
+</div>
+</body></html>"""
+
+
+def _send_email(subject: str, markdown_body: str, html_body: str) -> bool:
+    """Send the report as multipart plain-text + HTML email. Returns True on success."""
     recipient = os.getenv("NOTIFY_EMAIL")
     if not recipient:
         print("NOTIFY_EMAIL not set — skipping email.", file=sys.stderr)
@@ -235,22 +474,6 @@ def _send_email(subject: str, markdown_body: str) -> bool:
     if not smtp_user or not smtp_password:
         print("SMTP_USER / SMTP_PASSWORD not set — skipping email.", file=sys.stderr)
         return False
-
-    run_id = os.getenv("GITHUB_RUN_ID", "")
-    repo = os.getenv("GITHUB_REPOSITORY", "edgesentry/indago")
-    run_url = (
-        f"https://github.com/{repo}/actions/runs/{run_id}"
-        if run_id
-        else f"https://github.com/{repo}/actions"
-    )
-
-    html_body = (
-        "<html><body><pre style='font-family:monospace;font-size:13px'>"
-        + markdown_body.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-        + "</pre>"
-        + f"<p><a href='{run_url}'>View CI run →</a></p>"
-        + "</body></html>"
-    )
 
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
@@ -306,7 +529,16 @@ def main() -> int:
 
     if args.email:
         today = date.today().isoformat()
-        _send_email(f"[OSINT Check] Watchlist — {today}", report)
+        subject = f"[OSINT Check] Watchlist — {today}"
+        run_id = os.getenv("GITHUB_RUN_ID", "")
+        repo = os.getenv("GITHUB_REPOSITORY", "edgesentry/indago")
+        run_url = (
+            f"https://github.com/{repo}/actions/runs/{run_id}"
+            if run_id
+            else f"https://github.com/{repo}/actions"
+        )
+        html_body = generate_html_email(df, top_n=args.top, run_url=run_url)
+        _send_email(subject, report, html_body)
 
     return 0
 

--- a/tests/test_generate_osint_report.py
+++ b/tests/test_generate_osint_report.py
@@ -3,10 +3,14 @@ import pytest
 
 from scripts.generate_osint_report import (
     _ALLOCATED_MIDS,
+    _MID_TO_FLAG,
+    _flag_from_mid,
+    _has_real_name,
     _is_stateless,
     _mt_url,
     _ofac_url,
     _vf_url,
+    generate_html_email,
     generate_report,
 )
 
@@ -18,6 +22,12 @@ from scripts.generate_osint_report import (
 
 def test_allocated_mids_not_empty():
     assert len(_ALLOCATED_MIDS) > 100
+
+
+def test_mid_to_flag_coverage():
+    # Every MID in _ALLOCATED_MIDS must have a _MID_TO_FLAG entry
+    missing = _ALLOCATED_MIDS - set(_MID_TO_FLAG.keys())
+    assert not missing, f"MIDs in _ALLOCATED_MIDS but missing from _MID_TO_FLAG: {missing}"
 
 
 @pytest.mark.parametrize(
@@ -41,6 +51,41 @@ def test_is_stateless(mmsi, expected):
     assert _is_stateless(mmsi) == expected
 
 
+@pytest.mark.parametrize(
+    "mmsi,expected_flag",
+    [
+        ("273449240", "RU"),   # Russia
+        ("244374235", "NL"),   # Netherlands
+        ("563069100", "SG"),   # Singapore
+        ("457133000", "MN"),   # Mongolia
+        ("400789012", ""),     # unallocated — no flag
+        ("", ""),
+    ],
+)
+def test_flag_from_mid(mmsi, expected_flag):
+    assert _flag_from_mid(mmsi) == expected_flag
+
+
+# ---------------------------------------------------------------------------
+# Vessel-name fallback detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "vessel_name,mmsi,expected",
+    [
+        ("ANHONA", "312171000", True),         # real name
+        ("312171000", "312171000", False),     # MMSI used as name fallback
+        ("273449240", "273449240", False),     # MMSI used as name fallback
+        ("", "563000001", False),              # empty name
+        ("123456789", "999999999", False),     # any digit-only string
+        ("PIONEER 92", "457133000", True),     # real name with space
+    ],
+)
+def test_has_real_name(vessel_name, mmsi, expected):
+    assert _has_real_name(vessel_name, mmsi) == expected
+
+
 # ---------------------------------------------------------------------------
 # URL builders
 # ---------------------------------------------------------------------------
@@ -55,17 +100,11 @@ def test_vf_url_contains_mmsi():
 
 
 def test_ofac_url_encodes_spaces():
-    url = _ofac_url("SHADOW TANKER")
-    assert "SHADOW+TANKER" in url
-
-
-def test_ofac_url_unknown_vessel():
-    url = _ofac_url("Unknown")
-    assert "unknown" in url.lower()
+    assert "SHADOW+TANKER" in _ofac_url("SHADOW TANKER")
 
 
 # ---------------------------------------------------------------------------
-# generate_report
+# generate_report — Markdown
 # ---------------------------------------------------------------------------
 
 
@@ -73,104 +112,178 @@ def test_ofac_url_unknown_vessel():
 def sample_watchlist():
     return pl.DataFrame(
         {
-            "mmsi": ["312171000", "400789012", "563456789", "273111222"],
-            "imo": ["9354521", "", "9123456", "9876543"],
-            "vessel_name": ["ANHONA", "GHOST SHIP", "REAL VESSEL", "PETROVSKY"],
-            "vessel_type": ["Tanker", "Unknown", "Cargo", "Tanker"],
-            "flag": ["BZ", "", "SG", "RU"],
-            "confidence": [0.566, 0.700, 0.489, 0.610],
-            "sanctions_distance": [0, 99, 2, 0],
+            "mmsi":          ["312171000", "400789012", "563456789", "273449240"],
+            "imo":           ["9354521",   "",          "9123456",   ""],
+            "vessel_name":   ["ANHONA",    "400789012", "REAL VESSEL", "273449240"],
+            "vessel_type":   ["Tanker",    "Unknown",   "Cargo",      "Tanker"],
+            "flag":          ["BZ",        "",          "SG",         "RU"],
+            "confidence":    [0.566,       0.700,       0.489,        0.674],
+            "sanctions_distance": [0,      99,          2,            0],
         }
     )
 
 
 def test_report_is_string(sample_watchlist):
-    report = generate_report(sample_watchlist, top_n=50)
-    assert isinstance(report, str)
-    assert len(report) > 0
+    assert isinstance(generate_report(sample_watchlist, top_n=50), str)
 
 
 def test_report_header(sample_watchlist):
-    report = generate_report(sample_watchlist, top_n=50)
-    assert "[OSINT Check] Watchlist" in report
+    assert "[OSINT Check] Watchlist" in generate_report(sample_watchlist, top_n=50)
 
 
 def test_sanctioned_section_count(sample_watchlist):
     report = generate_report(sample_watchlist, top_n=50)
-    # ANHONA (SD=0) and PETROVSKY (SD=0) — 2 sanctioned vessels
     assert "sanctions_distance=0 (2 vessels)" in report
     assert "ANHONA" in report
-    assert "PETROVSKY" in report
+    # 273449240 has no real name → shown as "—" not as the MMSI
+    assert "| — |" in report or "| —" in report
 
 
-def test_stateless_section_count(sample_watchlist):
+def test_stateless_section(sample_watchlist):
     report = generate_report(sample_watchlist, top_n=50)
-    # GHOST SHIP has MID 400 (unallocated)
     assert "ITU unallocated (1 vessels)" in report
-    assert "GHOST SHIP" in report
+    assert "400789012" in report
     assert "400" in report
 
 
 def test_stateless_marker_in_full_table(sample_watchlist):
     report = generate_report(sample_watchlist, top_n=50)
-    # Stateless vessels are marked with ⚠ in the full table
     lines = [l for l in report.splitlines() if "400789012" in l]
     assert any("⚠" in l for l in lines)
 
 
-def test_allocated_vessels_have_no_marker(sample_watchlist):
+def test_allocated_vessel_has_no_marker(sample_watchlist):
     report = generate_report(sample_watchlist, top_n=50)
     lines = [l for l in report.splitlines() if "563456789" in l]
-    # ⚠ must not appear on the allocated-MMSI row
     assert all("⚠" not in l for l in lines)
+
+
+def test_mmsi_fallback_name_shown_as_dash(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    # 273449240 has vessel_name == mmsi — should display "—", not the MMSI as a name
+    lines = [l for l in report.splitlines() if "273449240" in l]
+    assert lines, "Row for 273449240 missing from report"
+    # The name column should be "—", not "273449240"
+    for line in lines:
+        cols = [c.strip() for c in line.split("|")]
+        name_cols = [c for c in cols if c == "—"]
+        assert name_cols, f"Expected '—' name in: {line}"
+
+
+def test_flag_derived_from_mid_when_blank():
+    df = pl.DataFrame(
+        {
+            "mmsi": ["457133000"],
+            "imo": [""],
+            "vessel_name": ["PIONEER 92"],
+            "vessel_type": ["Cargo"],
+            "flag": [""],          # blank in registry
+            "confidence": [0.5],
+            "sanctions_distance": [0],
+        }
+    )
+    report = generate_report(df, top_n=50)
+    # Flag should be derived as MN (Mongolia MID 457)
+    assert "MN" in report
+
+
+def test_ofac_link_absent_when_no_real_name(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    # 273449240 has no real name — its sanctioned-section row must not have an OFAC link
+    lines = [l for l in report.splitlines() if "273449240" in l and "sanctions_distance" not in l]
+    for line in lines:
+        if "| 1 |" in line or "| 4 |" in line:  # the sanctioned rows
+            assert "OFAC" not in line
+
+
+def test_ofac_link_present_for_named_vessel(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=50)
+    lines = [l for l in report.splitlines() if "ANHONA" in l]
+    assert any("OFAC" in l for l in lines)
+
+
+def test_top_n_limits_rows(sample_watchlist):
+    report = generate_report(sample_watchlist, top_n=2)
+    assert "400789012" in report   # rank 1
+    assert "273449240" in report   # rank 2
+    assert "ANHONA" not in report  # rank 3 — excluded
+    assert "REAL VESSEL" not in report
 
 
 def test_links_present(sample_watchlist):
     report = generate_report(sample_watchlist, top_n=50)
     assert "marinetraffic.com" in report
     assert "vesselfinder.com" in report
-    assert "sanctionssearch.ofac.treas.gov" in report
-
-
-def test_top_n_limits_rows(sample_watchlist):
-    report = generate_report(sample_watchlist, top_n=2)
-    # Only the top-2 by confidence should appear in the full table
-    # GHOST SHIP (0.700) and PETROVSKY (0.610) are top-2
-    assert "GHOST SHIP" in report
-    assert "PETROVSKY" in report
-    assert "ANHONA" not in report
-    assert "REAL VESSEL" not in report
 
 
 def test_empty_sanctions_section():
-    df = pl.DataFrame(
-        {
-            "mmsi": ["563456789"],
-            "imo": ["9123456"],
-            "vessel_name": ["CLEAN VESSEL"],
-            "vessel_type": ["Cargo"],
-            "flag": ["SG"],
-            "confidence": [0.4],
-            "sanctions_distance": [5],
-        }
-    )
-    report = generate_report(df, top_n=50)
-    assert "sanctions_distance=0 (0 vessels)" in report
-    assert "No directly sanctioned vessels" in report
+    df = pl.DataFrame({
+        "mmsi": ["563456789"], "imo": ["9123456"], "vessel_name": ["CLEAN"],
+        "vessel_type": ["Cargo"], "flag": ["SG"], "confidence": [0.4],
+        "sanctions_distance": [5],
+    })
+    assert "sanctions_distance=0 (0 vessels)" in generate_report(df, top_n=50)
+    assert "No directly sanctioned" in generate_report(df, top_n=50)
 
 
 def test_empty_stateless_section():
-    df = pl.DataFrame(
-        {
-            "mmsi": ["563456789"],
-            "imo": ["9123456"],
-            "vessel_name": ["CLEAN VESSEL"],
-            "vessel_type": ["Cargo"],
-            "flag": ["SG"],
-            "confidence": [0.4],
-            "sanctions_distance": [5],
-        }
-    )
-    report = generate_report(df, top_n=50)
-    assert "ITU unallocated (0 vessels)" in report
-    assert "No stateless MMSIs" in report
+    df = pl.DataFrame({
+        "mmsi": ["563456789"], "imo": ["9123456"], "vessel_name": ["CLEAN"],
+        "vessel_type": ["Cargo"], "flag": ["SG"], "confidence": [0.4],
+        "sanctions_distance": [5],
+    })
+    assert "ITU unallocated (0 vessels)" in generate_report(df, top_n=50)
+    assert "No stateless MMSIs" in generate_report(df, top_n=50)
+
+
+# ---------------------------------------------------------------------------
+# generate_html_email
+# ---------------------------------------------------------------------------
+
+
+def test_html_email_is_html(sample_watchlist):
+    html = generate_html_email(sample_watchlist, top_n=50, run_url="https://example.com")
+    assert html.strip().startswith("<!DOCTYPE html>")
+    assert "<table>" in html
+    assert "<td>" in html
+
+
+def test_html_email_contains_vessel_data(sample_watchlist):
+    html = generate_html_email(sample_watchlist, top_n=50, run_url="https://example.com")
+    assert "ANHONA" in html
+    assert "312171000" in html
+    assert "marinetraffic.com" in html
+
+
+def test_html_email_sdn_badge(sample_watchlist):
+    html = generate_html_email(sample_watchlist, top_n=50, run_url="https://example.com")
+    assert "SDN" in html
+
+
+def test_html_email_stateless_badge(sample_watchlist):
+    html = generate_html_email(sample_watchlist, top_n=50, run_url="https://example.com")
+    assert "badge-stateless" in html
+
+
+def test_html_email_ci_link(sample_watchlist):
+    html = generate_html_email(sample_watchlist, top_n=50, run_url="https://ci.example.com/run/42")
+    assert "https://ci.example.com/run/42" in html
+
+
+def test_html_email_no_ofac_for_unnamed_vessel(sample_watchlist):
+    html = generate_html_email(sample_watchlist, top_n=50, run_url="https://example.com")
+    # 273449240 has no real name — its OFAC link must not appear
+    import re
+    ofac_links = re.findall(r'href="(https://sanctionssearch\.ofac[^"]*)"', html)
+    for url in ofac_links:
+        assert "273449240" not in url, f"OFAC URL should not search for MMSI: {url}"
+
+
+def test_html_email_flag_derived_from_mid():
+    df = pl.DataFrame({
+        "mmsi": ["457133000"], "imo": [""], "vessel_name": ["PIONEER 92"],
+        "vessel_type": ["Cargo"], "flag": [""],
+        "confidence": [0.5], "sanctions_distance": [0],
+    })
+    html = generate_html_email(df, top_n=50, run_url="https://example.com")
+    assert "MN" in html


### PR DESCRIPTION
## What

Three fixes driven by the actual watchlist output (pasted in issue #86 thread):

### 1. Vessel-name fallback (`composite.py` uses MMSI as name when no registry entry exists)
- Detect `vessel_name == mmsi` (or any digit-only string) via `_has_real_name()`
- Display `—` instead of the MMSI in the name column
- Suppress the OFAC link — searching OFAC for a 9-digit number returns nothing useful

### 2. Flag derived from MMSI MID prefix when registry is blank
- Added comprehensive `_MID_TO_FLAG` table that covers all entries in `_ALLOCATED_MIDS` (enforced by test)
- `_flag_from_mid()` fills in the flag column when `vessel_meta` has no registry entry
- e.g. MMSI `457133000` (MID 457 = Mongolia) now shows `MN` instead of `—`

### 3. Proper HTML email instead of `<pre>`-wrapped markdown
- `generate_html_email()` builds a fully styled HTML email: cards, tables, `SDN`/`⚠` badges, CI run link
- Markdown kept as the `text/plain` fallback part
- `_send_email()` now takes both parts

## Test plan

- [x] 50 tests pass (up from 27), 566 total pass
- [x] `_MID_TO_FLAG` completeness enforced — every MID in `_ALLOCATED_MIDS` must have a flag entry
- [x] `_has_real_name` parametrized: real name, MMSI-as-name, empty, digit-only, name-with-space
- [x] Flag derived from MID when blank (Markdown + HTML)
- [x] OFAC link absent for unnamed vessels, present for named vessels
- [x] HTML email: DOCTYPE, tables, SDN badge, stateless badge, CI link, no OFAC URL for unnamed vessels

🤖 Generated with [Claude Code](https://claude.com/claude-code)