### PR TITLE
fix(ci): use candidate_watchlist.parquet path for lead time validation

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Lead time validation (#268)
         run: |
           uv run python scripts/validate_lead_time_ofac.py \
-            --all-regions \
+            --watchlist "${MARIDB_DATA_DIR:-data/processed}/candidate_watchlist.parquet" \
             --out data/processed/lead_time_report.json
 
       - name: Push metrics snapshot to R2 (#104)


### PR DESCRIPTION
## Problem

Lead time metrics (pre_designation_count, median_lead_days, unknown_unknown_candidates) showed 0 in the dashboard because `validate_lead_time_ofac.py --all-regions` reads watchlists from `~/.arktrace/data/` — a path that doesn't exist in CI.

## Fix

Pass `--watchlist` explicitly pointing to `$MARIDB_DATA_DIR/candidate_watchlist.parquet`, which is where the pipeline writes it in CI.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)