### PR TITLE
feat(bca): clarus→documaris BCA aggregation pipeline

### DIFF
--- a/config/launchagents/io.indago.bca-aggregate.plist
+++ b/config/launchagents/io.indago.bca-aggregate.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.indago.bca-aggregate</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_UV_BIN</string>
+    <string>run</string>
+    <string>--project</string>
+    <string>REPLACE_WITH_PROJECT_DIR</string>
+    <string>python</string>
+    <string>REPLACE_WITH_PROJECT_DIR/scripts/aggregate_bca.py</string>
+    <string>--days</string>
+    <string>90</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>REPLACE_WITH_PROJECT_DIR</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>CLARUS_ANALYTICS_URL</key>
+    <string>REPLACE_WITH_CLARUS_ANALYTICS_URL</string>
+    <key>HOME</key>
+    <string>REPLACE_WITH_HOME</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:REPLACE_WITH_HOME/.local/bin:REPLACE_WITH_HOME/.cargo/bin</string>
+    <key>PYTHONUNBUFFERED</key>
+    <string>1</string>
+  </dict>
+
+  <!-- Run daily at 02:00 -->
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>2</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_WITH_HOME/.indago/logs/bca-aggregate.log</string>
+  <key>StandardErrorPath</key>
+  <string>REPLACE_WITH_HOME/.indago/logs/bca-aggregate.err</string>
+</dict>
+</plist>

--- a/pipelines/bca/aggregate.py
+++ b/pipelines/bca/aggregate.py
@@ -1,0 +1,267 @@
+"""BCA Green Mark aggregation pipeline.
+
+Reads clarus audit_chain Parquet from clarus-dev-public-raw, aggregates
+EUI / COP / LPD sensor readings per outlet, and writes bca_outlet_features.parquet
+to documaris-dev-public-analytics.
+
+Data flow:
+    clarus-dev-public-raw / live/{site_id}/audit_chain/*.parquet
+        → aggregate()
+        → documaris-dev-public-analytics / bca/bca_outlet_features.parquet
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+CLARUS_RAW_BUCKET = "clarus-dev-public-raw"
+DOCUMARIS_ANALYTICS_BUCKET = "documaris-dev-public-analytics"
+OUTPUT_KEY = "bca/bca_outlet_features.parquet"
+
+# Maps clarus rule_id → output column name in bca_outlet_features
+RULE_TO_COLUMN: dict[str, str] = {
+    "EUI_PLATINUM_EXCEEDED": "eui_kwh_m2",
+    "CHILLER_COP_EXCEEDED":  "chiller_cop",
+    "LPD_PLATINUM_EXCEEDED": "lpd_w_m2",
+}
+
+# Default value when a metric has no data yet
+_METRIC_DEFAULT = 0.0
+
+_CF_ENDPOINT = "https://b8a0b09feb89390fb6e8cf4ef9294f48.r2.cloudflarestorage.com"
+
+# Clarus analytics app URL — exposes /api/live-index (key listing) and
+# /data/raw/{key} (Parquet download) without requiring R2 credentials.
+# Override with CLARUS_ANALYTICS_URL env var once main branch is redeployed.
+_CLARUS_ANALYTICS_URL = os.getenv(
+    "CLARUS_ANALYTICS_URL",
+    "https://feat-sg-bca-greenmark.clarus-d5d.pages.dev",
+)
+
+
+# ── R2 read helpers (via clarus analytics CF Pages — no credentials needed) ───
+
+def list_audit_chain_keys() -> list[str]:
+    """List audit_chain Parquet keys via the clarus live-index API.
+
+    Calls /api/live-index on the clarus analytics deployment, which uses an
+    R2 binding server-side. No client credentials required.
+    """
+    import httpx
+
+    url = f"{_CLARUS_ANALYTICS_URL}/api/live-index"
+    logger.debug("GET %s", url)
+    resp = httpx.get(url, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    # "alerts" field = audit_chain Parquet keys
+    return sorted(data.get("alerts", []))
+
+
+def read_audit_chain(keys: list[str]) -> pl.DataFrame:
+    """Download and concatenate audit_chain Parquet files via clarus /data/raw/."""
+    import io
+    import httpx
+
+    if not keys:
+        return pl.DataFrame()
+
+    frames: list[pl.DataFrame] = []
+    for key in keys:
+        url = f"{_CLARUS_ANALYTICS_URL}/data/raw/{key}"
+        try:
+            resp = httpx.get(url, timeout=15)
+            resp.raise_for_status()
+            df = pl.read_parquet(io.BytesIO(resp.content))
+            frames.append(df)
+        except Exception as exc:
+            logger.warning("Failed to read %s: %s", key, exc)
+
+    if not frames:
+        return pl.DataFrame()
+    return pl.concat(frames, how="diagonal_relaxed")
+
+
+# ── R2 write helper (wrangler — same approach as clarus edge daemon) ───────────
+
+def _wrangler_put(bucket: str, key: str, src: str) -> None:
+    import subprocess
+
+    result = subprocess.run(
+        [
+            "wrangler", "r2", "object", "put", f"{bucket}/{key}",
+            "--file", src, "--content-type", "application/octet-stream", "--remote",
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"wrangler r2 object put failed for {key}: {result.stderr.strip()}")
+
+
+# ── Aggregation ────────────────────────────────────────────────────────────────
+
+def derive_operator_id(site_id: str) -> str:
+    """Extract operator prefix from site_id.
+
+    'MCH-OUTLET-042' → 'MCH'
+    'ACM-001'        → 'ACM'
+    """
+    return site_id.split("-")[0]
+
+
+def compute_score(alert_count: int) -> float:
+    """Compliance score 0–100. Each alert costs 5 points, minimum 0."""
+    return max(0.0, 100.0 - alert_count * 5.0)
+
+
+def aggregate(df: pl.DataFrame) -> pl.DataFrame:
+    """Aggregate audit_chain events into one row per outlet.
+
+    Input columns expected (from clarus audit_chain Parquet):
+        timestamp_ms, site_id, rule_id, measured_value, threshold,
+        severity, evidence_quality
+
+    Output columns:
+        outlet_id, operator_id, eui_kwh_m2, chiller_cop, lpd_w_m2,
+        alert_count, score, period_start, period_end
+    """
+    if df.is_empty():
+        return pl.DataFrame(schema={
+            "outlet_id":   pl.Utf8,
+            "operator_id": pl.Utf8,
+            "eui_kwh_m2":  pl.Float64,
+            "chiller_cop": pl.Float64,
+            "lpd_w_m2":    pl.Float64,
+            "alert_count": pl.Int32,
+            "score":       pl.Float64,
+            "period_start": pl.Int64,
+            "period_end":   pl.Int64,
+        })
+
+    bca_rules = list(RULE_TO_COLUMN.keys())
+    bca = df.filter(pl.col("rule_id").is_in(bca_rules))
+
+    if bca.is_empty():
+        return pl.DataFrame(schema={
+            "outlet_id":   pl.Utf8,
+            "operator_id": pl.Utf8,
+            "eui_kwh_m2":  pl.Float64,
+            "chiller_cop": pl.Float64,
+            "lpd_w_m2":    pl.Float64,
+            "alert_count": pl.Int32,
+            "score":       pl.Float64,
+            "period_start": pl.Int64,
+            "period_end":   pl.Int64,
+        })
+
+    # Period bounds per site
+    period = bca.group_by("site_id").agg(
+        pl.col("timestamp_ms").min().alias("period_start"),
+        pl.col("timestamp_ms").max().alias("period_end"),
+        pl.len().alias("alert_count"),
+    )
+
+    # Latest measured_value per (site_id, rule_id)
+    latest = (
+        bca.sort("timestamp_ms", descending=True)
+        .group_by(["site_id", "rule_id"])
+        .first()
+        .select(["site_id", "rule_id", "measured_value"])
+    )
+
+    # Pivot: one column per rule_id value (columns named by rule_id)
+    pivoted = latest.pivot(
+        on="rule_id",
+        index="site_id",
+        values="measured_value",
+        aggregate_function="first",
+    )
+
+    # Rename rule_id columns → metric column names, then fill any missing metrics
+    rename_map = {rule: col for rule, col in RULE_TO_COLUMN.items() if rule in pivoted.columns}
+    if rename_map:
+        pivoted = pivoted.rename(rename_map)
+    for col in RULE_TO_COLUMN.values():
+        if col not in pivoted.columns:
+            pivoted = pivoted.with_columns(pl.lit(_METRIC_DEFAULT).cast(pl.Float64).alias(col))
+
+    # Join period info
+    result = pivoted.join(period, on="site_id", how="left")
+
+    # Add derived columns
+    result = result.with_columns([
+        pl.col("site_id").alias("outlet_id"),
+        pl.col("site_id").map_elements(derive_operator_id, return_dtype=pl.Utf8).alias("operator_id"),
+        pl.col("alert_count").cast(pl.Int32),
+        pl.col("eui_kwh_m2").cast(pl.Float64).fill_null(_METRIC_DEFAULT),
+        pl.col("chiller_cop").cast(pl.Float64).fill_null(_METRIC_DEFAULT),
+        pl.col("lpd_w_m2").cast(pl.Float64).fill_null(_METRIC_DEFAULT),
+    ]).with_columns(
+        pl.col("alert_count").map_elements(compute_score, return_dtype=pl.Float64).alias("score"),
+    ).select([
+        "outlet_id", "operator_id",
+        "eui_kwh_m2", "chiller_cop", "lpd_w_m2",
+        "alert_count", "score",
+        "period_start", "period_end",
+    ])
+
+    return result
+
+
+def write_features(df: pl.DataFrame, bucket: str = DOCUMARIS_ANALYTICS_BUCKET) -> None:
+    """Write aggregated features to documaris-dev-public-analytics R2 via wrangler."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        tmp = f.name
+    try:
+        df.write_parquet(tmp)
+        _wrangler_put(bucket, OUTPUT_KEY, tmp)
+        logger.info("Wrote %d outlet(s) → %s/%s", len(df), bucket, OUTPUT_KEY)
+    finally:
+        os.unlink(tmp)
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+def run(dry_run: bool = False) -> pl.DataFrame:
+    """Full pipeline: read clarus → aggregate → write documaris.
+
+    Args:
+        dry_run: If True, skip the R2 write and return the DataFrame only.
+
+    Returns:
+        Aggregated bca_outlet_features DataFrame.
+    """
+    logger.info("Listing audit_chain keys via %s…", _CLARUS_ANALYTICS_URL)
+    keys = list_audit_chain_keys()
+    logger.info("Found %d audit_chain file(s)", len(keys))
+
+    if not keys:
+        logger.warning("No audit_chain data found — nothing to aggregate")
+        return pl.DataFrame()
+
+    logger.info("Reading %d file(s)…", len(keys))
+    raw = read_audit_chain(keys)
+    logger.info("Loaded %d event(s) total", len(raw))
+
+    features = aggregate(raw)
+    logger.info("Aggregated %d outlet(s)", len(features))
+
+    if not dry_run:
+        write_features(features)
+    else:
+        logger.info("Dry run — skipping R2 write")
+
+    return features

--- a/pipelines/bca/aggregate.py
+++ b/pipelines/bca/aggregate.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -123,6 +124,14 @@ def derive_operator_id(site_id: str) -> str:
 def compute_score(alert_count: int) -> float:
     """Compliance score 0–100. Each alert costs 5 points, minimum 0."""
     return max(0.0, 100.0 - alert_count * 5.0)
+
+
+def filter_window(df: pl.DataFrame, days: int) -> pl.DataFrame:
+    """Retain only rows within the past `days` days."""
+    if df.is_empty() or days <= 0:
+        return df
+    cutoff_ms = int((time.time() - days * 86_400) * 1_000)
+    return df.filter(pl.col("timestamp_ms") >= cutoff_ms)
 
 
 def aggregate(df: pl.DataFrame) -> pl.DataFrame:
@@ -235,11 +244,13 @@ def write_features(df: pl.DataFrame, bucket: str = DOCUMARIS_ANALYTICS_BUCKET) -
 
 # ── Entry point ────────────────────────────────────────────────────────────────
 
-def run(dry_run: bool = False) -> pl.DataFrame:
+def run(dry_run: bool = False, days: int = 90) -> pl.DataFrame:
     """Full pipeline: read clarus → aggregate → write documaris.
 
     Args:
         dry_run: If True, skip the R2 write and return the DataFrame only.
+        days:    Retention window — only events within the past N days are
+                 included. Default 90. Pass 0 to include all history.
 
     Returns:
         Aggregated bca_outlet_features DataFrame.
@@ -255,6 +266,10 @@ def run(dry_run: bool = False) -> pl.DataFrame:
     logger.info("Reading %d file(s)…", len(keys))
     raw = read_audit_chain(keys)
     logger.info("Loaded %d event(s) total", len(raw))
+
+    if days > 0:
+        raw = filter_window(raw, days)
+        logger.info("After %d-day window: %d event(s)", days, len(raw))
 
     features = aggregate(raw)
     logger.info("Aggregated %d outlet(s)", len(features))

--- a/pipelines/bca/aggregate.py
+++ b/pipelines/bca/aggregate.py
@@ -40,8 +40,6 @@ RULE_TO_COLUMN: dict[str, str] = {
 # Default value when a metric has no data yet
 _METRIC_DEFAULT = 0.0
 
-_CF_ENDPOINT = "https://b8a0b09feb89390fb6e8cf4ef9294f48.r2.cloudflarestorage.com"
-
 # Clarus analytics app URL — exposes /api/live-index (key listing) and
 # /data/raw/{key} (Parquet download) without requiring R2 credentials.
 # Override with CLARUS_ANALYTICS_URL env var once main branch is redeployed.

--- a/scripts/aggregate_bca.py
+++ b/scripts/aggregate_bca.py
@@ -27,6 +27,7 @@ load_dotenv()
 def main() -> None:
     parser = argparse.ArgumentParser(description="BCA Green Mark aggregation pipeline")
     parser.add_argument("--dry-run", action="store_true", help="Skip R2 write, print result only")
+    parser.add_argument("--days", type=int, default=90, help="Retention window in days (default 90, 0=all)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Debug logging")
     args = parser.parse_args()
 
@@ -40,7 +41,7 @@ def main() -> None:
 
     from pipelines.bca.aggregate import run
 
-    features = run(dry_run=args.dry_run)
+    features = run(dry_run=args.dry_run, days=args.days)
 
     if features.is_empty():
         logging.warning("No BCA outlet features generated")

--- a/scripts/aggregate_bca.py
+++ b/scripts/aggregate_bca.py
@@ -1,0 +1,54 @@
+"""CLI: aggregate clarus BCA audit_chain data → documaris outlet features.
+
+Usage
+-----
+  uv run python scripts/aggregate_bca.py            # live R2 run
+  uv run python scripts/aggregate_bca.py --dry-run  # print result, skip write
+  uv run python scripts/aggregate_bca.py --verbose  # debug logging
+
+Environment
+-----------
+  AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY — Cloudflare R2 credentials
+  S3_ENDPOINT                               — override R2 endpoint (optional)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="BCA Green Mark aggregation pipeline")
+    parser.add_argument("--dry-run", action="store_true", help="Skip R2 write, print result only")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if not os.getenv("AWS_ACCESS_KEY_ID"):
+        logging.warning("AWS_ACCESS_KEY_ID not set — R2 reads/writes will fail unless the bucket is public")
+
+    from pipelines.bca.aggregate import run
+
+    features = run(dry_run=args.dry_run)
+
+    if features.is_empty():
+        logging.warning("No BCA outlet features generated")
+        sys.exit(1)
+
+    print(features)
+    print(f"\n{len(features)} outlet(s) aggregated")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_launchagents.sh
+++ b/scripts/install_launchagents.sh
@@ -26,6 +26,7 @@ AISSTREAM_API_KEY="${AISSTREAM_API_KEY:-}"
 AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
 AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
 S3_BUCKET="${S3_BUCKET:-indago-public}"
+CLARUS_ANALYTICS_URL="${CLARUS_ANALYTICS_URL:-https://clarus.edgesentry.io}"
 
 # ---------------------------------------------------------------------------
 # Parse arguments
@@ -64,6 +65,7 @@ install_agent() {
     -e "s|REPLACE_WITH_AWS_ACCESS_KEY_ID|${AWS_ACCESS_KEY_ID}|g" \
     -e "s|REPLACE_WITH_AWS_SECRET_ACCESS_KEY|${AWS_SECRET_ACCESS_KEY}|g" \
     -e "s|REPLACE_WITH_S3_BUCKET|${S3_BUCKET}|g" \
+    -e "s|REPLACE_WITH_CLARUS_ANALYTICS_URL|${CLARUS_ANALYTICS_URL}|g" \
     -e "s|REPLACE_WITH_PROJECT_DIR|$REPO_DIR|g" \
     -e "s|REPLACE_WITH_UV_BIN|$UV_BIN|g" \
     -e "s|REPLACE_WITH_HOME|$HOME|g" \
@@ -93,6 +95,8 @@ if [[ $UNLOAD -eq 0 ]] && [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
 else
   install_agent "io.indago.r2sync"
 fi
+
+install_agent "io.indago.bca-aggregate"
 
 echo ""
 echo "Done."

--- a/tests/test_bca_aggregate.py
+++ b/tests/test_bca_aggregate.py
@@ -1,0 +1,184 @@
+"""Unit tests for BCA aggregation pipeline (pipelines/bca/aggregate.py).
+
+All tests run without R2 access — pure function tests on in-memory DataFrames.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from pipelines.bca.aggregate import (
+    RULE_TO_COLUMN,
+    aggregate,
+    compute_score,
+    derive_operator_id,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def make_audit_chain(rows: list[dict]) -> pl.DataFrame:
+    """Build a minimal audit_chain DataFrame matching the clarus schema."""
+    schema = {
+        "timestamp_ms":     pl.Int64,
+        "site_id":          pl.Utf8,
+        "rule_id":          pl.Utf8,
+        "measured_value":   pl.Float64,
+        "threshold":        pl.Float64,
+        "severity":         pl.Utf8,
+        "evidence_quality": pl.Utf8,
+    }
+    return pl.DataFrame(rows, schema=schema)
+
+
+# ── derive_operator_id ─────────────────────────────────────────────────────────
+
+def test_derive_operator_id_standard():
+    assert derive_operator_id("MCH-OUTLET-042") == "MCH"
+
+
+def test_derive_operator_id_short():
+    assert derive_operator_id("ACM-001") == "ACM"
+
+
+def test_derive_operator_id_no_separator():
+    assert derive_operator_id("SITEONLY") == "SITEONLY"
+
+
+# ── compute_score ──────────────────────────────────────────────────────────────
+
+def test_compute_score_zero_alerts():
+    assert compute_score(0) == 100.0
+
+
+def test_compute_score_one_alert():
+    assert compute_score(1) == 95.0
+
+
+def test_compute_score_clamps_to_zero():
+    assert compute_score(100) == 0.0
+    assert compute_score(999) == 0.0
+
+
+def test_compute_score_twenty_alerts():
+    assert compute_score(20) == 0.0
+
+
+# ── aggregate ─────────────────────────────────────────────────────────────────
+
+def test_aggregate_empty_returns_correct_schema():
+    result = aggregate(pl.DataFrame())
+    assert result.is_empty()
+    assert "outlet_id" in result.columns
+    assert "score" in result.columns
+
+
+def test_aggregate_no_bca_rules_returns_empty():
+    df = make_audit_chain([{
+        "timestamp_ms": 1_000, "site_id": "MCH-OUTLET-042",
+        "rule_id": "RESTRICTED_ZONE_APPROACH", "measured_value": 3.0,
+        "threshold": 5.0, "severity": "High", "evidence_quality": "Certified",
+    }])
+    result = aggregate(df)
+    assert result.is_empty()
+
+
+def test_aggregate_single_outlet_single_rule():
+    df = make_audit_chain([
+        {"timestamp_ms": 1_000, "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 120.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+    ])
+    result = aggregate(df)
+    assert len(result) == 1
+    row = result.row(0, named=True)
+    assert row["outlet_id"] == "MCH-OUTLET-042"
+    assert row["operator_id"] == "MCH"
+    assert abs(row["eui_kwh_m2"] - 120.0) < 1e-6
+    assert row["alert_count"] == 1
+    assert row["score"] == 95.0
+
+
+def test_aggregate_latest_value_wins():
+    df = make_audit_chain([
+        {"timestamp_ms": 1_000, "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 118.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+        {"timestamp_ms": 2_000, "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 122.5,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+    ])
+    result = aggregate(df)
+    row = result.row(0, named=True)
+    assert abs(row["eui_kwh_m2"] - 122.5) < 1e-6
+
+
+def test_aggregate_all_three_metrics():
+    df = make_audit_chain([
+        {"timestamp_ms": 1_000, "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 120.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+        {"timestamp_ms": 1_001, "site_id": "MCH-OUTLET-042",
+         "rule_id": "CHILLER_COP_EXCEEDED", "measured_value": 0.67,
+         "threshold": 0.65, "severity": "High", "evidence_quality": "Certified"},
+        {"timestamp_ms": 1_002, "site_id": "MCH-OUTLET-042",
+         "rule_id": "LPD_PLATINUM_EXCEEDED", "measured_value": 15.8,
+         "threshold": 15.0, "severity": "High", "evidence_quality": "Certified"},
+    ])
+    result = aggregate(df)
+    row = result.row(0, named=True)
+    assert abs(row["eui_kwh_m2"] - 120.0) < 1e-6
+    assert abs(row["chiller_cop"] - 0.67) < 1e-6
+    assert abs(row["lpd_w_m2"] - 15.8) < 1e-6
+    assert row["alert_count"] == 3
+    assert row["score"] == 85.0
+
+
+def test_aggregate_multiple_outlets():
+    df = make_audit_chain([
+        {"timestamp_ms": 1_000, "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 120.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+        {"timestamp_ms": 2_000, "site_id": "MCH-OUTLET-043",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 117.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+    ])
+    result = aggregate(df)
+    assert len(result) == 2
+    outlet_ids = set(result["outlet_id"].to_list())
+    assert outlet_ids == {"MCH-OUTLET-042", "MCH-OUTLET-043"}
+
+
+def test_aggregate_period_bounds():
+    df = make_audit_chain([
+        {"timestamp_ms": 1_000, "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 120.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+        {"timestamp_ms": 5_000, "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 121.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+    ])
+    result = aggregate(df)
+    row = result.row(0, named=True)
+    assert row["period_start"] == 1_000
+    assert row["period_end"] == 5_000
+
+
+def test_aggregate_output_columns():
+    df = make_audit_chain([{
+        "timestamp_ms": 1_000, "site_id": "ACM-001",
+        "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 118.0,
+        "threshold": 115.0, "severity": "High", "evidence_quality": "Certified",
+    }])
+    result = aggregate(df)
+    expected = {"outlet_id", "operator_id", "eui_kwh_m2", "chiller_cop",
+                "lpd_w_m2", "alert_count", "score", "period_start", "period_end"}
+    assert set(result.columns) == expected
+
+
+def test_rule_to_column_mapping_complete():
+    assert set(RULE_TO_COLUMN.keys()) == {
+        "EUI_PLATINUM_EXCEEDED", "CHILLER_COP_EXCEEDED", "LPD_PLATINUM_EXCEEDED"
+    }
+    assert set(RULE_TO_COLUMN.values()) == {"eui_kwh_m2", "chiller_cop", "lpd_w_m2"}

--- a/tests/test_bca_aggregate.py
+++ b/tests/test_bca_aggregate.py
@@ -177,6 +177,43 @@ def test_aggregate_output_columns():
     assert set(result.columns) == expected
 
 
+def test_filter_window_removes_old_events():
+    from pipelines.bca.aggregate import filter_window
+    import time
+
+    now_ms = int(time.time() * 1000)
+    old_ms = now_ms - 91 * 86_400_000  # 91 days ago
+    recent_ms = now_ms - 1 * 86_400_000  # 1 day ago
+
+    df = make_audit_chain([
+        {"timestamp_ms": old_ms,    "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 120.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+        {"timestamp_ms": recent_ms, "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 118.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+    ])
+    result = filter_window(df, days=90)
+    assert len(result) == 1
+    assert result["timestamp_ms"][0] == recent_ms
+
+
+def test_filter_window_zero_days_returns_all():
+    from pipelines.bca.aggregate import filter_window
+    import time
+
+    now_ms = int(time.time() * 1000)
+    old_ms = now_ms - 365 * 86_400_000
+
+    df = make_audit_chain([
+        {"timestamp_ms": old_ms, "site_id": "MCH-OUTLET-042",
+         "rule_id": "EUI_PLATINUM_EXCEEDED", "measured_value": 120.0,
+         "threshold": 115.0, "severity": "High", "evidence_quality": "Certified"},
+    ])
+    result = filter_window(df, days=0)
+    assert len(result) == 1
+
+
 def test_rule_to_column_mapping_complete():
     assert set(RULE_TO_COLUMN.keys()) == {
         "EUI_PLATINUM_EXCEEDED", "CHILLER_COP_EXCEEDED", "LPD_PLATINUM_EXCEEDED"

--- a/tests/test_bca_aggregate.py
+++ b/tests/test_bca_aggregate.py
@@ -6,7 +6,6 @@ All tests run without R2 access — pure function tests on in-memory DataFrames.
 from __future__ import annotations
 
 import polars as pl
-import pytest
 
 from pipelines.bca.aggregate import (
     RULE_TO_COLUMN,


### PR DESCRIPTION
Closes #121

## Summary

Implements the indago BCA aggregation pipeline connecting clarus edge data to the documaris BCA portfolio view.

**Data flow:**
```
clarus-dev-public-raw / live/{site_id}/audit_chain/*.parquet
    → pipelines/bca/aggregate.py (this PR)
    → documaris-dev-public-analytics / bca/bca_outlet_features.parquet
    → documaris /bca portfolio view
```

## What's added

- `pipelines/bca/aggregate.py` — core pipeline: list keys, read Parquet, aggregate per outlet, write to documaris R2
- `scripts/aggregate_bca.py` — CLI entry point (`uv run python scripts/aggregate_bca.py [--dry-run]`)
- `tests/test_bca_aggregate.py` — 16 unit tests (pure logic, no R2 access)

## Key design decisions

- **Reading**: uses clarus analytics `/api/live-index` + `/data/raw/{key}` endpoints via httpx — no R2 credentials needed for reads (CF Pages function proxies R2 with its binding)
- **Writing**: wrangler subprocess to `documaris-dev-public-analytics` — same pattern as clarus edge daemon
- **Aggregation**: latest `measured_value` per rule per outlet; `score = max(0, 100 - alert_count * 5)`
- `CLARUS_ANALYTICS_URL` env var to switch between feature branch and production once main is redeployed

## Verified

Ran against real clarus data (114 audit_chain files):
```
outlet_id       operator_id  eui_kwh_m2  chiller_cop  lpd_w_m2  alert_count  score
MCH-OUTLET-042  MCH          115.2       0.70         0.0       114          0.0
```
Successfully wrote to `documaris-dev-public-analytics/bca/bca_outlet_features.parquet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)