### PR TITLE
fix: invoke watchlist via -c to survive missing __main__ guard

### DIFF
--- a/pipelines/score/watchlist.py
+++ b/pipelines/score/watchlist.py
@@ -73,3 +73,7 @@ def main() -> None:
     watchlist = build_candidate_watchlist(args.db, existing_path=args.output)
     write_candidate_watchlist(watchlist, args.output)
     print(f"Watchlist rows written: {watchlist.height}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -327,7 +327,8 @@ def step_score(region: RegionConfig) -> bool:
         ([sys.executable, "-m", "pipelines.score.mpol_baseline", "--db", region.db_path], "mpol_baseline"),
         ([sys.executable, "-m", "pipelines.score.anomaly", "--db", region.db_path], "anomaly"),
         ([sys.executable, "-m", "pipelines.score.composite", "--db", region.db_path], "composite"),
-        ([sys.executable, "-m", "pipelines.score.watchlist",
+        ([sys.executable, "-c",
+          "from pipelines.score.watchlist import main; main()",
           "--db", region.db_path,
           "--output", watchlist_out], "watchlist"),
     ]


### PR DESCRIPTION
## Summary

- `run_pipeline.py` now calls `python -c "from pipelines.score.watchlist import main; main()"` instead of `python -m pipelines.score.watchlist`. The `-c` form calls `main()` directly so it works regardless of whether the `__main__` guard is present in the module (the guard was dropped during squash merge of #143).
- Also restores `if __name__ == "__main__": main()` in `watchlist.py` for direct CLI invocations.

Fixes the Public Backtest Integration regression introduced in #142/#143.

## Test plan

- [ ] Public Backtest Integration passes on merge
- [ ] `python -m pipelines.score.watchlist --db ... --output ...` still works (guard restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)