### PR TITLE
fix: skip first_flagged_at when it post-dates designation; None for empty lead stats

### DIFF
--- a/scripts/validate_lead_time_ofac.py
+++ b/scripts/validate_lead_time_ofac.py
@@ -185,18 +185,25 @@ def _retrospective(
         # designation: last_seen advances daily, so window_start drifts forward
         # and lead_days shrinks to near zero. See indago#141.
         first_flagged_raw = row.get("first_flagged_at")
+        window_start = None
         if first_flagged_raw:
             try:
                 if isinstance(first_flagged_raw, str):
-                    window_start = datetime.fromisoformat(first_flagged_raw).replace(tzinfo=UTC)
+                    candidate = datetime.fromisoformat(first_flagged_raw).replace(tzinfo=UTC)
                 else:
-                    window_start = datetime.fromtimestamp(
+                    candidate = datetime.fromtimestamp(
                         first_flagged_raw.timestamp(), tz=UTC
                     )
+                # Only use first_flagged_at when it predates the designation date.
+                # If first_flagged_at >= desig_date the field was initialised after
+                # the vessel was already sanctioned (bootstrap run on 2026-05-16),
+                # so it cannot serve as a pre-designation detection timestamp.
+                if candidate < desig_date:
+                    window_start = candidate
             except Exception:
-                first_flagged_raw = None
+                pass
 
-        if not first_flagged_raw:
+        if window_start is None:
             # Legacy fallback: last_seen - 30d
             last_seen_raw = row.get("last_seen")
             if last_seen_raw:
@@ -413,10 +420,10 @@ def main() -> None:
     n_pre = len(pre_desig)
     lead_days_pre = sorted([r["lead_days"] for r in pre_desig])
     n = len(lead_days_pre)
-    mean_lead = int(sum(lead_days_pre) / n) if n else 0
-    median_lead = lead_days_pre[n // 2] if n else 0
-    p25_lead = lead_days_pre[n // 4] if n else 0
-    p75_lead = lead_days_pre[(3 * n) // 4] if n else 0
+    mean_lead = int(sum(lead_days_pre) / n) if n else None
+    median_lead = lead_days_pre[n // 2] if n else None
+    p25_lead = lead_days_pre[n // 4] if n else None
+    p75_lead = lead_days_pre[(3 * n) // 4] if n else None
     print(f"  Matched to designation dates : {n_matched}")
     print(f"  Pre-designation detections   : {n_pre} / {n_matched}")
     print(f"  Mean lead time (pre-desig)   : {mean_lead} days")

--- a/tests/test_validate_lead_time.py
+++ b/tests/test_validate_lead_time.py
@@ -352,6 +352,35 @@ def test_retrospective_first_flagged_at_invalid_falls_back_to_last_seen():
     assert rows[0]["lead_days"] == pytest.approx(55, abs=1)
 
 
+def test_retrospective_first_flagged_at_after_designation_falls_back():
+    """first_flagged_at >= designation_date means bootstrap init after sanction — fall back to last_seen - 30d.
+
+    This happens when first_flagged_at was set on the first pipeline run that
+    introduced the field (2026-05-16), but the vessel was already designated
+    before that date. Using first_flagged_at would give a negative lead time,
+    so we fall back to last_seen - 30d.
+    """
+    now = datetime.now(UTC)
+    designation_date = now - timedelta(days=30)  # designated 30 days ago
+    # first_flagged_at set to today (bootstrap), which is AFTER designation
+    first_flagged_at = now.strftime("%Y-%m-%d")
+    # last_seen 65 days ago → window_start = last_seen - 30d = 95 days ago → lead = 65d
+    last_seen = (now - timedelta(days=65)).isoformat()
+
+    wl = pl.DataFrame([{
+        **_watchlist_row("bootstrap001", confidence=0.60, last_seen=last_seen),
+        "first_flagged_at": first_flagged_at,
+        "behavioral_deviation_score": 0.5,
+        "graph_risk_score": 0.4,
+    }])
+    rows = _retrospective(wl, {"bootstrap001": designation_date}, reference_date=now)
+
+    assert len(rows) == 1
+    # Must NOT use first_flagged_at (would give -30d); must fall back to last_seen - 30d
+    assert rows[0]["pre_designation"] is True
+    assert rows[0]["lead_days"] == pytest.approx(65, abs=1)
+
+
 def test_percentile_values_correct():
     lead_days = sorted([10, 20, 30, 40, 50, 60, 70, 80])
     n = len(lead_days)


### PR DESCRIPTION
## Problem

First pipeline run after `first_flagged_at` was introduced (2026-05-16) set all existing vessels to `first_flagged_at = today`. For the 6 case-study vessels with OFAC designation dates in April 2026, this made `first_flagged_at > designation_date`, giving negative lead times → `pre_designation_count = 0`, `mean_lead_days = 0.0` in the email.

## Fix

- `validate_lead_time_ofac.py`: only use `first_flagged_at` when it strictly predates the designation date; fall back to `last_seen − 30d` otherwise
- Change `mean/median/p25/p75` to `None` (not `0`) when no pre-designation detections exist, so the email shows `—` instead of `0.0 days`
- New test: `test_retrospective_first_flagged_at_after_designation_falls_back`

## Test plan
- [ ] Lead Time Validation step shows non-zero mean/median after merge
- [ ] Email shows `—` if genuinely 0 pre-designation detections

🤖 Generated with [Claude Code](https://claude.com/claude-code)