### PR TITLE
feat(identity): imo_under_construction_flag — detect construction IMO hijacking

### DIFF
--- a/pipelines/features/build_matrix.py
+++ b/pipelines/features/build_matrix.py
@@ -37,6 +37,7 @@ DEFAULTS = {
     "ais_pre_gap_regularity": 1.0,
     "imo_type_mismatch": False,
     "imo_scrapped_flag": False,
+    "imo_under_construction_flag": False,
     "flag_changes_2y": 0,
     "name_changes_2y": 0,
     "owner_changes_2y": 0,

--- a/pipelines/features/identity.py
+++ b/pipelines/features/identity.py
@@ -200,26 +200,35 @@ def _ship_type_category(ship_type: int | None) -> int:
 
 
 def compute_imo_mismatch_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
-    """imo_type_mismatch and imo_scrapped_flag per MMSI.
+    """IMO identity spoofing features per MMSI.
 
     Joins vessel_meta (AIS-reported ship_type + imo) against equasis_vessel_ref
-    (registered vessel_type and scrapped status from Equasis CSV).
+    (registered vessel_type, build_year, and scrapped status from Equasis CSV).
 
     imo_type_mismatch — True when the AIS-reported ship type category (cargo,
     tanker, passenger, fishing …) differs from the category registered for the
-    same IMO number in Equasis.  A 2005-built VLCC (Equasis: tanker) cannot be
-    a 2018-built chemical tanker (AIS: cargo).
+    same IMO number in Equasis.
 
     imo_scrapped_flag — True when the vessel's IMO number is marked as scrapped
     or deleted in the Equasis reference data.
 
-    Returns a DataFrame with (mmsi, imo_type_mismatch, imo_scrapped_flag).
-    If equasis_vessel_ref is empty, both features are False for all vessels.
+    imo_under_construction_flag — True when build_year > current year, meaning
+    the IMO belongs to a vessel not yet launched.  Broadcasting such an IMO is
+    unambiguous identity fraud (construction IMO hijacking).
+
+    Returns a DataFrame with
+    (mmsi, imo_type_mismatch, imo_scrapped_flag, imo_under_construction_flag).
+    If equasis_vessel_ref is empty, all three features are False for all vessels.
     """
+    import datetime
+
+    current_year = datetime.date.today().year
+
     _empty_schema = {
         "mmsi": pl.Utf8,
         "imo_type_mismatch": pl.Boolean,
         "imo_scrapped_flag": pl.Boolean,
+        "imo_under_construction_flag": pl.Boolean,
     }
 
     con = duckdb.connect(db_path, read_only=True)
@@ -236,9 +245,12 @@ def compute_imo_mismatch_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFram
                 [
                     pl.lit(False).alias("imo_type_mismatch"),
                     pl.lit(False).alias("imo_scrapped_flag"),
+                    pl.lit(False).alias("imo_under_construction_flag"),
                 ]
             )
-        ref = con.execute("SELECT imo, vessel_type, scrapped FROM equasis_vessel_ref").pl()
+        ref = con.execute(
+            "SELECT imo, vessel_type, build_year, scrapped FROM equasis_vessel_ref"
+        ).pl()
     finally:
         con.close()
 
@@ -253,11 +265,14 @@ def compute_imo_mismatch_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFram
         eq_cat = _ship_type_category(row.get("vessel_type"))
         mismatch = ais_cat != 0 and eq_cat != 0 and ais_cat != eq_cat
         scrapped = bool(row.get("scrapped") or False)
+        build_year = row.get("build_year")
+        under_construction = bool(build_year is not None and build_year > current_year)
         rows.append(
             {
                 "mmsi": row["mmsi"],
                 "imo_type_mismatch": mismatch,
                 "imo_scrapped_flag": scrapped,
+                "imo_under_construction_flag": under_construction,
             }
         )
 
@@ -272,6 +287,7 @@ def compute_imo_mismatch_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFram
         [
             pl.col("imo_type_mismatch").fill_null(False),
             pl.col("imo_scrapped_flag").fill_null(False),
+            pl.col("imo_under_construction_flag").fill_null(False),
         ]
     )
 
@@ -329,6 +345,7 @@ def compute_identity_features(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
                 pl.col("ownership_depth").fill_null(0).cast(pl.Int32),
                 pl.col("imo_type_mismatch").fill_null(False),
                 pl.col("imo_scrapped_flag").fill_null(False),
+                pl.col("imo_under_construction_flag").fill_null(False),
             ]
         )
         .collect()

--- a/pipelines/ingest/schema.py
+++ b/pipelines/ingest/schema.py
@@ -261,6 +261,10 @@ def init_schema(db_path: str = DEFAULT_DB_PATH) -> None:
         """)
         con.execute("""
             ALTER TABLE vessel_features
+            ADD COLUMN IF NOT EXISTS imo_under_construction_flag BOOLEAN DEFAULT FALSE
+        """)
+        con.execute("""
+            ALTER TABLE vessel_features
             ADD COLUMN IF NOT EXISTS chokepoint_exit_gap_count INTEGER DEFAULT 0
         """)
         con.execute("""

--- a/tests/test_imo_mismatch.py
+++ b/tests/test_imo_mismatch.py
@@ -184,7 +184,7 @@ def test_imo_unknown_category_not_flagged(tmp_db):
 
 
 def test_imo_no_equasis_ref_returns_false_defaults(tmp_db):
-    """When equasis_vessel_ref is empty, both features default to False."""
+    """When equasis_vessel_ref is empty, all three features default to False."""
     _seed_vessel_meta(tmp_db, [{"mmsi": "555555555", "imo": "9000005", "ship_type": 80}])
 
     result = compute_imo_mismatch_features(tmp_db)
@@ -192,6 +192,7 @@ def test_imo_no_equasis_ref_returns_false_defaults(tmp_db):
     assert not row.is_empty()
     assert row["imo_type_mismatch"][0] is False
     assert row["imo_scrapped_flag"][0] is False
+    assert row["imo_under_construction_flag"][0] is False
 
 
 def test_imo_mismatch_empty_db_returns_correct_schema(tmp_db):
@@ -199,3 +200,48 @@ def test_imo_mismatch_empty_db_returns_correct_schema(tmp_db):
     assert "mmsi" in result.columns
     assert "imo_type_mismatch" in result.columns
     assert "imo_scrapped_flag" in result.columns
+    assert "imo_under_construction_flag" in result.columns
+
+
+# ---------------------------------------------------------------------------
+# imo_under_construction_flag
+# ---------------------------------------------------------------------------
+
+
+def test_imo_under_construction_flag_detected(tmp_db):
+    """Vessel's IMO has build_year in the future → construction IMO hijacking."""
+    import datetime
+    future_year = datetime.date.today().year + 1
+    _seed_vessel_meta(tmp_db, [{"mmsi": "666666666", "imo": "9000006", "ship_type": 80}])
+    _seed_equasis_ref(tmp_db, [{"imo": "9000006", "vessel_type": 80, "build_year": future_year}])
+
+    result = compute_imo_mismatch_features(tmp_db)
+    row = result.filter(pl.col("mmsi") == "666666666")
+    assert not row.is_empty()
+    assert row["imo_under_construction_flag"][0] is True
+    assert row["imo_type_mismatch"][0] is False
+    assert row["imo_scrapped_flag"][0] is False
+
+
+def test_imo_under_construction_not_flagged_for_past_build_year(tmp_db):
+    """Vessel with build_year in the past is not flagged."""
+    import datetime
+    past_year = datetime.date.today().year - 1
+    _seed_vessel_meta(tmp_db, [{"mmsi": "777777777", "imo": "9000007", "ship_type": 80}])
+    _seed_equasis_ref(tmp_db, [{"imo": "9000007", "vessel_type": 80, "build_year": past_year}])
+
+    result = compute_imo_mismatch_features(tmp_db)
+    row = result.filter(pl.col("mmsi") == "777777777")
+    assert not row.is_empty()
+    assert row["imo_under_construction_flag"][0] is False
+
+
+def test_imo_under_construction_null_build_year_not_flagged(tmp_db):
+    """NULL build_year does not trigger the flag."""
+    _seed_vessel_meta(tmp_db, [{"mmsi": "888888888", "imo": "9000008", "ship_type": 80}])
+    _seed_equasis_ref(tmp_db, [{"imo": "9000008", "vessel_type": 80, "build_year": None}])
+
+    result = compute_imo_mismatch_features(tmp_db)
+    row = result.filter(pl.col("mmsi") == "888888888")
+    assert not row.is_empty()
+    assert row["imo_under_construction_flag"][0] is False


### PR DESCRIPTION
Closes #95

## Summary

- Adds `imo_under_construction_flag` to `compute_imo_mismatch_features()` in `pipelines/features/identity.py`
- `build_year` was already stored in `equasis_vessel_ref` but unused; a vessel broadcasting an IMO whose `build_year > current year` cannot physically exist yet — unambiguous identity fraud
- Wired through `compute_identity_features()` with `fill_null(False)`
- 3 new tests: future `build_year` → `True`, past → `False`, NULL → `False`

## Test plan

- [x] `pytest tests/test_imo_mismatch.py` — 17 passed
- [x] `pytest tests/` — 569 passed, 9 skipped locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)