### PR TITLE
feat(dashboard): metrics history dashboard — R2 + OPFS, zero cloud cost (#104)

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -290,6 +290,13 @@ jobs:
             --all-regions \
             --out data/processed/lead_time_report.json
 
+      - name: Push metrics snapshot to R2 (#104)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+        run: uv run python scripts/push_metrics_snapshot.py
+
       - name: Send metrics email (#210)
         if: always()
         env:

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,0 +1,31 @@
+name: Deploy metrics dashboard to Cloudflare Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "dashboard/**"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy indago-metrics → indago-metrics.pages.dev
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Deploy to Cloudflare Pages
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=format:'%s' | LC_ALL=C tr -cd '[:print:]' | cut -c1-72)
+          npx wrangler pages deploy dashboard \
+            --project-name=indago-metrics \
+            --branch=main \
+            --commit-dirty=true \
+            --commit-message="${COMMIT_MSG}"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy indago-metrics → indago-metrics.pages.dev
+    name: Deploy dashboard → indago-4oy.pages.dev
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,7 +22,7 @@ jobs:
         run: |
           COMMIT_MSG=$(git log -1 --pretty=format:'%s' | LC_ALL=C tr -cd '[:print:]' | cut -c1-72)
           npx wrangler pages deploy dashboard \
-            --project-name=indago-metrics \
+            --project-name=indago \
             --branch=main \
             --commit-dirty=true \
             --commit-message="${COMMIT_MSG}"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules/
 dist/
 site/
 uv.lock
+metrics/

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -10,9 +10,11 @@
 
 import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
 
-const R2_BASE = "https://pub-e088008b61ee432b906ef710d52af28c.r2.dev";
+// ?local=1 serves from ./metrics/ (for local dev — run dev-serve.sh)
+const LOCAL_MODE = new URLSearchParams(location.search).has("local");
+const R2_BASE = LOCAL_MODE ? "." : "https://pub-e088008b61ee432b906ef710d52af28c.r2.dev";
 const INDEX_URL = `${R2_BASE}/metrics/index.json`;
-const OPFS_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const OPFS_CACHE_TTL_MS = LOCAL_MODE ? 0 : 24 * 60 * 60 * 1000; // skip cache in local mode
 
 // ---------------------------------------------------------------------------
 // OPFS helpers

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1,0 +1,227 @@
+/**
+ * indago metrics dashboard
+ *
+ * Data flow:
+ *   1. Fetch metrics/index.json from R2
+ *   2. For each entry: check OPFS cache (< 24h) → else fetch from R2
+ *   3. Render time-series charts with Observable Plot (CDN)
+ *   4. Render summary table
+ */
+
+import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
+
+const R2_BASE = "https://pub-e088008b61ee432b906ef710d52af28c.r2.dev";
+const INDEX_URL = `${R2_BASE}/metrics/index.json`;
+const OPFS_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// ---------------------------------------------------------------------------
+// OPFS helpers
+// ---------------------------------------------------------------------------
+
+async function opfsGet(key) {
+  try {
+    const root = await navigator.storage.getDirectory();
+    const dir = await root.getDirectoryHandle("indago-metrics", { create: true });
+    const file = await dir.getFileHandle(key);
+    const f = await file.getFile();
+    const text = await f.text();
+    const { ts, data } = JSON.parse(text);
+    if (Date.now() - ts < OPFS_CACHE_TTL_MS) return data;
+  } catch (_) { /* cache miss */ }
+  return null;
+}
+
+async function opfsSet(key, data) {
+  try {
+    const root = await navigator.storage.getDirectory();
+    const dir = await root.getDirectoryHandle("indago-metrics", { create: true });
+    const file = await dir.getFileHandle(key, { create: true });
+    const writable = await file.createWritable();
+    await writable.write(JSON.stringify({ ts: Date.now(), data }));
+    await writable.close();
+  } catch (_) { /* best-effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch with OPFS cache
+// ---------------------------------------------------------------------------
+
+async function fetchWithCache(url, cacheKey) {
+  const cached = await opfsGet(cacheKey);
+  if (cached) return cached;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${url}`);
+  const data = await res.json();
+  await opfsSet(cacheKey, data);
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Chart helpers
+// ---------------------------------------------------------------------------
+
+function sparkline(snapshots, field, { color = "#3fb950", label = field, fmt = (v) => v.toFixed(3) } = {}) {
+  const data = snapshots
+    .filter((s) => s[field] != null)
+    .map((s) => ({ date: new Date(s.date), value: +s[field] }));
+
+  if (data.length === 0) return null;
+
+  return Plot.plot({
+    width: 320,
+    height: 100,
+    marginLeft: 40,
+    marginRight: 8,
+    marginTop: 8,
+    marginBottom: 24,
+    style: { background: "transparent", color: "#8b949e", fontSize: "11px" },
+    x: { type: "time", label: null, tickFormat: "%m/%d" },
+    y: { label: null, tickFormat: fmt, ticks: 3 },
+    marks: [
+      Plot.lineY(data, { x: "date", y: "value", stroke: color, strokeWidth: 2 }),
+      Plot.dotY(data, { x: "date", y: "value", fill: color, r: 3 }),
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DOM helpers
+// ---------------------------------------------------------------------------
+
+function setStatus(msg, isError = false) {
+  const el = document.getElementById("status");
+  el.textContent = msg;
+  el.className = isError ? "error" : "";
+}
+
+function setMetric(id, value, fmt = (v) => v) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = value != null ? fmt(value) : "—";
+}
+
+function colorClass(value, { floor, ceiling } = {}) {
+  if (value == null) return "";
+  if (floor != null && value < floor) return "bad";
+  if (ceiling != null && value > ceiling) return "warn";
+  return "good";
+}
+
+function renderTable(snapshots) {
+  const tbody = document.getElementById("history-body");
+  tbody.innerHTML = "";
+  for (const s of snapshots) {
+    const p50 = s.precision_at_50;
+    const recall = s.recall_at_200;
+    const lead = s.median_lead_days;
+    const uu = s.unknown_unknown_candidates;
+    const known = s.known_positives;
+
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${s.date}</td>
+      <td class="${colorClass(p50, { floor: 0.25, ceiling: 0.95 })}">${p50 != null ? p50.toFixed(4) : "—"}</td>
+      <td class="${colorClass(recall, { floor: 0.5 })}">${recall != null ? recall.toFixed(4) : "—"}</td>
+      <td>${lead != null ? lead + "d" : "—"}</td>
+      <td>${uu != null ? uu : "—"}</td>
+      <td>${known != null ? known : "—"}</td>
+      <td style="color:#484f58;font-size:0.7rem">${(s.regions || []).join(", ") || "—"}</td>
+    `;
+    tbody.appendChild(row);
+  }
+}
+
+function mountChart(containerId, chart) {
+  const el = document.getElementById(containerId);
+  if (!el || !chart) return;
+  el.innerHTML = "";
+  el.appendChild(chart);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  setStatus("Fetching index from R2…");
+
+  let index;
+  try {
+    index = await fetchWithCache(INDEX_URL, "index.json");
+  } catch (err) {
+    setStatus(`Failed to load index: ${err.message}`, true);
+    return;
+  }
+
+  const entries = index.entries || [];
+  if (entries.length === 0) {
+    setStatus("No snapshots found in index.", true);
+    return;
+  }
+
+  setStatus(`Loading ${entries.length} snapshot(s)…`);
+
+  const snapshots = [];
+  for (const dateKey of entries) {
+    const url = `${R2_BASE}/metrics/${dateKey}.json`;
+    try {
+      const snap = await fetchWithCache(url, `snapshot-${dateKey}.json`);
+      snapshots.push(snap);
+    } catch (err) {
+      console.warn(`Failed to load snapshot ${dateKey}:`, err);
+    }
+  }
+
+  if (snapshots.length === 0) {
+    setStatus("No snapshots could be loaded.", true);
+    return;
+  }
+
+  // Sort oldest-first for charts
+  snapshots.sort((a, b) => a.date.localeCompare(b.date));
+  const latest = snapshots.at(-1);
+
+  // Latest metric values
+  setMetric("val-p50", latest.precision_at_50, (v) => v.toFixed(4));
+  if (latest.precision_at_50_ci_low != null && latest.precision_at_50_ci_high != null) {
+    document.getElementById("sub-p50").textContent =
+      `CI 95%: ${latest.precision_at_50_ci_low.toFixed(3)}–${latest.precision_at_50_ci_high.toFixed(3)} · gate ≥ 0.60`;
+  }
+  setMetric("val-recall", latest.recall_at_200, (v) => v.toFixed(4));
+  setMetric("val-lead", latest.median_lead_days, (v) => `${v}d`);
+  if (latest.pre_designation_count != null) {
+    document.getElementById("sub-lead").textContent =
+      `median · ${latest.pre_designation_count} vessel(s) detected pre-designation`;
+  }
+  setMetric("val-uu", latest.unknown_unknown_candidates);
+
+  // Charts
+  mountChart("chart-p50", sparkline(snapshots, "precision_at_50", {
+    color: latest.precision_at_50 >= 0.25 ? "#3fb950" : "#f85149",
+    fmt: (v) => v.toFixed(2),
+  }));
+  mountChart("chart-recall", sparkline(snapshots, "recall_at_200", {
+    color: "#58a6ff",
+    fmt: (v) => v.toFixed(2),
+  }));
+  mountChart("chart-lead", sparkline(snapshots, "median_lead_days", {
+    color: "#d2a679",
+    fmt: (v) => `${v}d`,
+  }));
+  mountChart("chart-uu", sparkline(snapshots, "unknown_unknown_candidates", {
+    color: "#bc8cff",
+    fmt: (v) => String(Math.round(v)),
+  }));
+
+  // Table (newest first)
+  renderTable([...snapshots].reverse());
+
+  const cached = await navigator.storage.estimate();
+  const updatedAt = index.updated_at_utc?.slice(0, 16).replace("T", " ") ?? "unknown";
+  const cacheKB = cached.usage ? Math.round(cached.usage / 1024) : "?";
+  document.getElementById("footer").textContent =
+    `Index updated: ${updatedAt} UTC · OPFS cache: ~${cacheKB} KB · Source: maridb-public R2`;
+
+  setStatus(`Showing ${snapshots.length} snapshot(s) · latest: ${latest.date}`);
+}
+
+main().catch((err) => setStatus(`Unexpected error: ${err.message}`, true));

--- a/dashboard/dev-serve.sh
+++ b/dashboard/dev-serve.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Serve the metrics dashboard locally with mock data.
+# Visit: http://localhost:8080/?local
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+METRICS_DIR="$SCRIPT_DIR/metrics"
+
+mkdir -p "$METRICS_DIR"
+
+# Generate mock snapshots for the last 7 days
+python3 - <<'EOF'
+import json, os, random
+from datetime import date, timedelta
+
+metrics_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "metrics")
+os.makedirs(metrics_dir, exist_ok=True)
+
+base_p50      = 0.356
+base_recall   = 1.0
+base_lead     = 29
+base_uu       = 50
+base_positives = 89
+regions = ["singapore", "japan", "europe", "blacksea", "middleeast"]
+
+entries = []
+for i in range(7):
+    d = date.today() - timedelta(days=6 - i)
+    key = d.strftime("%Y%m%d")
+    entries.append(key)
+
+    noise = random.uniform(-0.02, 0.02)
+    snap = {
+        "date": d.isoformat(),
+        "precision_at_50": round(base_p50 + noise, 4),
+        "precision_at_50_ci_low": round(base_p50 + noise - 0.07, 4),
+        "precision_at_50_ci_high": round(base_p50 + noise + 0.07, 4),
+        "recall_at_200": base_recall,
+        "auroc": round(0.87 + random.uniform(-0.03, 0.03), 4),
+        "known_positives": base_positives + random.randint(-2, 2),
+        "regions": regions,
+        "skipped_regions": [],
+        "pre_designation_count": 6 + random.randint(-1, 1),
+        "mean_lead_days": base_lead + random.randint(-3, 3),
+        "median_lead_days": base_lead + random.randint(-2, 2),
+        "unknown_unknown_candidates": base_uu + random.randint(-5, 5),
+        "generated_at_utc": f"{d.isoformat()}T01:00:00+00:00",
+    }
+    path = os.path.join(metrics_dir, f"{key}.json")
+    with open(path, "w") as f:
+        json.dump(snap, f, indent=2)
+    print(f"  wrote {key}.json  P@50={snap['precision_at_50']}")
+
+index = {"entries": list(reversed(entries)), "updated_at_utc": entries[-1] + "T01:00:00+00:00"}
+with open(os.path.join(metrics_dir, "index.json"), "w") as f:
+    json.dump(index, f, indent=2)
+print(f"  wrote index.json  entries={index['entries']}")
+EOF
+
+echo ""
+echo "Mock data written to dashboard/metrics/"
+echo ""
+echo "Starting server at http://localhost:8080"
+echo "Open: http://localhost:8080/?local"
+echo ""
+cd "$SCRIPT_DIR"
+python3 -m http.server 8080

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>indago — Metrics Dashboard</title>
+  <script type="module" src="dashboard.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+      background: #0d1117;
+      color: #c9d1d9;
+      padding: 2rem;
+      min-height: 100vh;
+    }
+
+    header {
+      display: flex;
+      align-items: baseline;
+      gap: 1rem;
+      margin-bottom: 2rem;
+      border-bottom: 1px solid #21262d;
+      padding-bottom: 1rem;
+    }
+
+    header h1 { font-size: 1.2rem; font-weight: 600; color: #e6edf3; }
+    header span { font-size: 0.8rem; color: #8b949e; }
+
+    #status {
+      font-size: 0.75rem;
+      color: #8b949e;
+      margin-bottom: 1.5rem;
+      min-height: 1.2em;
+    }
+    #status.error { color: #f85149; }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+      gap: 1.5rem;
+      margin-bottom: 2rem;
+    }
+
+    .card {
+      background: #161b22;
+      border: 1px solid #21262d;
+      border-radius: 6px;
+      padding: 1rem 1.25rem 1.25rem;
+    }
+
+    .card h2 {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #8b949e;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 0.5rem;
+    }
+
+    .metric-value {
+      font-size: 2rem;
+      font-weight: 700;
+      color: #e6edf3;
+      letter-spacing: -0.02em;
+    }
+
+    .metric-sub {
+      font-size: 0.75rem;
+      color: #8b949e;
+      margin-top: 0.15rem;
+    }
+
+    .chart-container {
+      margin-top: 0.75rem;
+      min-height: 120px;
+    }
+
+    /* Observable Plot overrides for dark theme */
+    .chart-container svg text { fill: #8b949e !important; }
+    .chart-container svg [aria-label="y-axis tick"] line,
+    .chart-container svg [aria-label="x-axis tick"] line { stroke: #21262d; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.8rem;
+      margin-top: 0.5rem;
+    }
+    th {
+      text-align: left;
+      font-weight: 600;
+      color: #8b949e;
+      border-bottom: 1px solid #21262d;
+      padding: 0.3rem 0.5rem;
+    }
+    td {
+      padding: 0.3rem 0.5rem;
+      border-bottom: 1px solid #161b22;
+      color: #c9d1d9;
+    }
+    td.good { color: #3fb950; }
+    td.warn { color: #d29922; }
+    td.bad  { color: #f85149; }
+
+    footer {
+      font-size: 0.7rem;
+      color: #484f58;
+      margin-top: 2rem;
+      border-top: 1px solid #21262d;
+      padding-top: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>indago — Metrics Dashboard</h1>
+    <span>Last 7 days · R2 + OPFS · zero cloud compute</span>
+  </header>
+
+  <div id="status">Loading…</div>
+
+  <div class="grid">
+    <div class="card">
+      <h2>Precision @ 50</h2>
+      <div class="metric-value" id="val-p50">—</div>
+      <div class="metric-sub" id="sub-p50">gate ≥ 0.60 · ceiling 0.95</div>
+      <div class="chart-container" id="chart-p50"></div>
+    </div>
+
+    <div class="card">
+      <h2>Recall @ 200</h2>
+      <div class="metric-value" id="val-recall">—</div>
+      <div class="metric-sub">all known positives reachable in top 200</div>
+      <div class="chart-container" id="chart-recall"></div>
+    </div>
+
+    <div class="card">
+      <h2>Pre-designation Lead Time</h2>
+      <div class="metric-value" id="val-lead">—</div>
+      <div class="metric-sub" id="sub-lead">days · 60–90 day target</div>
+      <div class="chart-container" id="chart-lead"></div>
+    </div>
+
+    <div class="card">
+      <h2>Unknown-Unknown Watch</h2>
+      <div class="metric-value" id="val-uu">—</div>
+      <div class="metric-sub">candidates with no current sanctions link</div>
+      <div class="chart-container" id="chart-uu"></div>
+    </div>
+  </div>
+
+  <div class="card" style="margin-bottom: 1.5rem;">
+    <h2>Daily Snapshot History</h2>
+    <table id="history-table">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>P@50</th>
+          <th>Recall@200</th>
+          <th>Lead days (median)</th>
+          <th>UU candidates</th>
+          <th>Known positives</th>
+          <th>Source</th>
+        </tr>
+      </thead>
+      <tbody id="history-body">
+        <tr><td colspan="7" style="color:#484f58">Loading…</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <footer id="footer">Cache: OPFS · Data: maridb-public R2</footer>
+</body>
+</html>

--- a/scripts/push_metrics_snapshot.py
+++ b/scripts/push_metrics_snapshot.py
@@ -128,8 +128,9 @@ def _write_json(fs, bucket: str, key: str, obj: dict) -> None:
 def _delete_key(fs, bucket: str, key: str) -> None:
     try:
         fs.delete_file(f"{bucket}/{key}")
-    except Exception:
-        pass
+    except Exception as exc:
+        # Best-effort cleanup: deletion failures should not fail snapshot publishing.
+        print(f"warning: failed to delete {bucket}/{key}: {exc}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/push_metrics_snapshot.py
+++ b/scripts/push_metrics_snapshot.py
@@ -1,0 +1,192 @@
+"""Push a dated metrics snapshot to R2 and maintain a 7-entry rolling index.
+
+Called after the regression gate passes in the data-publish CI workflow.
+Writes one JSON file per day and keeps only the last 7 days in the index.
+Older files are deleted from R2 to keep storage near zero.
+
+Layout in maridb-public:
+    metrics/YYYYMMDD.json      — daily snapshot
+    metrics/index.json         — list of last 7 dated keys (newest first)
+
+Usage
+-----
+    uv run python scripts/push_metrics_snapshot.py
+    uv run python scripts/push_metrics_snapshot.py --dry-run
+    uv run python scripts/push_metrics_snapshot.py --date 2026-05-06
+
+Environment (same as sync_r2.py)
+---------------------------------
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_REGION        (default: auto)
+    S3_BUCKET         (default: maridb-public)
+    S3_ENDPOINT       (default: maridb-public R2 endpoint)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_BUCKET = "maridb-public"
+_DEFAULT_ENDPOINT = os.getenv(
+    "S3_ENDPOINT",
+    "https://4d28b4cbebe4bcbc11d45e99fda3a44c.r2.cloudflarestorage.com",
+)
+_METRICS_PREFIX = "metrics"
+_INDEX_KEY = f"{_METRICS_PREFIX}/index.json"
+_MAX_HISTORY = 7
+
+
+def _processed_dir() -> Path:
+    """Return the processed data directory, relative to cwd (tests can chdir)."""
+    return Path.cwd() / "data" / "processed"
+
+
+# ---------------------------------------------------------------------------
+# Collect metrics from local pipeline outputs
+# ---------------------------------------------------------------------------
+
+def _collect_snapshot(date_str: str) -> dict:
+    """Build a snapshot dict from available pipeline output files."""
+    snap: dict = {"date": date_str}
+    _PROCESSED = _processed_dir()
+
+    # Backtest summary (data-publish)
+    summary_path = _PROCESSED / "backtest_public_integration_summary.json"
+    if summary_path.exists():
+        summary = json.loads(summary_path.read_text())
+        ms = summary.get("metrics_summary", {})
+        snap["precision_at_50"] = ms.get("precision_at_50", {}).get("mean")
+        snap["precision_at_50_ci_low"] = ms.get("precision_at_50", {}).get("ci95_low")
+        snap["precision_at_50_ci_high"] = ms.get("precision_at_50", {}).get("ci95_high")
+        snap["recall_at_200"] = ms.get("recall_at_200", {}).get("mean")
+        snap["auroc"] = ms.get("auroc", {}).get("mean") if isinstance(ms.get("auroc"), dict) else ms.get("auroc")
+        snap["known_positives"] = summary.get("total_known_cases")
+        snap["regions"] = summary.get("regions", [])
+        snap["skipped_regions"] = summary.get("skipped_regions", [])
+
+    # Lead time validation
+    lead_path = _PROCESSED / "lead_time_report.json"  # noqa: F821 (defined above)
+    if lead_path.exists():
+        lead = json.loads(lead_path.read_text())
+        snap["pre_designation_count"] = lead.get("pre_designation_count")
+        snap["mean_lead_days"] = lead.get("mean_lead_days")
+        snap["median_lead_days"] = lead.get("median_lead_days")
+        snap["unknown_unknown_candidates"] = lead.get("unknown_unknown_candidates")
+
+    # Validation metrics (AIS)
+    val_path = _PROCESSED / "validation_metrics.json"
+    if val_path.exists():
+        val = json.loads(val_path.read_text())
+        snap.setdefault("precision_at_50", val.get("precision_at_50"))
+        snap.setdefault("recall_at_200", val.get("recall_at_200"))
+        snap.setdefault("auroc", val.get("auroc"))
+
+    snap["generated_at_utc"] = datetime.now(UTC).isoformat()
+    return snap
+
+
+# ---------------------------------------------------------------------------
+# R2 helpers
+# ---------------------------------------------------------------------------
+
+def _make_fs():
+    import pyarrow.fs as pafs
+
+    endpoint = _DEFAULT_ENDPOINT
+    host = endpoint.split("://", 1)[-1].rstrip("/")
+    scheme = "https" if endpoint.startswith("https://") else "http"
+    return pafs.S3FileSystem(
+        access_key=os.environ["AWS_ACCESS_KEY_ID"],
+        secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        endpoint_override=host,
+        scheme=scheme,
+        region=os.getenv("AWS_REGION", "auto"),
+    )
+
+
+def _read_index(fs, bucket: str) -> list[str]:
+    try:
+        with fs.open_input_stream(f"{bucket}/{_INDEX_KEY}") as f:
+            data = json.loads(f.read().decode())
+            return data.get("entries", [])
+    except Exception:
+        return []
+
+
+def _write_json(fs, bucket: str, key: str, obj: dict) -> None:
+    payload = json.dumps(obj, indent=2).encode()
+    with fs.open_output_stream(f"{bucket}/{key}") as f:
+        f.write(payload)
+
+
+def _delete_key(fs, bucket: str, key: str) -> None:
+    try:
+        fs.delete_file(f"{bucket}/{key}")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Push daily metrics snapshot to R2")
+    parser.add_argument("--date", default=None, help="Date YYYY-MM-DD (default: today UTC)")
+    parser.add_argument("--dry-run", action="store_true", help="Print snapshot without uploading")
+    args = parser.parse_args()
+
+    date_str = args.date or datetime.now(UTC).strftime("%Y-%m-%d")
+    date_key = date_str.replace("-", "")  # YYYYMMDD
+    snapshot_key = f"{_METRICS_PREFIX}/{date_key}.json"
+
+    snap = _collect_snapshot(date_str)
+    print(f"Snapshot for {date_str}:")
+    print(json.dumps(snap, indent=2))
+
+    if args.dry_run:
+        print("\n[dry-run] No upload performed.")
+        return
+
+    for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
+        if not os.getenv(var):
+            print(f"[error] {var} not set — cannot push to R2", file=sys.stderr)
+            sys.exit(1)
+
+    bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
+    fs = _make_fs()
+
+    # Write today's snapshot
+    _write_json(fs, bucket, snapshot_key, snap)
+    print(f"Uploaded: {snapshot_key}")
+
+    # Update index (newest first, max 7 entries)
+    entries = _read_index(fs, bucket)
+    if date_key not in entries:
+        entries = [date_key] + entries
+    entries = entries[:_MAX_HISTORY]
+
+    _write_json(fs, bucket, _INDEX_KEY, {"entries": entries, "updated_at_utc": datetime.now(UTC).isoformat()})
+    print(f"Updated index: {entries}")
+
+    # Delete entries beyond the 7-day window
+    cutoff = datetime.now(UTC) - timedelta(days=_MAX_HISTORY)
+    for entry in entries[_MAX_HISTORY:]:
+        try:
+            entry_date = datetime.strptime(entry, "%Y%m%d").replace(tzinfo=UTC)
+            if entry_date < cutoff:
+                key = f"{_METRICS_PREFIX}/{entry}.json"
+                _delete_key(fs, bucket, key)
+                print(f"Deleted old snapshot: {key}")
+        except ValueError:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/push_metrics_snapshot.py
+++ b/scripts/push_metrics_snapshot.py
@@ -186,7 +186,10 @@ def main() -> None:
                 _delete_key(fs, bucket, key)
                 print(f"Deleted old snapshot: {key}")
         except ValueError:
-            pass
+            print(
+                f"[warn] Skipping invalid index entry (expected YYYYMMDD): {entry!r}",
+                file=sys.stderr,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_push_metrics_snapshot.py
+++ b/tests/test_push_metrics_snapshot.py
@@ -1,0 +1,123 @@
+"""Tests for push_metrics_snapshot.py."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+from scripts.push_metrics_snapshot import _collect_snapshot
+
+
+def test_collect_snapshot_minimal(tmp_path, monkeypatch):
+    """_collect_snapshot returns a dict with at least date and generated_at."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data" / "processed").mkdir(parents=True)
+    snap = _collect_snapshot("2026-05-06")
+    assert snap["date"] == "2026-05-06"
+    assert "generated_at_utc" in snap
+
+
+def test_collect_snapshot_reads_backtest_summary(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    processed = tmp_path / "data" / "processed"
+    processed.mkdir(parents=True)
+    summary = {
+        "metrics_summary": {
+            "precision_at_50": {"mean": 0.356, "ci95_low": 0.289, "ci95_high": 0.423},
+            "recall_at_200": {"mean": 1.0},
+            "auroc": {"mean": 0.87},
+        },
+        "total_known_cases": 89,
+        "regions": ["singapore", "japan"],
+        "skipped_regions": [],
+    }
+    (processed / "backtest_public_integration_summary.json").write_text(json.dumps(summary))
+
+    snap = _collect_snapshot("2026-05-06")
+    assert snap["precision_at_50"] == pytest.approx(0.356)
+    assert snap["precision_at_50_ci_low"] == pytest.approx(0.289)
+    assert snap["recall_at_200"] == pytest.approx(1.0)
+    assert snap["known_positives"] == 89
+    assert snap["regions"] == ["singapore", "japan"]
+
+
+def test_collect_snapshot_reads_lead_time(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    processed = tmp_path / "data" / "processed"
+    processed.mkdir(parents=True)
+    lead = {
+        "pre_designation_count": 6,
+        "mean_lead_days": 26,
+        "median_lead_days": 29,
+        "unknown_unknown_candidates": 50,
+    }
+    (processed / "lead_time_report.json").write_text(json.dumps(lead))
+
+    snap = _collect_snapshot("2026-05-06")
+    assert snap["pre_designation_count"] == 6
+    assert snap["median_lead_days"] == 29
+    assert snap["unknown_unknown_candidates"] == 50
+
+
+def test_collect_snapshot_partial_files(tmp_path, monkeypatch):
+    """Only lead time report available — no backtest summary."""
+    monkeypatch.chdir(tmp_path)
+    processed = tmp_path / "data" / "processed"
+    processed.mkdir(parents=True)
+    lead = {"pre_designation_count": 3, "mean_lead_days": 22, "median_lead_days": 22, "unknown_unknown_candidates": 10}
+    (processed / "lead_time_report.json").write_text(json.dumps(lead))
+
+    snap = _collect_snapshot("2026-05-06")
+    assert snap["pre_designation_count"] == 3
+    assert snap.get("precision_at_50") is None
+
+
+def test_dry_run_cli(tmp_path, monkeypatch):
+    """--dry-run prints snapshot without uploading (no credentials needed)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data" / "processed").mkdir(parents=True)
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "push_metrics_snapshot.py"),
+         "--dry-run", "--date", "2026-05-06"],
+        capture_output=True, text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "2026-05-06" in result.stdout
+    assert "dry-run" in result.stdout
+
+
+def test_dry_run_includes_all_keys(tmp_path, monkeypatch):
+    """--dry-run snapshot contains expected top-level keys."""
+    monkeypatch.chdir(tmp_path)
+    processed = tmp_path / "data" / "processed"
+    processed.mkdir(parents=True)
+    summary = {
+        "metrics_summary": {
+            "precision_at_50": {"mean": 0.40},
+            "recall_at_200": {"mean": 0.95},
+            "auroc": {"mean": 0.80},
+        },
+        "total_known_cases": 50,
+        "regions": ["singapore"],
+        "skipped_regions": [],
+    }
+    lead = {"pre_designation_count": 4, "mean_lead_days": 28, "median_lead_days": 28, "unknown_unknown_candidates": 30}
+    (processed / "backtest_public_integration_summary.json").write_text(json.dumps(summary))
+    (processed / "lead_time_report.json").write_text(json.dumps(lead))
+
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "push_metrics_snapshot.py"),
+         "--dry-run", "--date", "2026-05-06"],
+        capture_output=True, text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0
+    output = result.stdout
+    for key in ("precision_at_50", "recall_at_200", "pre_designation_count", "median_lead_days"):
+        assert key in output, f"missing key in output: {key}"


### PR DESCRIPTION
## Summary

Implements indago#104 — browser-based metrics history dashboard backed by R2 and OPFS.

### Architecture

```
GitHub Actions (data-publish, daily)
    → regression gate passes
        → push_metrics_snapshot.py writes metrics/YYYYMMDD.json to R2
        → index.json updated (last 7 entries, oldest deleted)

Browser (https://indago-4oy.pages.dev)
    → fetch index.json from R2 public URL
    → fetch missing snapshots → cache in OPFS (24h TTL)
    → render time-series charts with Observable Plot (CDN)
```

**Zero cloud cost:** R2 public reads are free. No CF Worker. Static HTML served from Cloudflare Pages free tier.

### URLs

| | URL |
|---|---|
| Dashboard (production) | https://indago-4oy.pages.dev |
| Local dev | `bash dashboard/dev-serve.sh` → http://localhost:8080/?local |

### Files

| File | Purpose |
|---|---|
| `scripts/push_metrics_snapshot.py` | Collect pipeline metrics → write dated JSON to R2 → maintain 7-entry rolling index |
| `dashboard/index.html` | Static dashboard shell |
| `dashboard/dashboard.js` | ES module: OPFS cache, R2 fetch, Observable Plot charts; `?local` mode for dev |
| `dashboard/dev-serve.sh` | Generate mock data + serve locally at http://localhost:8080/?local |
| `tests/test_push_metrics_snapshot.py` | 6 tests for snapshot collection and CLI |
| `.github/workflows/deploy-dashboard.yml` | Deploy `dashboard/` to `indago` CF Pages project on push to main |
| `.github/workflows/data-publish.yml` | Added push step after lead time validation |

### Metrics tracked

| Metric | Source |
|---|---|
| Precision@50 (with CI 95%) | `backtest_public_integration_summary.json` |
| Recall@200 | Same |
| Median lead days | `lead_time_report.json` |
| Pre-designation count | Same |
| Unknown-unknown candidates | Same |
| Known positives | Backtest summary |

### Test results

29 passed (6 new for push_metrics_snapshot + 23 existing lead time tests).

Closes #104

🤖 Generated with [Claude Code](https://claude.ai/claude-code)