### PR TITLE
fix(metrics): correct R2 endpoint + boto3 + test coverage

### DIFF
--- a/scripts/push_metrics_snapshot.py
+++ b/scripts/push_metrics_snapshot.py
@@ -35,7 +35,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 _DEFAULT_BUCKET = "maridb-public"
 _DEFAULT_ENDPOINT = os.getenv(
     "S3_ENDPOINT",
-    "https://4d28b4cbebe4bcbc11d45e99fda3a44c.r2.cloudflarestorage.com",
+    "https://b8a0b09feb89390fb6e8cf4ef9294f48.r2.cloudflarestorage.com",
 )
 _METRICS_PREFIX = "metrics"
 _INDEX_KEY = f"{_METRICS_PREFIX}/index.json"


### PR DESCRIPTION
## Problems fixed

**1. Wrong R2 S3 API endpoint (root cause of all SSL failures)**
`push_metrics_snapshot.py` used `4d28b4cb…r2.cloudflarestorage.com` (the public URL account ID) instead of `b8a0b09f…r2.cloudflarestorage.com` (the S3 API endpoint from `sync_r2.py`). The wrong endpoint caused SSL handshake failures with both pyarrow and boto3.

**2. Unnecessary pyarrow → boto3 switch**
The original switch from pyarrow to boto3 was chasing the wrong root cause. Now using boto3 with the correct endpoint (simpler — avoids pyarrow multipart for small JSON files).

**3. Missing boto3 dependency**
`boto3` was not declared in `pyproject.toml`.

**4. Test silent skip masked the missing dependency**
`pytest.importorskip("boto3")` silently skipped the client test when boto3 was not installed locally. Fixed with `sys.modules` patching so the test always runs.

## Changes

- `scripts/push_metrics_snapshot.py` — correct R2 endpoint; use boto3 put_object
- `pyproject.toml` — add `boto3>=1.34`
- `uv.lock` — updated
- `tests/test_push_metrics_snapshot.py` — 7 new tests; mock boto3 via sys.modules (no skip)

## Tests

13/13 passed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)