### PR TITLE
fix: include hornofafrica in R2 uploads and validation

### DIFF
--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -183,12 +183,15 @@ _DEMO_FILES = [
 _REGION_PREFIX: dict[str, str] = {
     "singapore": "singapore",
     "japan": "japansea",
+    "japansea": "japansea",
+    "blacksea": "blacksea",
     "middleeast": "middleeast",
     "europe": "europe",
     "persiangulf": "persiangulf",
     "gulfofguinea": "gulfofguinea",
     "gulfofaden": "gulfofaden",
     "gulfofmexico": "gulfofmexico",
+    "hornofafrica": "hornofafrica",
 }
 
 # Files always downloaded regardless of region (shared by the API across all regions)
@@ -1004,7 +1007,7 @@ def cmd_push_ducklake_public(args: argparse.Namespace) -> int:
 
 _DUCKLAKE_AIS_CATALOG = "ducklake/catalog.duckdb"
 _DUCKLAKE_AIS_DATA = "ducklake/data"
-_AIS_DB_MIN_SIZE_BYTES = 1_048_576  # skip placeholder DBs smaller than 1 MB
+_AIS_DB_MIN_SIZE_BYTES = 65_536  # skip placeholder DBs smaller than 64 KB (empty schema ~12 KB)
 _GEBCO_R2_PREFIX = "gebco-masks/"  # maridb-public sub-prefix for GEBCO depth masks
 
 

--- a/scripts/validate_ais_upload.py
+++ b/scripts/validate_ais_upload.py
@@ -31,9 +31,9 @@ _ALL_REGIONS = [
     "gulfofmexico", "hornofafrica", "persiangulf", "gulfofaden", "gulfofguinea",
 ]
 _ACTIVE_REGIONS = [
-    "japansea", "singapore", "europe", "blacksea", "middleeast", "gulfofguinea",
+    "japansea", "singapore", "europe", "blacksea", "middleeast", "gulfofguinea", "hornofafrica",
 ]
-_MIN_ACTIVE_REGIONS = 5
+_MIN_ACTIVE_REGIONS = 6
 
 
 def _build_fs():


### PR DESCRIPTION
## Summary

- `hornofafrica.duckdb` (524 KB) was silently dropped by `_ais_db_candidates` because `_AIS_DB_MIN_SIZE_BYTES` was 1 MB — too high for sparse regions
- Lowered threshold to 64 KB (well above the ~12 KB empty-schema floor); row-count validation in `cmd_push_ais_dbs` already handles truly empty tables
- Added `hornofafrica`, `blacksea`, and `japansea` as explicit keys in `_REGION_PREFIX`
- Promoted `hornofafrica` to `_ACTIVE_REGIONS` in `validate_ais_upload.py` and raised `_MIN_ACTIVE_REGIONS` from 5 → 6 so validation enforces its presence

## Test plan

- [ ] Run `push-ais-parquet` without `--regions` and confirm hornofafrica Parquet is staged and uploaded
- [ ] Run `validate_ais_upload.py` and confirm hornofafrica appears in the active region coverage check
- [ ] Confirm overall validation still passes with 6/7 active regions required

🤖 Generated with [Claude Code](https://claude.com/claude-code)