### PR TITLE
fix(test): update regions count 10 → 9 after persiangulf disable

### DIFF
--- a/tests/test_ais_rotate.py
+++ b/tests/test_ais_rotate.py
@@ -12,7 +12,7 @@ from scripts.ais_rotate import REGIONS, rotate
 # ---------------------------------------------------------------------------
 
 def test_regions_count():
-    assert len(REGIONS) == 10
+    assert len(REGIONS) == 9  # persiangulf disabled (aisstream.io has no coverage)
 
 
 def test_regions_unique_names():


### PR DESCRIPTION
Fixes the test broken by #139.

`test_regions_count` was asserting `len(REGIONS) == 10` but persiangulf was disabled in #139, making it 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)