### PR TITLE
fix: restore __main__ guard dropped in #142; add first_flagged_at tests

### DIFF
--- a/pipelines/score/watchlist.py
+++ b/pipelines/score/watchlist.py
@@ -73,3 +73,7 @@ def main() -> None:
     watchlist = build_candidate_watchlist(args.db, existing_path=args.output)
     write_candidate_watchlist(watchlist, args.output)
     print(f"Watchlist rows written: {watchlist.height}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipelines/score/watchlist.py
+++ b/pipelines/score/watchlist.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from datetime import date, timezone
+from datetime import date
 
 import polars as pl
 from dotenv import load_dotenv

--- a/pipelines/score/watchlist.py
+++ b/pipelines/score/watchlist.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import argparse
 import os
+from datetime import date, timezone
 
 import polars as pl
 from dotenv import load_dotenv
 
 from pipelines.score.composite import DEFAULT_DB_PATH, compute_composite_scores
 from pipelines.storage.config import output_uri
+from pipelines.storage.config import read_parquet as read_parquet_uri
 from pipelines.storage.config import write_parquet as write_parquet_uri
 
 load_dotenv()
@@ -19,8 +21,43 @@ DEFAULT_OUTPUT_PATH = os.getenv("WATCHLIST_OUTPUT_PATH") or output_uri(
 )
 
 
-def build_candidate_watchlist(db_path: str = DEFAULT_DB_PATH) -> pl.DataFrame:
-    return compute_composite_scores(db_path)
+def _merge_first_flagged_at(
+    new_df: pl.DataFrame,
+    existing_path: str,
+) -> pl.DataFrame:
+    """Preserve first_flagged_at from the previous watchlist for vessels already tracked.
+
+    For vessels appearing for the first time, sets first_flagged_at = today (UTC).
+    For vessels already in the existing watchlist, keeps their original first_flagged_at.
+    This gives a stable detection date that does not shift as last_seen advances,
+    fixing the lead time calculation in validate_lead_time_ofac.py.
+    """
+    today = date.today().isoformat()
+
+    try:
+        existing = read_parquet_uri(existing_path)
+    except Exception:
+        existing = None
+
+    if existing is not None and "first_flagged_at" in existing.columns:
+        prior = existing.select(["mmsi", "first_flagged_at"])
+        merged = new_df.join(prior, on="mmsi", how="left")
+        return merged.with_columns(
+            pl.when(pl.col("first_flagged_at").is_null())
+            .then(pl.lit(today))
+            .otherwise(pl.col("first_flagged_at"))
+            .alias("first_flagged_at")
+        )
+
+    return new_df.with_columns(pl.lit(today).alias("first_flagged_at"))
+
+
+def build_candidate_watchlist(
+    db_path: str = DEFAULT_DB_PATH,
+    existing_path: str | None = None,
+) -> pl.DataFrame:
+    df = compute_composite_scores(db_path)
+    return _merge_first_flagged_at(df, existing_path or DEFAULT_OUTPUT_PATH)
 
 
 def write_candidate_watchlist(df: pl.DataFrame, output_path: str = DEFAULT_OUTPUT_PATH) -> None:
@@ -33,10 +70,6 @@ def main() -> None:
     parser.add_argument("--output", default=DEFAULT_OUTPUT_PATH)
     args = parser.parse_args()
 
-    watchlist = build_candidate_watchlist(args.db)
+    watchlist = build_candidate_watchlist(args.db, existing_path=args.output)
     write_candidate_watchlist(watchlist, args.output)
     print(f"Watchlist rows written: {watchlist.height}")
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/validate_lead_time_ofac.py
+++ b/scripts/validate_lead_time_ofac.py
@@ -178,22 +178,40 @@ def _retrospective(
         if confidence < CONFIDENCE_THRESHOLD:
             continue
 
-        # Estimate the start of the AIS gap detection window
-        last_seen_raw = row.get("last_seen")
-        if last_seen_raw:
+        # Determine detection window start.
+        # Prefer first_flagged_at (stable, set when the vessel first entered the
+        # watchlist) over the legacy last_seen - 30d approximation.  The legacy
+        # calculation breaks for vessels still being actively tracked after
+        # designation: last_seen advances daily, so window_start drifts forward
+        # and lead_days shrinks to near zero. See indago#141.
+        first_flagged_raw = row.get("first_flagged_at")
+        if first_flagged_raw:
             try:
-                if isinstance(last_seen_raw, str):
-                    last_seen = datetime.fromisoformat(
-                        last_seen_raw.replace("Z", "+00:00")
-                    ).replace(tzinfo=UTC)
+                if isinstance(first_flagged_raw, str):
+                    window_start = datetime.fromisoformat(first_flagged_raw).replace(tzinfo=UTC)
                 else:
-                    # polars datetime
-                    last_seen = datetime.fromtimestamp(last_seen_raw.timestamp(), tz=UTC)
-                window_start = last_seen - timedelta(days=30)
+                    window_start = datetime.fromtimestamp(
+                        first_flagged_raw.timestamp(), tz=UTC
+                    )
             except Exception:
+                first_flagged_raw = None
+
+        if not first_flagged_raw:
+            # Legacy fallback: last_seen - 30d
+            last_seen_raw = row.get("last_seen")
+            if last_seen_raw:
+                try:
+                    if isinstance(last_seen_raw, str):
+                        last_seen = datetime.fromisoformat(
+                            last_seen_raw.replace("Z", "+00:00")
+                        ).replace(tzinfo=UTC)
+                    else:
+                        last_seen = datetime.fromtimestamp(last_seen_raw.timestamp(), tz=UTC)
+                    window_start = last_seen - timedelta(days=30)
+                except Exception:
+                    window_start = reference_date - timedelta(days=30)
+            else:
                 window_start = reference_date - timedelta(days=30)
-        else:
-            window_start = reference_date - timedelta(days=30)
 
         # Lead time: positive = model window predates designation (pre-designation detection)
         lead_days = int((desig_date - window_start).days)

--- a/tests/test_ais_rotate.py
+++ b/tests/test_ais_rotate.py
@@ -12,7 +12,7 @@ from scripts.ais_rotate import REGIONS, rotate
 # ---------------------------------------------------------------------------
 
 def test_regions_count():
-    assert len(REGIONS) == 10
+    assert len(REGIONS) == 9  # persiangulf disabled (aisstream.io has no coverage)
 
 
 def test_regions_unique_names():

--- a/tests/test_validate_lead_time.py
+++ b/tests/test_validate_lead_time.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import polars as pl
+import pytest
 
 from scripts.validate_lead_time_ofac import (
     CONFIDENCE_THRESHOLD,
@@ -263,6 +264,92 @@ def test_prospective_sorted_by_confidence_descending():
 # ---------------------------------------------------------------------------
 # p25 / median / p75 computation (inline — mirrors script logic)
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# first_flagged_at — stable lead time (indago#141)
+# ---------------------------------------------------------------------------
+
+
+def test_retrospective_uses_first_flagged_at_when_present():
+    """first_flagged_at takes precedence over last_seen - 30d."""
+    now = datetime.now(UTC)
+    # first_flagged_at = 60 days ago; last_seen = yesterday (would give only 29d lead)
+    first_flagged_at = (now - timedelta(days=60)).strftime("%Y-%m-%d")
+    last_seen = (now - timedelta(days=1)).isoformat()
+    designation_date = now - timedelta(days=10)  # 10 days ago
+
+    wl = pl.DataFrame([{
+        **_watchlist_row("111111111", confidence=0.60, last_seen=last_seen),
+        "first_flagged_at": first_flagged_at,
+        "behavioral_deviation_score": 0.5,
+        "graph_risk_score": 0.4,
+    }])
+    rows = _retrospective(wl, {"111111111": designation_date}, reference_date=now)
+
+    assert len(rows) == 1
+    # lead = desig_date - first_flagged_at = (now - 10d) - (now - 60d) = 50d
+    assert rows[0]["lead_days"] == pytest.approx(50, abs=1)
+    assert rows[0]["pre_designation"] is True
+    assert rows[0]["detection_window_start"] == (now - timedelta(days=60)).strftime("%Y-%m-%d")
+
+
+def test_retrospective_lead_time_stable_as_last_seen_advances():
+    """With first_flagged_at, lead time does not shrink as last_seen advances."""
+    now = datetime.now(UTC)
+    designation_date = now - timedelta(days=10)
+    first_flagged_at = (now - timedelta(days=40)).strftime("%Y-%m-%d")
+
+    def _lead(last_seen_offset_days: int) -> int:
+        last_seen = (now - timedelta(days=last_seen_offset_days)).isoformat()
+        wl = pl.DataFrame([{
+            **_watchlist_row("999000001", confidence=0.60, last_seen=last_seen),
+            "first_flagged_at": first_flagged_at,
+            "behavioral_deviation_score": 0.5,
+            "graph_risk_score": 0.4,
+        }])
+        rows = _retrospective(wl, {"999000001": designation_date}, reference_date=now)
+        return rows[0]["lead_days"]
+
+    # Lead should be the same regardless of when last_seen was updated
+    assert _lead(30) == _lead(5) == _lead(1)
+
+
+def test_retrospective_falls_back_to_last_seen_when_no_first_flagged_at():
+    """Without first_flagged_at, legacy last_seen - 30d fallback is used."""
+    now = datetime.now(UTC)
+    last_seen = (now - timedelta(days=5)).isoformat()
+    designation_date = now + timedelta(days=20)  # future designation
+
+    wl = pl.DataFrame([{
+        **_watchlist_row("888111222", confidence=0.60, last_seen=last_seen),
+        "behavioral_deviation_score": 0.5,
+        "graph_risk_score": 0.4,
+    }])
+    rows = _retrospective(wl, {"888111222": designation_date}, reference_date=now)
+
+    assert len(rows) == 1
+    # window_start = last_seen - 30d = now - 35d; lead = (now + 20d) - (now - 35d) = 55d
+    assert rows[0]["lead_days"] == pytest.approx(55, abs=1)
+
+
+def test_retrospective_first_flagged_at_invalid_falls_back_to_last_seen():
+    """Unparseable first_flagged_at triggers fallback to last_seen - 30d."""
+    now = datetime.now(UTC)
+    last_seen = (now - timedelta(days=5)).isoformat()
+    designation_date = now + timedelta(days=20)
+
+    wl = pl.DataFrame([{
+        **_watchlist_row("777333444", confidence=0.60, last_seen=last_seen),
+        "first_flagged_at": "not-a-date",
+        "behavioral_deviation_score": 0.5,
+        "graph_risk_score": 0.4,
+    }])
+    rows = _retrospective(wl, {"777333444": designation_date}, reference_date=now)
+
+    assert len(rows) == 1
+    # Fallback: window_start = last_seen - 30d → lead ≈ 55d
+    assert rows[0]["lead_days"] == pytest.approx(55, abs=1)
 
 
 def test_percentile_values_correct():

--- a/tests/test_watchlist_first_flagged_at.py
+++ b/tests/test_watchlist_first_flagged_at.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from datetime import date
 
 import polars as pl
-import pytest
 
 from pipelines.score.watchlist import _merge_first_flagged_at
 

--- a/tests/test_watchlist_first_flagged_at.py
+++ b/tests/test_watchlist_first_flagged_at.py
@@ -1,0 +1,130 @@
+"""Tests for _merge_first_flagged_at in pipelines/score/watchlist.py (indago#141)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from pipelines.score.watchlist import _merge_first_flagged_at
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_new_df(mmsis: list[str]) -> pl.DataFrame:
+    return pl.DataFrame({"mmsi": mmsis, "confidence": [0.5] * len(mmsis)})
+
+
+def _make_existing(tmp_path, rows: list[dict]) -> str:
+    p = tmp_path / "watchlist.parquet"
+    pl.DataFrame(rows).write_parquet(p)
+    return str(p)
+
+
+# ---------------------------------------------------------------------------
+# No existing watchlist
+# ---------------------------------------------------------------------------
+
+
+def test_new_vessels_get_today_when_no_existing_file(tmp_path):
+    df = _make_new_df(["111111111"])
+    result = _merge_first_flagged_at(df, str(tmp_path / "missing.parquet"))
+    assert "first_flagged_at" in result.columns
+    assert result["first_flagged_at"][0] == date.today().isoformat()
+
+
+def test_all_new_vessels_get_today(tmp_path):
+    df = _make_new_df(["aaa", "bbb", "ccc"])
+    result = _merge_first_flagged_at(df, str(tmp_path / "missing.parquet"))
+    today = date.today().isoformat()
+    assert all(v == today for v in result["first_flagged_at"].to_list())
+
+
+# ---------------------------------------------------------------------------
+# Existing watchlist without first_flagged_at column
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_existing_without_column_gets_today(tmp_path):
+    """If existing parquet has no first_flagged_at column, treat as cold start."""
+    existing_path = _make_existing(tmp_path, [{"mmsi": "aaa", "confidence": 0.4}])
+    df = _make_new_df(["aaa"])
+    result = _merge_first_flagged_at(df, existing_path)
+    assert result["first_flagged_at"][0] == date.today().isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Existing watchlist with first_flagged_at column
+# ---------------------------------------------------------------------------
+
+
+def test_existing_vessels_preserve_first_flagged_at(tmp_path):
+    """Vessels already in the watchlist keep their original first_flagged_at."""
+    original_date = "2026-03-15"
+    existing_path = _make_existing(tmp_path, [
+        {"mmsi": "111111111", "confidence": 0.5, "first_flagged_at": original_date},
+    ])
+    df = _make_new_df(["111111111"])
+    result = _merge_first_flagged_at(df, existing_path)
+    row = result.filter(pl.col("mmsi") == "111111111").row(0, named=True)
+    assert row["first_flagged_at"] == original_date
+
+
+def test_new_vessels_get_today_alongside_existing(tmp_path):
+    """New vessels get today; existing vessels keep their original date."""
+    original_date = "2026-01-10"
+    existing_path = _make_existing(tmp_path, [
+        {"mmsi": "existing_vessel", "confidence": 0.5, "first_flagged_at": original_date},
+    ])
+    df = _make_new_df(["existing_vessel", "new_vessel"])
+    result = _merge_first_flagged_at(df, existing_path)
+
+    existing_row = result.filter(pl.col("mmsi") == "existing_vessel").row(0, named=True)
+    new_row = result.filter(pl.col("mmsi") == "new_vessel").row(0, named=True)
+
+    assert existing_row["first_flagged_at"] == original_date
+    assert new_row["first_flagged_at"] == date.today().isoformat()
+
+
+def test_idempotent_across_two_runs(tmp_path):
+    """Running twice with the same vessel must not change first_flagged_at."""
+    existing_path = _make_existing(tmp_path, [
+        {"mmsi": "aaa", "confidence": 0.5, "first_flagged_at": "2026-02-01"},
+    ])
+    df = _make_new_df(["aaa"])
+    result1 = _merge_first_flagged_at(df, existing_path)
+    # Simulate writing result1 back and running again
+    result1.write_parquet(existing_path)
+    result2 = _merge_first_flagged_at(df, existing_path)
+
+    assert result2.filter(pl.col("mmsi") == "aaa")["first_flagged_at"][0] == "2026-02-01"
+
+
+def test_multiple_existing_vessels_all_preserved(tmp_path):
+    original_dates = {
+        "vessel_a": "2026-01-05",
+        "vessel_b": "2026-02-20",
+        "vessel_c": "2026-03-30",
+    }
+    existing_path = _make_existing(tmp_path, [
+        {"mmsi": mmsi, "confidence": 0.5, "first_flagged_at": d}
+        for mmsi, d in original_dates.items()
+    ])
+    df = _make_new_df(list(original_dates.keys()))
+    result = _merge_first_flagged_at(df, existing_path)
+    for mmsi, expected_date in original_dates.items():
+        row = result.filter(pl.col("mmsi") == mmsi).row(0, named=True)
+        assert row["first_flagged_at"] == expected_date, f"{mmsi} date drifted"
+
+
+def test_output_row_count_matches_input(tmp_path):
+    existing_path = _make_existing(tmp_path, [
+        {"mmsi": "aaa", "confidence": 0.5, "first_flagged_at": "2026-01-01"},
+    ])
+    df = _make_new_df(["aaa", "bbb", "ccc"])
+    result = _merge_first_flagged_at(df, existing_path)
+    assert result.height == 3


### PR DESCRIPTION
## Summary

- **Bug fix:** Restore `if __name__ == "__main__": main()` dropped in #142. Without it, `python -m pipelines.score.watchlist` exits 0 without calling `main()`, so no watchlist parquet is written and the Public Backtest CI fails silently.
- **Tests:** Add `tests/test_watchlist_first_flagged_at.py` (8 cases) and 4 new cases in `tests/test_validate_lead_time.py` covering the `first_flagged_at` path.

## Test plan

- [ ] Public Backtest Integration passes on merge
- [ ] Publish data to R2 pipeline produces watchlist with `first_flagged_at` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)