### PR TITLE
fix(ci): use GITHUB_OUTPUT flag instead of exit 1 for missing R2 data

### DIFF
--- a/.github/workflows/lead-time-validation.yml
+++ b/.github/workflows/lead-time-validation.yml
@@ -28,31 +28,34 @@ jobs:
 
       - name: Pull watchlist and sanctions DB from R2
         id: pull
-        continue-on-error: true
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          uv run python scripts/sync_r2.py pull \
-            || { echo "::warning::pull skipped — no latest pointer in R2 (run a push first)"; exit 1; }
+          if uv run python scripts/sync_r2.py pull; then
+            echo "data_available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::pull skipped — no latest pointer in R2 (run a push first)"
+            echo "data_available=false" >> "$GITHUB_OUTPUT"
+          fi
           uv run python scripts/sync_r2.py pull-sanctions-db \
             || echo "::warning::pull-sanctions-db skipped or failed (non-fatal)"
 
       - name: Run lead time validation
-        if: steps.pull.outcome == 'success'
+        if: steps.pull.outputs.data_available == 'true'
         run: |
           uv run python scripts/validate_lead_time_ofac.py \
             --watchlist ~/.indago/data/candidate_watchlist.parquet \
             --out data/processed/lead_time_report.json
 
       - name: Print formatted report
-        if: steps.pull.outcome == 'success'
+        if: steps.pull.outputs.data_available == 'true'
         run: |
           uv run python scripts/print_lead_time_report.py \
             --report data/processed/lead_time_report.json
 
       - name: Upload report artifact
-        if: steps.pull.outcome == 'success'
+        if: steps.pull.outputs.data_available == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: lead-time-report-${{ github.run_id }}


### PR DESCRIPTION
Supersedes #107 (conflicts from squash-merged commits).

## Problem

`continue-on-error: true` + `exit 1` still marks the step as failed in the UI even though the job continues.

## Fix

Use `if/else` so the pull step always exits 0, with a `GITHUB_OUTPUT` flag gating downstream steps:

```bash
if uv run python scripts/sync_r2.py pull; then
  echo "data_available=true" >> "$GITHUB_OUTPUT"
else
  echo "::warning::pull skipped — no latest pointer in R2"
  echo "data_available=false" >> "$GITHUB_OUTPUT"
fi
```

Downstream steps use `if: steps.pull.outputs.data_available == 'true'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)