### PR TITLE
fix(ais): disable persiangulf region — no aisstream.io coverage

### DIFF
--- a/scripts/ais_rotate.py
+++ b/scripts/ais_rotate.py
@@ -29,7 +29,7 @@ REGIONS: list[tuple[str, list[float]]] = [
     ("blacksea",     [40,  27,  48,  42]),
     ("europe",       [35, -10,  65,  30]),
     ("middleeast",   [10,  32,  32,  62]),
-    ("persiangulf",  [20,  48,  30,  65]),
+    # ("persiangulf",  [20,  48,  30,  65]),  # disabled: aisstream.io has no coverage here
     ("gulfofguinea", [-5,  -5,  10,  10]),
     ("gulfofaden",   [10,  42,  16,  52]),
     ("gulfofmexico", [18, -98,  31, -80]),


### PR DESCRIPTION
## Problem

`persiangulf` bbox `[20,48,30,65]` (lat 20–30°N, lon 48–65°E) has returned **0 records for 8+ days** despite successful WebSocket connections to aisstream.io. The stream connects and subscribes correctly but the provider simply has no AIS receiver coverage for this area.

## Fix

Comment out the persiangulf entry in `REGIONS` list. This frees up one rotation slot for the remaining 9 active regions, improving their refresh frequency.

## Overlap

`middleeast` (lat 10–32°N, lon 32–62°E) already covers the Persian Gulf area, so no screening coverage is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)