### PR TITLE
chore(ci): disable hourly schedule for clarus live rollup

### DIFF
--- a/.github/workflows/clarus-live-rollup.yml
+++ b/.github/workflows/clarus-live-rollup.yml
@@ -8,8 +8,6 @@ name: clarus live rollup
 #   - Manual dispatch
 
 on:
-  schedule:
-    - cron: "0 * * * *"   # every hour
   workflow_dispatch:
     inputs:
       days:


### PR DESCRIPTION
disabled the hourly schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)