### PR TITLE
fix: backfill first_flagged_at for 6 bootstrap vessels in existing pipeline

### DIFF
--- a/pipelines/score/watchlist.py
+++ b/pipelines/score/watchlist.py
@@ -20,6 +20,41 @@ DEFAULT_OUTPUT_PATH = os.getenv("WATCHLIST_OUTPUT_PATH") or output_uri(
     "candidate_watchlist.parquet"
 )
 
+# Authoritative first-detection dates for vessels whose first_flagged_at was
+# incorrectly initialised to the bootstrap date (2026-05-16) because the field
+# did not exist when they first entered the watchlist.
+# Values are detection_window_start from the static snapshot of 2026-05-06,
+# derived as: designation_date - lead_days (indago#141).
+_FIRST_FLAGGED_OVERRIDES: dict[str, str] = {
+    "314189000": "2026-03-21",  # Bangus  — OFAC 2026-04-24, lead 34d
+    "352179000": "2026-03-17",  # Horae   — OFAC+EU 2026-04-15, lead 29d
+    "352001906": "2026-03-17",  # Anaya   — OFAC+EU 2026-04-15, lead 29d
+    "352002243": "2026-03-23",  # Anika   — OFAC+EU 2026-04-15, lead 23d
+    "352001849": "2026-03-24",  # Bellaris — OFAC+EU 2026-04-15, lead 22d
+    "352001907": "2026-03-24",  # Versa   — OFAC+EU 2026-04-15, lead 22d
+}
+
+# Any first_flagged_at on or after this date was set during the bootstrap run
+# and should be replaced with the override value if one exists.
+_BOOTSTRAP_DATE = "2026-05-16"
+
+
+def _apply_overrides(df: pl.DataFrame) -> pl.DataFrame:
+    """Replace bootstrap-era first_flagged_at with known correct detection dates."""
+    if "first_flagged_at" not in df.columns or not _FIRST_FLAGGED_OVERRIDES:
+        return df
+    return df.with_columns(
+        pl.struct(["mmsi", "first_flagged_at"]).map_elements(
+            lambda r: (
+                _FIRST_FLAGGED_OVERRIDES[r["mmsi"]]
+                if r["mmsi"] in _FIRST_FLAGGED_OVERRIDES
+                and (r["first_flagged_at"] or "") >= _BOOTSTRAP_DATE
+                else r["first_flagged_at"]
+            ),
+            return_dtype=pl.Utf8,
+        ).alias("first_flagged_at")
+    )
+
 
 def _merge_first_flagged_at(
     new_df: pl.DataFrame,
@@ -42,14 +77,15 @@ def _merge_first_flagged_at(
     if existing is not None and "first_flagged_at" in existing.columns:
         prior = existing.select(["mmsi", "first_flagged_at"])
         merged = new_df.join(prior, on="mmsi", how="left")
-        return merged.with_columns(
+        result = merged.with_columns(
             pl.when(pl.col("first_flagged_at").is_null())
             .then(pl.lit(today))
             .otherwise(pl.col("first_flagged_at"))
             .alias("first_flagged_at")
         )
+        return _apply_overrides(result)
 
-    return new_df.with_columns(pl.lit(today).alias("first_flagged_at"))
+    return _apply_overrides(new_df.with_columns(pl.lit(today).alias("first_flagged_at")))
 
 
 def build_candidate_watchlist(

--- a/tests/test_watchlist_first_flagged_at.py
+++ b/tests/test_watchlist_first_flagged_at.py
@@ -120,6 +120,45 @@ def test_multiple_existing_vessels_all_preserved(tmp_path):
         assert row["first_flagged_at"] == expected_date, f"{mmsi} date drifted"
 
 
+# ---------------------------------------------------------------------------
+# Bootstrap override (_FIRST_FLAGGED_OVERRIDES)
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_override_applied_on_first_run(tmp_path):
+    """Known vessels get correct first_flagged_at even on bootstrap (no existing file)."""
+    df = _make_new_df(["314189000"])  # Bangus
+    result = _merge_first_flagged_at(df, str(tmp_path / "missing.parquet"))
+    assert result["first_flagged_at"][0] == "2026-03-21"
+
+
+def test_bootstrap_override_corrects_bootstrap_date(tmp_path):
+    """Bootstrap date (2026-05-16) is replaced with the authoritative value."""
+    existing_path = _make_existing(tmp_path, [
+        {"mmsi": "314189000", "confidence": 0.5, "first_flagged_at": "2026-05-16"},
+    ])
+    df = _make_new_df(["314189000"])
+    result = _merge_first_flagged_at(df, existing_path)
+    assert result["first_flagged_at"][0] == "2026-03-21"
+
+
+def test_bootstrap_override_does_not_overwrite_earlier_date(tmp_path):
+    """If first_flagged_at is already earlier than bootstrap, keep it."""
+    existing_path = _make_existing(tmp_path, [
+        {"mmsi": "314189000", "confidence": 0.5, "first_flagged_at": "2026-02-01"},
+    ])
+    df = _make_new_df(["314189000"])
+    result = _merge_first_flagged_at(df, existing_path)
+    assert result["first_flagged_at"][0] == "2026-02-01"
+
+
+def test_bootstrap_override_non_override_vessel_unaffected(tmp_path):
+    """Vessels not in the override dict get today's date as normal."""
+    df = _make_new_df(["999999999"])
+    result = _merge_first_flagged_at(df, str(tmp_path / "missing.parquet"))
+    assert result["first_flagged_at"][0] == date.today().isoformat()
+
+
 def test_output_row_count_matches_input(tmp_path):
     existing_path = _make_existing(tmp_path, [
         {"mmsi": "aaa", "confidence": 0.5, "first_flagged_at": "2026-01-01"},


### PR DESCRIPTION
## Problem

The lead time trend chart shows a daily downward drift (~1 day/day) because:
1. `first_flagged_at` was initialised to `2026-05-16` for all existing vessels on the first pipeline run that introduced the field
2. For the 6 case-study vessels already designated in April 2026, `first_flagged_at >= designation_date` → falls back to `last_seen − 30d`
3. `last_seen` advances daily → `window_start` drifts forward → `lead_days` shrinks each day

## Fix

Add `_FIRST_FLAGGED_OVERRIDES` dict in `watchlist.py` mapping the 6 vessel MMSIs to their authoritative detection dates from the 2026-05-06 static snapshot (`detection_window_start = designation_date − lead_days`).

`_apply_overrides()` replaces any `first_flagged_at >= 2026-05-16` with the correct value **on every existing pipeline run** — no one-off migration, no schema change.

After merge, the next Publish data to R2 run will write corrected parquets. Lead time trend will stabilise at the historical values (Bangus 34d, Horae/Anaya 29d, Anika 23d, Bellaris/Versa 22d).

## Test plan
- [ ] Merge + trigger Publish data to R2
- [ ] Lead time email shows mean ~26d, median ~29d (not drifting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)