### PR TITLE
fix(sync_r2): raise AIS DB minimum size threshold to 1 MB

### DIFF
--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -183,12 +183,15 @@ _DEMO_FILES = [
 _REGION_PREFIX: dict[str, str] = {
     "singapore": "singapore",
     "japan": "japansea",
+    "japansea": "japansea",
+    "blacksea": "blacksea",
     "middleeast": "middleeast",
     "europe": "europe",
     "persiangulf": "persiangulf",
     "gulfofguinea": "gulfofguinea",
     "gulfofaden": "gulfofaden",
     "gulfofmexico": "gulfofmexico",
+    "hornofafrica": "hornofafrica",
 }
 
 # Files always downloaded regardless of region (shared by the API across all regions)
@@ -1004,7 +1007,7 @@ def cmd_push_ducklake_public(args: argparse.Namespace) -> int:
 
 _DUCKLAKE_AIS_CATALOG = "ducklake/catalog.duckdb"
 _DUCKLAKE_AIS_DATA = "ducklake/data"
-_AIS_DB_MIN_SIZE_BYTES = 1_048_576  # skip placeholder DBs smaller than 1 MB
+_AIS_DB_MIN_SIZE_BYTES = 65_536  # skip placeholder DBs smaller than 64 KB (empty schema ~12 KB)
 _GEBCO_R2_PREFIX = "gebco-masks/"  # maridb-public sub-prefix for GEBCO depth masks
 
 

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1007,7 +1007,7 @@ def cmd_push_ducklake_public(args: argparse.Namespace) -> int:
 
 _DUCKLAKE_AIS_CATALOG = "ducklake/catalog.duckdb"
 _DUCKLAKE_AIS_DATA = "ducklake/data"
-_AIS_DB_MIN_SIZE_BYTES = 65_536  # skip placeholder DBs smaller than 64 KB (empty schema ~12 KB)
+_AIS_DB_MIN_SIZE_BYTES = 1_048_576  # skip placeholder DBs smaller than 1 MB (empty schema ~274 KB on duckdb ≥1.x)
 _GEBCO_R2_PREFIX = "gebco-masks/"  # maridb-public sub-prefix for GEBCO depth masks
 
 

--- a/scripts/validate_ais_upload.py
+++ b/scripts/validate_ais_upload.py
@@ -31,9 +31,9 @@ _ALL_REGIONS = [
     "gulfofmexico", "hornofafrica", "persiangulf", "gulfofaden", "gulfofguinea",
 ]
 _ACTIVE_REGIONS = [
-    "japansea", "singapore", "europe", "blacksea", "middleeast", "gulfofguinea",
+    "japansea", "singapore", "europe", "blacksea", "middleeast", "gulfofguinea", "hornofafrica",
 ]
-_MIN_ACTIVE_REGIONS = 5
+_MIN_ACTIVE_REGIONS = 6
 
 
 def _build_fs():


### PR DESCRIPTION
## Summary

- `_AIS_DB_MIN_SIZE_BYTES` was 64 KB, but DuckDB ≥1.x creates empty-schema files at ~274 KB
- The `test_skips_small_db` test created a schema-only DB that passed the size filter, reached `_build_r2_fs()`, and crashed on missing `AWS_ACCESS_KEY_ID`
- Raised threshold to 1 MB — safely above any empty placeholder, well below any real AIS DB with data

Fixes failing CI job: https://github.com/edgesentry/indago/actions/runs/25295245602/job/74152894394

## Test plan

- [x] `pytest tests/test_sync_r2_ais_parquet.py` — 14 passed locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)