### PR TITLE
refactor(dashboard): reframe as maintainer ops tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Multi-domain OSINT data layer. indago ingests raw signals from maritime, corpora
 |------|------|-------------|
 | [arktrace](https://github.com/edgesentry/arktrace) | Shadow fleet detection | Reads maritime + sanctions features from `arktrace-public` R2 |
 | [documaris](https://github.com/edgesentry/documaris) | Port call documents | Reads voyage and cargo data from `documaris-public` R2 |
-| [clarus](https://github.com/edgesentry/clarus) | Vessel risk intelligence | Reads vessel behavioral features from `maridb-public` R2 |
+| [clarus](https://github.com/edgesentry/clarus) | Physical port safety monitoring | Reads vessel behavioral features from `maridb-public` R2 |
 | [edgesentry-rs](https://github.com/edgesentry/edgesentry-rs) | Audit chain | Audit record format (BLAKE3 + Ed25519) used for signed data outputs |
 
 ## Directory map

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 indago is the shared data foundation for the edgesentry product stack. It collects and transforms raw signals from multiple open-source intelligence domains into structured Parquet datasets distributed via Cloudflare R2.
 
+> **Audience:** This repo is for engineers who maintain indago and its downstream products. The analyst-facing product is **[arktrace.edgesentry.io](https://arktrace.edgesentry.io)** — shadow fleet watchlist, SHAP attribution, vessel detail, and review workflow.
+
 ### Domains
 
 | Domain | Sources | Output |
@@ -38,11 +40,18 @@ All buckets: unauthenticated public read.
 
 See [`docs/ref-r2-buckets.md`](docs/ref-r2-buckets.md) for full partition layout and data flow.
 
+## Pipeline dashboard
+
+`dashboard/` — maintainer ops tool. Shows pipeline health: regression gate pass/fail, region coverage, skipped regions, and data freshness. Served from `maridb-public` R2.
+
+Analyst metrics (Precision@50, Recall, pre-designation lead time, SHAP scores) are displayed at **[arktrace.edgesentry.io](https://arktrace.edgesentry.io)**.
+
 ## Repository layout
 
 ```
 indago/
   .agents/skills/      # agent skills (npx skills add edgesentry/indago)
+  dashboard/           # maintainer pipeline ops dashboard
   docs/                # reference material (ref-*.md)
   pipelines/           # ingest and transformation pipeline implementations
   scripts/             # one-off upload and maintenance scripts

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1,11 +1,16 @@
 /**
- * indago metrics dashboard
+ * indago pipeline dashboard — maintainer ops tool
+ *
+ * Shows pipeline health: regression gate pass/fail, region coverage,
+ * skipped regions, and data freshness.
+ *
+ * Analyst metrics (P@50, Recall, lead days, SHAP) live at arktrace.edgesentry.io.
  *
  * Data flow:
  *   1. Fetch metrics/index.json from R2
  *   2. For each entry: check OPFS cache (< 24h) → else fetch from R2
- *   3. Render time-series charts with Observable Plot (CDN)
- *   4. Render summary table
+ *   3. Render pipeline status charts with Observable Plot (CDN)
+ *   4. Render run history table
  */
 
 import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
@@ -18,6 +23,8 @@ const FORCE_REFRESH = _params.has("refresh");
 const R2_BASE = LOCAL_MODE ? "." : "https://pub-e088008b61ee432b906ef710d52af28c.r2.dev";
 const INDEX_URL = `${R2_BASE}/metrics/index.json`;
 const OPFS_CACHE_TTL_MS = LOCAL_MODE ? 0 : 24 * 60 * 60 * 1000;
+
+const GATE_THRESHOLD = 0.25;
 
 // ---------------------------------------------------------------------------
 // OPFS helpers
@@ -48,10 +55,6 @@ async function opfsSet(key, data) {
   } catch (_) { /* best-effort */ }
 }
 
-// ---------------------------------------------------------------------------
-// Fetch with OPFS cache
-// ---------------------------------------------------------------------------
-
 async function fetchWithCache(url, cacheKey) {
   const cached = await opfsGet(cacheKey);
   if (cached) return cached;
@@ -66,7 +69,7 @@ async function fetchWithCache(url, cacheKey) {
 // Chart helpers
 // ---------------------------------------------------------------------------
 
-function sparkline(snapshots, field, { color = "#3fb950", label = field, fmt = (v) => v.toFixed(3) } = {}) {
+function sparkline(snapshots, field, { color = "#3fb950", fmt = (v) => String(v) } = {}) {
   const data = snapshots
     .filter((s) => s[field] != null)
     .map((s) => ({ date: new Date(s.date), value: +s[field] }));
@@ -74,9 +77,9 @@ function sparkline(snapshots, field, { color = "#3fb950", label = field, fmt = (
   if (data.length === 0) return null;
 
   return Plot.plot({
-    width: 320,
+    width: 300,
     height: 100,
-    marginLeft: 40,
+    marginLeft: 32,
     marginRight: 8,
     marginTop: 8,
     marginBottom: 24,
@@ -100,40 +103,16 @@ function setStatus(msg, isError = false) {
   el.className = isError ? "error" : "";
 }
 
-function setMetric(id, value, fmt = (v) => v) {
+function setMetric(id, text, colorCls = "") {
   const el = document.getElementById(id);
-  if (el) el.textContent = value != null ? fmt(value) : "—";
+  if (!el) return;
+  el.textContent = text ?? "—";
+  el.className = ["metric-value", colorCls].filter(Boolean).join(" ");
 }
 
-function colorClass(value, { floor, ceiling } = {}) {
-  if (value == null) return "";
-  if (floor != null && value < floor) return "bad";
-  if (ceiling != null && value > ceiling) return "warn";
-  return "good";
-}
-
-function renderTable(snapshots) {
-  const tbody = document.getElementById("history-body");
-  tbody.innerHTML = "";
-  for (const s of snapshots) {
-    const p50 = s.precision_at_50;
-    const recall = s.recall_at_200;
-    const lead = s.median_lead_days;
-    const uu = s.unknown_unknown_candidates;
-    const known = s.known_positives;
-
-    const row = document.createElement("tr");
-    row.innerHTML = `
-      <td>${s.date}</td>
-      <td class="${colorClass(p50, { floor: 0.25, ceiling: 0.95 })}">${p50 != null ? p50.toFixed(4) : "—"}</td>
-      <td class="${colorClass(recall, { floor: 0.5 })}">${recall != null ? recall.toFixed(4) : "—"}</td>
-      <td>${lead != null ? lead + "d" : "—"}</td>
-      <td>${uu != null ? uu : "—"}</td>
-      <td>${known != null ? known : "—"}</td>
-      <td style="color:#484f58;font-size:0.7rem">${(s.regions || []).join(", ") || "—"}</td>
-    `;
-    tbody.appendChild(row);
-  }
+function setSub(id, text) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = text ?? "";
 }
 
 function mountChart(containerId, chart) {
@@ -141,6 +120,32 @@ function mountChart(containerId, chart) {
   if (!el || !chart) return;
   el.innerHTML = "";
   el.appendChild(chart);
+}
+
+function gatePass(snap) {
+  return snap.precision_at_50 != null && snap.precision_at_50 >= GATE_THRESHOLD;
+}
+
+function renderTable(snapshots) {
+  const tbody = document.getElementById("history-body");
+  tbody.innerHTML = "";
+  for (const s of snapshots) {
+    const pass = gatePass(s);
+    const regions = (s.regions || []).join(", ") || "—";
+    const skipped = (s.skipped_regions || []);
+    const skippedText = skipped.length > 0 ? skipped.join(", ") : "none";
+    const genTime = s.generated_at_utc?.slice(0, 16).replace("T", " ") ?? "—";
+
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${s.date}</td>
+      <td class="${pass ? "good" : "bad"}">${pass ? "PASS" : "FAIL"}</td>
+      <td>${regions}</td>
+      <td class="${skipped.length > 0 ? "bad" : "good"}">${skippedText}</td>
+      <td style="color:#484f58;font-size:0.7rem">${genTime} UTC</td>
+    `;
+    tbody.appendChild(row);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -182,43 +187,54 @@ async function main() {
     return;
   }
 
-  // Sort oldest-first for charts
   snapshots.sort((a, b) => a.date.localeCompare(b.date));
   const latest = snapshots.at(-1);
 
-  // Latest metric values
-  setMetric("val-p50", latest.precision_at_50, (v) => v.toFixed(4));
-  if (latest.precision_at_50_ci_low != null && latest.precision_at_50_ci_high != null) {
-    document.getElementById("sub-p50").textContent =
-      `CI 95%: ${latest.precision_at_50_ci_low.toFixed(3)}–${latest.precision_at_50_ci_high.toFixed(3)} · gate ≥ 0.60`;
-  }
-  setMetric("val-recall", latest.recall_at_200, (v) => v.toFixed(4));
-  setMetric("val-lead", latest.median_lead_days, (v) => `${v}d`);
-  if (latest.pre_designation_count != null) {
-    document.getElementById("sub-lead").textContent =
-      `median · ${latest.pre_designation_count} vessel(s) detected pre-designation`;
-  }
-  setMetric("val-uu", latest.unknown_unknown_candidates);
+  // Pipeline status (regression gate)
+  const pass = gatePass(latest);
+  setMetric("val-gate", pass ? "PASS" : "FAIL", pass ? "good" : "bad");
+  setSub("sub-gate", `regression gate · P@50 ≥ ${GATE_THRESHOLD} · latest: ${latest.precision_at_50?.toFixed(4) ?? "—"}`);
 
-  // Charts
-  mountChart("chart-p50", sparkline(snapshots, "precision_at_50", {
-    color: latest.precision_at_50 >= 0.25 ? "#3fb950" : "#f85149",
+  // Regression gate history as 0/1 sparkline
+  mountChart("chart-gate", sparkline(snapshots, "precision_at_50", {
+    color: pass ? "#3fb950" : "#f85149",
     fmt: (v) => v.toFixed(2),
   }));
-  mountChart("chart-recall", sparkline(snapshots, "recall_at_200", {
-    color: "#58a6ff",
-    fmt: (v) => v.toFixed(2),
-  }));
-  mountChart("chart-lead", sparkline(snapshots, "median_lead_days", {
-    color: "#d2a679",
-    fmt: (v) => `${v}d`,
-  }));
-  mountChart("chart-uu", sparkline(snapshots, "unknown_unknown_candidates", {
-    color: "#bc8cff",
-    fmt: (v) => String(Math.round(v)),
-  }));
 
-  // Table (newest first)
+  // Regions covered
+  const regionCount = (latest.regions || []).length;
+  const totalKnown = 5;
+  const regionColor = regionCount >= totalKnown ? "good" : regionCount > 0 ? "warn" : "bad";
+  setMetric("val-regions", `${regionCount}/${totalKnown}`, regionColor);
+  setSub("sub-regions", (latest.regions || []).join(" · ") || "no regions");
+
+  mountChart("chart-regions", sparkline(
+    snapshots.map((s) => ({ ...s, region_count: (s.regions || []).length })),
+    "region_count",
+    { color: "#58a6ff", fmt: (v) => String(Math.round(v)) },
+  ));
+
+  // Skipped regions
+  const skipped = latest.skipped_regions || [];
+  const skippedColor = skipped.length === 0 ? "good" : "bad";
+  setMetric("val-skipped", String(skipped.length), skippedColor);
+  setSub("sub-skipped", skipped.length > 0 ? `skipped: ${skipped.join(", ")}` : "all regions healthy");
+
+  mountChart("chart-skipped", sparkline(
+    snapshots.map((s) => ({ ...s, skipped_count: (s.skipped_regions || []).length })),
+    "skipped_count",
+    { color: "#f85149", fmt: (v) => String(Math.round(v)) },
+  ));
+
+  // Data freshness
+  if (latest.generated_at_utc) {
+    const genMs = new Date(latest.generated_at_utc).getTime();
+    const hoursAgo = Math.round((Date.now() - genMs) / 3_600_000);
+    const freshnessColor = hoursAgo <= 26 ? "good" : hoursAgo <= 48 ? "warn" : "bad";
+    setMetric("val-freshness", `${hoursAgo}h`, freshnessColor);
+    setSub("sub-freshness", `last run: ${latest.generated_at_utc.slice(0, 16).replace("T", " ")} UTC`);
+  }
+
   renderTable([...snapshots].reverse());
 
   const cached = await navigator.storage.estimate();

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -18,7 +18,7 @@ import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm"
 // ?local serves from ./metrics/ (for local dev — run dev-serve.sh)
 // ?refresh clears OPFS cache and re-fetches from R2
 const _params = new URLSearchParams(location.search);
-const LOCAL_MODE = _params.get("local") === "1" || _params.get("local") === "true";
+const LOCAL_MODE = _params.has("local") || _params.get("local") === "1" || _params.get("local") === "true";
 const FORCE_REFRESH = _params.has("refresh");
 const R2_BASE = LOCAL_MODE ? "." : "https://pub-e088008b61ee432b906ef710d52af28c.r2.dev";
 const INDEX_URL = `${R2_BASE}/metrics/index.json`;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>indago — Metrics Dashboard</title>
+  <title>indago — Pipeline Dashboard</title>
   <script type="module" src="dashboard.js"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -20,13 +20,25 @@
       display: flex;
       align-items: baseline;
       gap: 1rem;
-      margin-bottom: 2rem;
+      margin-bottom: 1rem;
       border-bottom: 1px solid #21262d;
       padding-bottom: 1rem;
     }
 
     header h1 { font-size: 1.2rem; font-weight: 600; color: #e6edf3; }
     header span { font-size: 0.8rem; color: #8b949e; }
+
+    .analyst-link {
+      font-size: 0.75rem;
+      color: #8b949e;
+      margin-bottom: 1.5rem;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #21262d;
+      border-radius: 6px;
+      display: inline-block;
+    }
+    .analyst-link a { color: #58a6ff; text-decoration: none; }
+    .analyst-link a:hover { text-decoration: underline; }
 
     #status {
       font-size: 0.75rem;
@@ -38,7 +50,7 @@
 
     .grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
       gap: 1.5rem;
       margin-bottom: 2rem;
     }
@@ -65,6 +77,9 @@
       color: #e6edf3;
       letter-spacing: -0.02em;
     }
+    .metric-value.good { color: #3fb950; }
+    .metric-value.bad  { color: #f85149; }
+    .metric-value.warn { color: #d29922; }
 
     .metric-sub {
       font-size: 0.75rem;
@@ -115,58 +130,60 @@
 </head>
 <body>
   <header>
-    <h1>indago — Metrics Dashboard</h1>
-    <span>Last 7 days · R2 + OPFS · zero cloud compute</span>
+    <h1>indago — Pipeline Dashboard</h1>
+    <span>Maintainer ops · pipeline health · R2 data freshness</span>
   </header>
+
+  <div class="analyst-link">
+    Analyst product: <a href="https://arktrace.edgesentry.io" target="_blank">arktrace.edgesentry.io</a>
+    — watchlist, SHAP scores, vessel detail, review workflow
+  </div>
 
   <div id="status">Loading…</div>
 
   <div class="grid">
     <div class="card">
-      <h2>Precision @ 50</h2>
-      <div class="metric-value" id="val-p50">—</div>
-      <div class="metric-sub" id="sub-p50">gate ≥ 0.60 · ceiling 0.95</div>
-      <div class="chart-container" id="chart-p50"></div>
+      <h2>Pipeline Status</h2>
+      <div class="metric-value" id="val-gate">—</div>
+      <div class="metric-sub" id="sub-gate">regression gate · P@50 ≥ 0.25</div>
+      <div class="chart-container" id="chart-gate"></div>
     </div>
 
     <div class="card">
-      <h2>Recall @ 200</h2>
-      <div class="metric-value" id="val-recall">—</div>
-      <div class="metric-sub">all known positives reachable in top 200</div>
-      <div class="chart-container" id="chart-recall"></div>
+      <h2>Regions Covered</h2>
+      <div class="metric-value" id="val-regions">—</div>
+      <div class="metric-sub" id="sub-regions">active regions</div>
+      <div class="chart-container" id="chart-regions"></div>
     </div>
 
     <div class="card">
-      <h2>Pre-designation Lead Time</h2>
-      <div class="metric-value" id="val-lead">—</div>
-      <div class="metric-sub" id="sub-lead">days · 60–90 day target</div>
-      <div class="chart-container" id="chart-lead"></div>
+      <h2>Skipped Regions</h2>
+      <div class="metric-value" id="val-skipped">—</div>
+      <div class="metric-sub" id="sub-skipped">0 = all regions healthy</div>
+      <div class="chart-container" id="chart-skipped"></div>
     </div>
 
     <div class="card">
-      <h2>Unknown-Unknown Watch</h2>
-      <div class="metric-value" id="val-uu">—</div>
-      <div class="metric-sub">candidates with no current sanctions link</div>
-      <div class="chart-container" id="chart-uu"></div>
+      <h2>Last Run</h2>
+      <div class="metric-value" id="val-freshness">—</div>
+      <div class="metric-sub" id="sub-freshness">hours since pipeline completed</div>
     </div>
   </div>
 
   <div class="card" style="margin-bottom: 1.5rem;">
-    <h2>Daily Snapshot History</h2>
+    <h2>Daily Run History</h2>
     <table id="history-table">
       <thead>
         <tr>
           <th>Date</th>
-          <th>P@50</th>
-          <th>Recall@200</th>
-          <th>Lead days (median)</th>
-          <th>UU candidates</th>
-          <th>Known positives</th>
-          <th>Source</th>
+          <th>Status</th>
+          <th>Regions</th>
+          <th>Skipped</th>
+          <th>Generated (UTC)</th>
         </tr>
       </thead>
       <tbody id="history-body">
-        <tr><td colspan="7" style="color:#484f58">Loading…</td></tr>
+        <tr><td colspan="5" style="color:#484f58">Loading…</td></tr>
       </tbody>
     </table>
   </div>

--- a/scripts/push_metrics_snapshot.py
+++ b/scripts/push_metrics_snapshot.py
@@ -88,6 +88,8 @@ def _collect_snapshot(date_str: str) -> dict:
         snap.setdefault("auroc", val.get("auroc"))
 
     snap["generated_at_utc"] = datetime.now(UTC).isoformat()
+    snap.setdefault("regions", [])
+    snap.setdefault("skipped_regions", [])
     return snap
 
 

--- a/tests/test_push_metrics_snapshot.py
+++ b/tests/test_push_metrics_snapshot.py
@@ -131,6 +131,80 @@ def test_dry_run_includes_all_keys(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Dashboard contract — fields required by dashboard/dashboard.js
+# ---------------------------------------------------------------------------
+
+# These are the fields the maintainer pipeline dashboard reads.
+# If _collect_snapshot stops producing any of these, the dashboard will
+# silently show "—" for that card. This test makes the contract explicit.
+_DASHBOARD_FIELDS: dict[str, type] = {
+    "regions": list,           # Regions Covered card
+    "skipped_regions": list,   # Skipped Regions card
+    "generated_at_utc": str,   # Last Run (data freshness) card
+    "precision_at_50": float,  # Pipeline Status regression gate (may be None if no backtest)
+}
+
+
+def test_collect_snapshot_dashboard_fields_present(tmp_path, monkeypatch):
+    """Snapshot contains all fields required by the maintainer dashboard."""
+    monkeypatch.chdir(tmp_path)
+    processed = tmp_path / "data" / "processed"
+    processed.mkdir(parents=True)
+    summary = {
+        "metrics_summary": {
+            "precision_at_50": {"mean": 0.356},
+            "recall_at_200": {"mean": 1.0},
+            "auroc": {"mean": 0.87},
+        },
+        "total_known_cases": 89,
+        "regions": ["singapore", "japan"],
+        "skipped_regions": [],
+    }
+    (processed / "backtest_public_integration_summary.json").write_text(json.dumps(summary))
+
+    snap = _collect_snapshot("2026-05-06")
+
+    for field, expected_type in _DASHBOARD_FIELDS.items():
+        assert field in snap, f"dashboard field missing from snapshot: {field!r}"
+        if snap[field] is not None:
+            assert isinstance(snap[field], expected_type), (
+                f"dashboard field {field!r}: expected {expected_type.__name__}, "
+                f"got {type(snap[field]).__name__}"
+            )
+
+
+def test_collect_snapshot_dashboard_fields_without_backtest(tmp_path, monkeypatch):
+    """regions and skipped_regions default to [] when no backtest summary exists."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data" / "processed").mkdir(parents=True)
+
+    snap = _collect_snapshot("2026-05-06")
+
+    assert isinstance(snap.get("regions"), list), "regions must default to a list"
+    assert isinstance(snap.get("skipped_regions"), list), "skipped_regions must default to a list"
+    assert isinstance(snap.get("generated_at_utc"), str), "generated_at_utc must always be present"
+
+
+def test_collect_snapshot_skipped_regions_preserved(tmp_path, monkeypatch):
+    """Skipped regions from backtest summary appear in snapshot for dashboard alert."""
+    monkeypatch.chdir(tmp_path)
+    processed = tmp_path / "data" / "processed"
+    processed.mkdir(parents=True)
+    summary = {
+        "metrics_summary": {"precision_at_50": {"mean": 0.30}},
+        "total_known_cases": 50,
+        "regions": ["singapore", "japan"],
+        "skipped_regions": ["middleeast", "blacksea"],
+    }
+    (processed / "backtest_public_integration_summary.json").write_text(json.dumps(summary))
+
+    snap = _collect_snapshot("2026-05-06")
+
+    assert snap["skipped_regions"] == ["middleeast", "blacksea"]
+    assert snap["regions"] == ["singapore", "japan"]
+
+
+# ---------------------------------------------------------------------------
 # boto3 upload helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Replaces analyst-facing metric cards (P@50, Recall, Lead Time, UU Watch) with pipeline ops cards: **Pipeline Status** (regression gate PASS/FAIL) · **Regions Covered** · **Skipped Regions** · **Last Run** (data freshness)
- Adds `arktrace.edgesentry.io` banner so maintainers know where analyst metrics live
- Updates `README.md`: maintainer audience note + pipeline dashboard section
- Updates `AGENTS.md`: clarus description → "Physical port safety monitoring"

Closes #117

## Test plan
- [ ] Open `dashboard/?local` — verify 4 new ops cards render, no P@50/Recall/Lead/UU cards
- [ ] Verify "PASS" / "FAIL" gate label changes colour correctly (green/red)
- [ ] Verify skipped regions column shows "none" when `skipped_regions: []`
- [ ] Verify arktrace.edgesentry.io link appears in header banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)