### PR TITLE
fix(r2sync): re-upload past 7 days to overwrite stale AIS sentinels

### DIFF
--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1227,9 +1227,15 @@ def cmd_push_ais_parquet(args: argparse.Namespace) -> int:
                         existing_r2.add(part.removeprefix("date="))
         except Exception:
             pass
-        # Always re-upload today's partition: the rotator may have uploaded an
-        # empty sentinel earlier in the day before it had visited this region.
-        existing_r2.discard(today_str)
+        # Always re-upload the past 7 days: the rotator cycles through regions
+        # and may have uploaded empty sentinels before a region's slot ran.
+        # Re-uploading the rolling window ensures stale sentinels get replaced.
+        from datetime import timedelta as _timedelta
+        recent = {
+            (_datetime.now(_UTC) - _timedelta(days=i)).date().isoformat()
+            for i in range(7)
+        }
+        existing_r2 -= recent
         to_upload = [d for d in dates if d not in existing_r2]
         # If today has no rows yet, upload an empty sentinel so validation
         # can confirm the pipeline ran for this region.

--- a/tests/test_sync_r2_ais_parquet.py
+++ b/tests/test_sync_r2_ais_parquet.py
@@ -168,17 +168,22 @@ class TestPushAisParquet:
         sentinel_keys = [k for k, rows in written_keys if f"date={today}" in k and rows == 0]
         assert len(sentinel_keys) == 1, f"expected 1 sentinel, got {written_keys}"
 
-    def test_overwrites_today_even_if_sentinel_already_in_r2(self, tmp_path):
-        """push-ais-parquet re-uploads today's partition even when R2 already has it.
+    def test_overwrites_recent_days_even_if_sentinel_already_in_r2(self, tmp_path):
+        """push-ais-parquet re-uploads the past 7 days even when R2 already has them.
 
         Reproduces the rotator race: sentinel uploaded before the region's slot ran,
         then real data arrived — the next r2sync run must overwrite the sentinel.
+        Also verifies that data from 3 days ago is re-uploaded (not just today).
         """
         from datetime import UTC, datetime, timedelta
 
         import duckdb
 
-        today_str = datetime.now(UTC).date().isoformat()
+        now = datetime.now(UTC)
+        today_str = now.date().isoformat()
+        ts_old = now - timedelta(days=3, hours=1)
+        old_date_str = ts_old.date().isoformat()
+
         db = tmp_path / "singapore.duckdb"
         con = duckdb.connect(str(db))
         con.execute("""
@@ -187,18 +192,20 @@ class TestPushAisParquet:
                 sog FLOAT, cog FLOAT, nav_status TINYINT, ship_type TINYINT
             )
         """)
-        # Insert a row dated today so the DB has today's data
-        con.execute(
-            "INSERT INTO ais_positions VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ["123456789", datetime.now(UTC) - timedelta(minutes=30), 1.3, 103.8, 12.0, 180.0, 0, 70],
-        )
+        for ts in [now - timedelta(minutes=30), ts_old]:
+            con.execute(
+                "INSERT INTO ais_positions VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                ["123456789", ts, 1.3, 103.8, 12.0, 180.0, 0, 70],
+            )
         con.close()
 
         mock_fs = MagicMock()
-        # Simulate R2 already having today's sentinel (0-row file uploaded earlier)
-        existing_info = MagicMock()
-        existing_info.path = f"maridb-public/ais/region=singapore/date={today_str}/positions.parquet"
-        mock_fs.get_file_info.return_value = [existing_info]
+        # R2 already has both dates as empty sentinels from earlier runs
+        def make_info(date_str):
+            m = MagicMock()
+            m.path = f"maridb-public/ais/region=singapore/date={date_str}/positions.parquet"
+            return m
+        mock_fs.get_file_info.return_value = [make_info(today_str), make_info(old_date_str)]
 
         written_keys = []
 
@@ -217,9 +224,10 @@ class TestPushAisParquet:
             rc = sync_r2.cmd_push_ais_parquet(args)
 
         assert rc == 0
-        today_uploads = [(k, rows) for k, rows in written_keys if f"date={today_str}" in k]
-        assert len(today_uploads) == 1, f"expected exactly 1 today upload, got {written_keys}"
-        assert today_uploads[0][1] == 1, "expected real data (1 row), not empty sentinel"
+        for date_str in [today_str, old_date_str]:
+            uploads = [(k, rows) for k, rows in written_keys if f"date={date_str}" in k]
+            assert len(uploads) == 1, f"expected 1 upload for {date_str}, got {written_keys}"
+            assert uploads[0][1] == 1, f"expected real data for {date_str}, got sentinel"
 
     def test_uploads_sentinel_when_today_missing_from_r2(self, tmp_path):
         """push-ais-parquet uploads empty sentinel for today even if DB has older rows."""


### PR DESCRIPTION
Extends #126 (today-only) to a rolling 7-day window.

## Problem

The rotator (`--max-slots 3`) cycles through all 10 regions spending 1h per slot. When r2sync runs, some regions haven't been visited in the past several days, so their R2 partitions still hold the empty sentinels that were uploaded before real data arrived. The today-only fix (#126) didn't cover partitions that went stale 1–6 days ago.

Observed: japansea/singapore/blacksea/middleeast showing 0 rows in the daily validation report for multiple past days.

## Fix

```python
recent = {
    (_datetime.now(_UTC) - _timedelta(days=i)).date().isoformat()
    for i in range(7)
}
existing_r2 -= recent  # always re-upload last 7 days
```

Historical partitions (8+ days old) are still uploaded once and skipped on subsequent runs — no change there.

## Test

`test_overwrites_recent_days_even_if_sentinel_already_in_r2`: DB has rows for today and 3 days ago, R2 already has both as empty sentinels → both are re-uploaded with real row counts.

## Already deployed locally

Triggered via `launchctl kickstart -k gui/.../io.indago.r2sync` — blacksea, europe and others already re-uploaded 6 days of real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)