### PR TITLE
feat: add lead time trend to email and dashboard

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -134,6 +134,43 @@ function trendChart(snapshots, { width = 560 } = {}) {
   });
 }
 
+function leadTimeTrendChart(snapshots, { width = 560 } = {}) {
+  const data = snapshots
+    .filter((s) => s.mean_lead_days != null)
+    .map((s) => ({
+      date: new Date(s.date),
+      mean: +s.mean_lead_days,
+      median: s.median_lead_days != null ? +s.median_lead_days : null,
+    }));
+
+  if (data.length === 0) return null;
+
+  const marks = [
+    Plot.lineY(data, { x: "date", y: "mean", stroke: "#bc8cff", strokeWidth: 2 }),
+    Plot.dotY(data, { x: "date", y: "mean", fill: "#bc8cff", r: 3 }),
+  ];
+  if (data.some((d) => d.median != null)) {
+    marks.push(
+      Plot.lineY(data.filter((d) => d.median != null), {
+        x: "date", y: "median", stroke: "#bc8cff", strokeWidth: 1.5, strokeDasharray: "4,3",
+      })
+    );
+  }
+
+  return Plot.plot({
+    width,
+    height: 140,
+    marginLeft: 40,
+    marginRight: 8,
+    marginTop: 8,
+    marginBottom: 28,
+    style: { background: "transparent", color: "#8b949e", fontSize: "11px" },
+    x: { type: "time", label: null, tickFormat: "%m/%d" },
+    y: { label: null, tickFormat: (v) => `${v}d`, ticks: 4 },
+    marks,
+  });
+}
+
 function knownPositivesChart(snapshots, { width = 560 } = {}) {
   const data = snapshots
     .filter((s) => s.known_positives != null)
@@ -322,6 +359,26 @@ async function main() {
   setMetric("val-kp-trend", kpLatest ?? "—");
   setSub("sub-kp-trend", kpDeltaStr || "OFAC-matched watchlist positives");
   mountChart("chart-kp-trend", knownPositivesChart(snapshots));
+
+  // Lead time trend
+  const ltLatest = latest.mean_lead_days;
+  const ltPrev = snapshots.length >= 2 ? snapshots.at(-2)?.mean_lead_days : null;
+  const ltDelta = ltLatest != null && ltPrev != null ? ltLatest - ltPrev : null;
+  const ltDeltaStr = ltDelta != null
+    ? `${ltDelta >= 0 ? "+" : ""}${ltDelta.toFixed(1)}d vs prev day`
+    : "";
+  const medianLatest = latest.median_lead_days;
+  const preDesigCount = latest.pre_designation_count;
+  const p25Latest = latest.p25_lead_days;
+  const p75Latest = latest.p75_lead_days;
+  setMetric("val-lt-trend", ltLatest != null ? `${ltLatest.toFixed(1)}d` : "—");
+  setSub("sub-lt-trend", [
+    ltDeltaStr || "mean lead days",
+    medianLatest != null ? `median ${medianLatest.toFixed(0)}d` : "",
+    p25Latest != null && p75Latest != null ? `p25–p75: ${p25Latest.toFixed(0)}–${p75Latest.toFixed(0)}d` : "",
+    preDesigCount != null ? `${preDesigCount} vessels` : "",
+  ].filter(Boolean).join(" · "));
+  mountChart("chart-lt-trend", leadTimeTrendChart(snapshots));
 
   renderTable([...snapshots].reverse());
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -184,6 +184,13 @@
       <div class="metric-sub" id="sub-kp-trend">OFAC-matched watchlist positives</div>
       <div class="chart-container" id="chart-kp-trend" style="min-height:160px"></div>
     </div>
+
+    <div class="card">
+      <h2>Lead Time — Pre-Designation Detection</h2>
+      <div class="metric-value" id="val-lt-trend">—</div>
+      <div class="metric-sub" id="sub-lt-trend">mean days before OFAC/EU listing (dashed = median)</div>
+      <div class="chart-container" id="chart-lt-trend" style="min-height:160px"></div>
+    </div>
   </div>
 
   <div class="card" style="margin-bottom: 1.5rem;">

--- a/scripts/notify_metrics.py
+++ b/scripts/notify_metrics.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 _REPORT_PATH = Path("data/processed/backtest_public_integration_summary.json")
 _TREND_PATH = Path("data/processed/metrics_trend.json")
+_LEAD_TIME_PATH = Path("data/processed/lead_time_report.json")
 _REGRESSION_THRESHOLD = 0.01  # #507: lowered from 0.02 — catches single-step drops like 0.27→0.26
 
 
@@ -59,6 +60,14 @@ def _load_trend() -> dict:
     """Return trend data from metrics_trend.json written by push_metrics_snapshot.py."""
     try:
         return json.loads(_TREND_PATH.read_text())
+    except Exception:
+        return {}
+
+
+def _load_lead_time() -> dict:
+    """Return lead time report produced by validate_lead_time_ofac.py."""
+    try:
+        return json.loads(_LEAD_TIME_PATH.read_text())
     except Exception:
         return {}
 
@@ -92,6 +101,15 @@ def _format_body(
     trend_prev_p50: float | None = prev_p50 or trend.get("prev_p50")
     trend_p50_7d: float | None = trend.get("p50_7d_ago")
     trend_prev_positives: int | None = trend.get("prev_known_positives")
+
+    lead = _load_lead_time()
+    mean_lead: float | None = lead.get("mean_lead_days")
+    median_lead: float | None = lead.get("median_lead_days")
+    p25_lead: float | None = lead.get("p25_lead_days")
+    p75_lead: float | None = lead.get("p75_lead_days")
+    pre_desig_count: int | None = lead.get("pre_designation_count")
+    prev_mean_lead: float | None = trend.get("prev_mean_lead_days")
+    prev_median_lead: float | None = trend.get("prev_median_lead_days")
 
     regression = trend_prev_p50 is not None and (trend_prev_p50 - p50) > _REGRESSION_THRESHOLD
     improvement = trend_prev_p50 is not None and (p50 - trend_prev_p50) > _REGRESSION_THRESHOLD
@@ -160,6 +178,33 @@ def _format_body(
     <td></td>
   </tr>
 </table>
+
+{f"""
+<h3>Lead Time — Pre-Designation Detection</h3>
+<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse">
+  <tr><th>Metric</th><th>Value</th><th>vs prev day</th></tr>
+  <tr>
+    <td>Pre-designation detections</td>
+    <td><strong>{pre_desig_count if pre_desig_count is not None else "—"}</strong></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Mean lead time</td>
+    <td><strong>{f"{mean_lead:.1f} days" if mean_lead is not None else "—"}</strong></td>
+    <td>{_delta_str(mean_lead, prev_mean_lead, ".1f") if mean_lead is not None else ""}</td>
+  </tr>
+  <tr>
+    <td>Median lead time</td>
+    <td>{f"{median_lead:.1f} days" if median_lead is not None else "—"}</td>
+    <td>{_delta_str(median_lead, prev_median_lead, ".1f") if median_lead is not None else ""}</td>
+  </tr>
+  <tr>
+    <td>p25 / p75</td>
+    <td>{f"{p25_lead:.0f} / {p75_lead:.0f} days" if p25_lead is not None and p75_lead is not None else "—"}</td>
+    <td></td>
+  </tr>
+</table>
+""" if pre_desig_count is not None or mean_lead is not None else ""}
 
 <h3>Per-Region Coverage</h3>
 <table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse">

--- a/scripts/push_metrics_snapshot.py
+++ b/scripts/push_metrics_snapshot.py
@@ -205,6 +205,9 @@ def main() -> None:
             prev_snap = json.loads(prev_obj["Body"].read().decode())
             trend["prev_p50"] = prev_snap.get("precision_at_50")
             trend["prev_known_positives"] = prev_snap.get("known_positives")
+            trend["prev_mean_lead_days"] = prev_snap.get("mean_lead_days")
+            trend["prev_median_lead_days"] = prev_snap.get("median_lead_days")
+            trend["prev_pre_designation_count"] = prev_snap.get("pre_designation_count")
             trend["prev_date"] = prev_snap.get("date")
         except Exception as exc:
             print(


### PR DESCRIPTION
## Summary

- **Email (`notify_metrics.py`):** New "Lead Time — Pre-Designation Detection" section with pre-designation count, mean / median / p25 / p75 days, and ↑/↓ vs previous day
- **Dashboard (`dashboard.js` + `index.html`):** New "Lead Time" card — mean lead days (solid line) + median (dashed), sub-text shows p25–p75 range and vessel count; reads `mean_lead_days` / `median_lead_days` already stored in R2 daily snapshots
- **Snapshot trend (`push_metrics_snapshot.py`):** Now writes `prev_mean_lead_days`, `prev_median_lead_days`, `prev_pre_designation_count` to `metrics_trend.json` so the email can show prev-day deltas

Lead time is per-vessel (each vessel flagged before designation has its own lead time). Showing mean + median + p25/p75 gives the full distribution rather than a single number.

## Test plan

- [ ] Trigger Publish data to R2 — verify email includes Lead Time section
- [ ] Open indago.edgesentry.io — verify Lead Time card appears with trend chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)