### PR TITLE
fix(clarus-rollup): always pass ?all=1 to live-index

### DIFF
--- a/pipelines/clarus/live_rollup.py
+++ b/pipelines/clarus/live_rollup.py
@@ -37,14 +37,16 @@ _CLARUS_ANALYTICS_URL = os.getenv(
 # ── Fetch helpers (same pattern as bca/aggregate.py) ──────────────────────────
 
 def _fetch_live_index(days: int) -> dict:
-    """Fetch live-index keys with server-side time filter baked in.
+    """Fetch raw live-index keys with server-side time filter.
 
-    Passing ?days=N tells live-index.js to exclude keys whose filename
-    timestamp is older than N days — so we never even list stale files.
+    Always passes ?all=1 so live-index returns raw files (not rollup files).
+    The rollup job reads raw files to produce the rollup — it must not read
+    its own output. ?days=N applies the time-window filter server-side so
+    stale files are never downloaded.
     Pass days=0 for all history.
     """
     import httpx
-    params = f"all=1&days={days}" if days <= 0 else f"days={days}"
+    params = "all=1" if days <= 0 else f"all=1&days={days}"
     url = f"{_CLARUS_ANALYTICS_URL}/api/live-index?{params}"
     logger.debug("GET %s", url)
     resp = httpx.get(url, timeout=30)


### PR DESCRIPTION
Fixes the GitHub Actions failure: https://github.com/edgesentry/indago/actions/runs/25581652946/job/75101693830

## Root cause

`_fetch_live_index(days=90)` sent `?days=90` without `?all=1`. When rollup files exist, `live-index.js` returns them instead of raw files. `_load_keys_by_site` requires 4 path segments (`live/{site}/{table}/{ts}.parquet`) but rollup files have 3 (`rollup/{site}/{table}.parquet`) — all keys were silently skipped → `Sites: []` → exit 1.

## Fix

Always pass `?all=1&days=N` — raw files only, time-window filter applied server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)