### PR TITLE
fix(metrics): use boto3 put_object instead of pyarrow multipart upload

### DIFF
--- a/.github/workflows/lead-time-validation.yml
+++ b/.github/workflows/lead-time-validation.yml
@@ -28,31 +28,34 @@ jobs:
 
       - name: Pull watchlist and sanctions DB from R2
         id: pull
-        continue-on-error: true
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          uv run python scripts/sync_r2.py pull \
-            || { echo "::warning::pull skipped — no latest pointer in R2 (run a push first)"; exit 1; }
+          if uv run python scripts/sync_r2.py pull; then
+            echo "data_available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::pull skipped — no latest pointer in R2 (run a push first)"
+            echo "data_available=false" >> "$GITHUB_OUTPUT"
+          fi
           uv run python scripts/sync_r2.py pull-sanctions-db \
             || echo "::warning::pull-sanctions-db skipped or failed (non-fatal)"
 
       - name: Run lead time validation
-        if: steps.pull.outcome == 'success'
+        if: steps.pull.outputs.data_available == 'true'
         run: |
           uv run python scripts/validate_lead_time_ofac.py \
             --watchlist ~/.indago/data/candidate_watchlist.parquet \
             --out data/processed/lead_time_report.json
 
       - name: Print formatted report
-        if: steps.pull.outcome == 'success'
+        if: steps.pull.outputs.data_available == 'true'
         run: |
           uv run python scripts/print_lead_time_report.py \
             --report data/processed/lead_time_report.json
 
       - name: Upload report artifact
-        if: steps.pull.outcome == 'success'
+        if: steps.pull.outputs.data_available == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: lead-time-report-${{ github.run_id }}

--- a/scripts/push_metrics_snapshot.py
+++ b/scripts/push_metrics_snapshot.py
@@ -92,42 +92,42 @@ def _collect_snapshot(date_str: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# R2 helpers
+# R2 helpers — use boto3 for simple PUT (pyarrow triggers multipart upload
+# even for tiny files, which fails with TLS handshake errors on some runners)
 # ---------------------------------------------------------------------------
 
-def _make_fs():
-    import pyarrow.fs as pafs
+def _make_client(bucket: str):
+    import boto3
 
-    endpoint = _DEFAULT_ENDPOINT
-    host = endpoint.split("://", 1)[-1].rstrip("/")
-    scheme = "https" if endpoint.startswith("https://") else "http"
-    return pafs.S3FileSystem(
-        access_key=os.environ["AWS_ACCESS_KEY_ID"],
-        secret_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-        endpoint_override=host,
-        scheme=scheme,
-        region=os.getenv("AWS_REGION", "auto"),
-    )
+    return boto3.client(
+        "s3",
+        endpoint_url=_DEFAULT_ENDPOINT,
+        aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        region_name=os.getenv("AWS_REGION", "auto"),
+    ), bucket
 
 
-def _read_index(fs, bucket: str) -> list[str]:
+def _read_index(client_bucket: tuple, _unused_bucket: str) -> list[str]:
+    client, bucket = client_bucket
     try:
-        with fs.open_input_stream(f"{bucket}/{_INDEX_KEY}") as f:
-            data = json.loads(f.read().decode())
-            return data.get("entries", [])
+        obj = client.get_object(Bucket=bucket, Key=_INDEX_KEY)
+        data = json.loads(obj["Body"].read().decode())
+        return data.get("entries", [])
     except Exception:
         return []
 
 
-def _write_json(fs, bucket: str, key: str, obj: dict) -> None:
+def _write_json(client_bucket: tuple, _unused_bucket: str, key: str, obj: dict) -> None:
+    client, bucket = client_bucket
     payload = json.dumps(obj, indent=2).encode()
-    with fs.open_output_stream(f"{bucket}/{key}") as f:
-        f.write(payload)
+    client.put_object(Bucket=bucket, Key=key, Body=payload, ContentType="application/json")
 
 
-def _delete_key(fs, bucket: str, key: str) -> None:
+def _delete_key(client_bucket: tuple, _unused_bucket: str, key: str) -> None:
+    client, bucket = client_bucket
     try:
-        fs.delete_file(f"{bucket}/{key}")
+        client.delete_object(Bucket=bucket, Key=key)
     except Exception as exc:
         # Best-effort cleanup: deletion failures should not fail snapshot publishing.
         print(f"warning: failed to delete {bucket}/{key}: {exc}", file=sys.stderr)
@@ -161,19 +161,19 @@ def main() -> None:
             sys.exit(1)
 
     bucket = os.getenv("S3_BUCKET", _DEFAULT_BUCKET)
-    fs = _make_fs()
+    cb = _make_client(bucket)
 
     # Write today's snapshot
-    _write_json(fs, bucket, snapshot_key, snap)
+    _write_json(cb, bucket, snapshot_key, snap)
     print(f"Uploaded: {snapshot_key}")
 
     # Update index (newest first, max 7 entries)
-    entries = _read_index(fs, bucket)
+    entries = _read_index(cb, bucket)
     if date_key not in entries:
         entries = [date_key] + entries
     entries = entries[:_MAX_HISTORY]
 
-    _write_json(fs, bucket, _INDEX_KEY, {"entries": entries, "updated_at_utc": datetime.now(UTC).isoformat()})
+    _write_json(cb, bucket, _INDEX_KEY, {"entries": entries, "updated_at_utc": datetime.now(UTC).isoformat()})
     print(f"Updated index: {entries}")
 
     # Delete entries beyond the 7-day window
@@ -183,7 +183,7 @@ def main() -> None:
             entry_date = datetime.strptime(entry, "%Y%m%d").replace(tzinfo=UTC)
             if entry_date < cutoff:
                 key = f"{_METRICS_PREFIX}/{entry}.json"
-                _delete_key(fs, bucket, key)
+                _delete_key(cb, bucket, key)
                 print(f"Deleted old snapshot: {key}")
         except ValueError:
             print(

--- a/tests/test_push_metrics_snapshot.py
+++ b/tests/test_push_metrics_snapshot.py
@@ -5,12 +5,19 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
-from scripts.push_metrics_snapshot import _collect_snapshot
+from scripts.push_metrics_snapshot import (
+    _collect_snapshot,
+    _delete_key,
+    _make_client,
+    _read_index,
+    _write_json,
+)
 
 
 def test_collect_snapshot_minimal(tmp_path, monkeypatch):
@@ -121,3 +128,83 @@ def test_dry_run_includes_all_keys(tmp_path, monkeypatch):
     output = result.stdout
     for key in ("precision_at_50", "recall_at_200", "pre_designation_count", "median_lead_days"):
         assert key in output, f"missing key in output: {key}"
+
+
+# ---------------------------------------------------------------------------
+# boto3 upload helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_client(bucket: str = "maridb-public"):
+    """Return a (mock_client, bucket) tuple with a pre-configured boto3 mock."""
+    mock = MagicMock()
+    return (mock, bucket), mock
+
+
+def test_write_json_calls_put_object():
+    """_write_json uses boto3 put_object (not multipart)."""
+    cb, mock = _make_mock_client()
+    _write_json(cb, "maridb-public", "metrics/20260506.json", {"date": "2026-05-06"})
+    mock.put_object.assert_called_once()
+    kwargs = mock.put_object.call_args.kwargs
+    assert kwargs["Bucket"] == "maridb-public"
+    assert kwargs["Key"] == "metrics/20260506.json"
+    assert kwargs["ContentType"] == "application/json"
+    assert b"2026-05-06" in kwargs["Body"]
+
+
+def test_write_json_serialises_correctly():
+    """_write_json Body is valid JSON with expected content."""
+    cb, mock = _make_mock_client()
+    obj = {"date": "2026-05-06", "precision_at_50": 0.356}
+    _write_json(cb, "maridb-public", "metrics/20260506.json", obj)
+    body = mock.put_object.call_args.kwargs["Body"]
+    parsed = json.loads(body.decode())
+    assert parsed["precision_at_50"] == pytest.approx(0.356)
+
+
+def test_read_index_returns_entries():
+    cb, mock = _make_mock_client()
+    mock.get_object.return_value = {
+        "Body": MagicMock(read=lambda: json.dumps({"entries": ["20260506", "20260505"]}).encode())
+    }
+    entries = _read_index(cb, "maridb-public")
+    assert entries == ["20260506", "20260505"]
+    mock.get_object.assert_called_once_with(Bucket="maridb-public", Key="metrics/index.json")
+
+
+def test_read_index_returns_empty_on_error():
+    """Missing index returns [] without raising."""
+    cb, mock = _make_mock_client()
+    mock.get_object.side_effect = Exception("NoSuchKey")
+    entries = _read_index(cb, "maridb-public")
+    assert entries == []
+
+
+def test_delete_key_calls_delete_object():
+    cb, mock = _make_mock_client()
+    _delete_key(cb, "maridb-public", "metrics/20260430.json")
+    mock.delete_object.assert_called_once_with(Bucket="maridb-public", Key="metrics/20260430.json")
+
+
+def test_delete_key_ignores_errors(capsys):
+    """Deletion errors are logged as warnings, not raised."""
+    cb, mock = _make_mock_client()
+    mock.delete_object.side_effect = Exception("AccessDenied")
+    _delete_key(cb, "maridb-public", "metrics/20260430.json")  # must not raise
+    captured = capsys.readouterr()
+    assert "warning" in captured.err
+
+
+def test_make_client_uses_env_credentials(monkeypatch):
+    boto3 = pytest.importorskip("boto3")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("AWS_REGION", "auto")
+    with patch("boto3.client") as mock_boto3:
+        mock_boto3.return_value = MagicMock()
+        cb, bucket = _make_client("maridb-public")
+        mock_boto3.assert_called_once()
+        kwargs = mock_boto3.call_args.kwargs
+        assert kwargs["aws_access_key_id"] == "test-key"
+        assert kwargs["aws_secret_access_key"] == "test-secret"
+        assert bucket == "maridb-public"


### PR DESCRIPTION
## Problem

`push_metrics_snapshot.py` used `pyarrow.fs.S3FileSystem.open_output_stream` which always initiates a multipart upload — even for tiny JSON files. This caused a TLS handshake failure on GitHub Actions runners:

```
OSError: SSL connect error; curlCode: 35, TLS connect error:
error:0A000410:SSL routines::ssl/tls alert handshake failure
```

## Fix

Switch to `boto3.client.put_object()` — a simple single-part PUT that avoids the multipart protocol entirely. Already used in other parts of the pipeline stack.

## Test

`--dry-run` still passes. CI will confirm on next data-publish run.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)