### PR TITLE
feat(#148): ownership_chain in watchlists + push-arktrace validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,16 @@ All buckets: unauthenticated public read. See [docs/ref-r2-buckets.md](docs/ref-
 | Symptom | Owner | Where |
 |---------|-------|-------|
 | Empty arktrace dashboard | indago pipeline not run / R2 not synced | `scripts/sync_r2.py` |
+| arktrace Ownership chain empty | watchlist missing `ownership_chain` column | re-run scoring + `sync_r2.py push-arktrace` |
+
+## arktrace dashboard publish
+
+Watchlists for [arktrace](https://arktrace.edgesentry.io) are **plain Parquet** under `arktrace-public/score/`, not DuckLake.
+
+1. `pipelines/score/watchlist.py` / `compute_composite_scores()` — must include `ownership_chain` (indago#148).
+2. `uv run python scripts/sync_r2.py push-arktrace --data-dir data/processed` — uploads `*_watchlist.parquet` + `manifest.json` / `ducklake_manifest.json`.
+
+Do **not** use `push-ducklake-public` for the browser app; that path is legacy DuckLake catalog storage only.
 | documaris vessel selector empty | `documaris-public` bucket not populated | `scripts/sync_r2.py` |
 | Score regression after model change | Check `check_score_regression.py` output | `scripts/check_score_regression.py` |
 | AIS validation failure | AIS stream or rotation issue | `scripts/validate_ais_upload.py` |

--- a/pipelines/features/ownership_graph.py
+++ b/pipelines/features/ownership_graph.py
@@ -11,6 +11,7 @@ Usage:
     uv run python src/features/ownership_graph.py
 """
 
+import json
 import os
 
 import duckdb
@@ -319,6 +320,166 @@ def _apply_direct_sanctions_fallback(sd_df: pl.DataFrame, db_path: str) -> pl.Da
         .otherwise(pl.col("sanctions_distance"))
         .alias("sanctions_distance")
     )
+
+
+# ---------------------------------------------------------------------------
+# Ownership chain materialization (arktrace dashboard export)
+# ---------------------------------------------------------------------------
+
+
+def _company_display(
+    company_id: str,
+    companies: pl.DataFrame,
+    sanctioned_ids: set[str],
+) -> tuple[str, str, bool]:
+    if len(companies):
+        row = companies.filter(pl.col("id") == company_id)
+        if len(row):
+            name = row["name"][0]
+            country = row["country"][0]
+            return (
+                str(name) if name else company_id,
+                str(country) if country else "",
+                company_id in sanctioned_ids,
+            )
+    return company_id, "", company_id in sanctioned_ids
+
+
+def _build_vessel_ownership_chain(mmsi: str, tables: dict) -> list[dict]:
+    """Return a short vessel → operator → parent → sanctions path for one MMSI."""
+    vessels = pl.from_arrow(tables["Vessel"])
+    ob = pl.from_arrow(tables["OWNED_BY"])
+    mb = pl.from_arrow(tables["MANAGED_BY"])
+    cb = pl.from_arrow(tables["CONTROLLED_BY"])
+    sb = pl.from_arrow(tables["SANCTIONED_BY"])
+
+    sanctioned_ids: set[str] = set(sb["src_id"].to_list()) if len(sb) else set()
+    company_df = (
+        pl.from_arrow(tables["Company"])
+        if len(tables["Company"])
+        else pl.DataFrame(schema={"id": pl.Utf8, "name": pl.Utf8, "country": pl.Utf8})
+    )
+
+    vrow = vessels.filter(pl.col("mmsi") == mmsi)
+    vessel_name = str(vrow["name"][0]) if len(vrow) and vrow["name"][0] else mmsi
+    chain: list[dict] = [
+        {
+            "hop": 0,
+            "kind": "vessel",
+            "name": vessel_name,
+            "country": "",
+            "sanctioned": mmsi in sanctioned_ids,
+            "relation": "vessel",
+        }
+    ]
+
+    company_id: str | None = None
+    relation: str | None = None
+    if len(ob):
+        owned = ob.filter(pl.col("src_id") == mmsi)
+        if len(owned):
+            company_id = owned["dst_id"][0]
+            relation = "operator"
+    if company_id is None and len(mb):
+        managed = mb.filter(pl.col("src_id") == mmsi)
+        if len(managed):
+            company_id = managed["dst_id"][0]
+            relation = "manager"
+
+    if not company_id:
+        return chain
+
+    name, country, sanctioned = _company_display(company_id, company_df, sanctioned_ids)
+    chain.append(
+        {
+            "hop": 1,
+            "kind": "company",
+            "name": name,
+            "country": country,
+            "sanctioned": sanctioned,
+            "relation": relation or "operator",
+        }
+    )
+
+    target_id = company_id
+    if len(cb):
+        parents = cb.filter(pl.col("src_id") == company_id)
+        if len(parents):
+            parent_id = parents["dst_id"][0]
+            pname, pcountry, psanc = _company_display(parent_id, company_df, sanctioned_ids)
+            chain.append(
+                {
+                    "hop": 2,
+                    "kind": "company",
+                    "name": pname,
+                    "country": pcountry,
+                    "sanctioned": psanc,
+                    "relation": "controlled_by",
+                }
+            )
+            target_id = parent_id
+
+    if len(sb):
+        listings = sb.filter(pl.col("src_id") == target_id)
+        for listing in listings.to_dicts():
+            list_name = listing.get("list") or "Sanctions list"
+            date = listing.get("date") or ""
+            label = f"{list_name}" + (f" ({date})" if date else "")
+            chain.append(
+                {
+                    "hop": len(chain),
+                    "kind": "sanction",
+                    "name": label,
+                    "country": "",
+                    "sanctioned": True,
+                    "relation": "sanctioned_by",
+                    "date": date,
+                }
+            )
+            break
+
+    return chain
+
+
+def _is_vessel_mmsi(value: str) -> bool:
+    """True when value looks like a 9-digit AIS MMSI (not a company node id)."""
+    return len(value) == 9 and value.isdigit()
+
+
+def _chain_export_mmsis(tables: dict) -> list[str]:
+    """MMSIs to materialize: graph vessels plus any with ownership/sanctions edges."""
+    mmsis: set[str] = set()
+    vessels = pl.from_arrow(tables["Vessel"])
+    if len(vessels):
+        mmsis.update(vessels["mmsi"].to_list())
+
+    for rel in ("OWNED_BY", "MANAGED_BY"):
+        edges = pl.from_arrow(tables[rel])
+        if len(edges):
+            mmsis.update(edges["src_id"].to_list())
+
+    sb = pl.from_arrow(tables["SANCTIONED_BY"])
+    if len(sb):
+        for src_id in sb["src_id"].to_list():
+            if _is_vessel_mmsi(src_id):
+                mmsis.add(src_id)
+
+    return sorted(mmsis)
+
+
+def compute_ownership_chains(db_path: str) -> pl.DataFrame:
+    """Materialize ownership paths for dashboard export (one JSON array per MMSI)."""
+    tables = load_tables(db_path)
+    mmsis = _chain_export_mmsis(tables)
+    if not mmsis:
+        return pl.DataFrame(schema={"mmsi": pl.Utf8, "ownership_chain": pl.Utf8})
+
+    rows = []
+    for mmsi in mmsis:
+        chain = _build_vessel_ownership_chain(mmsi, tables)
+        rows.append({"mmsi": mmsi, "ownership_chain": json.dumps(chain)})
+
+    return pl.DataFrame(rows, schema={"mmsi": pl.Utf8, "ownership_chain": pl.Utf8})
 
 
 # ---------------------------------------------------------------------------

--- a/pipelines/score/composite.py
+++ b/pipelines/score/composite.py
@@ -586,6 +586,20 @@ def compute_composite_scores(
                 f"[label propagation] floor applied to {n_lifted} vessels from {propagation_path}"
             )
 
+    if "sanctions_distance" in scored.columns:
+        scored = scored.drop("sanctions_distance")
+    graph_export = feature_df.select(["mmsi", "sanctions_distance"])
+    scored = scored.join(graph_export, on="mmsi", how="left")
+
+    try:
+        from pipelines.features.ownership_graph import compute_ownership_chains
+
+        chains_df = compute_ownership_chains(db_path)
+        scored = scored.join(chains_df, on="mmsi", how="left")
+    except Exception as exc:
+        print(f"Warning: ownership_chain export skipped ({exc})")
+        scored = scored.with_columns(pl.lit(None, dtype=pl.Utf8).alias("ownership_chain"))
+
     return scored.select(
         [
             "mmsi",
@@ -609,6 +623,7 @@ def compute_composite_scores(
             "name_changes_2y",
             "owner_changes_2y",
             "sanctions_distance",
+            "ownership_chain",
             "shared_address_centrality",
             "sts_hub_degree",
             "cluster_label",

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1548,6 +1548,18 @@ _MANIFEST_REGION_TAG: dict[str, str] = {
 }
 
 
+def _watchlists_missing_ownership_chain(watchlist_paths: list[Path]) -> list[str]:
+    """Return watchlist filenames that lack the ownership_chain column (indago#148)."""
+    import polars as pl
+
+    missing: list[str] = []
+    for wl_path in watchlist_paths:
+        cols = pl.read_parquet(wl_path, n_rows=0).columns
+        if "ownership_chain" not in cols:
+            missing.append(wl_path.name)
+    return missing
+
+
 def cmd_push_arktrace(args: argparse.Namespace) -> int:
     """Copy pipeline outputs from maridb-public → arktrace-public and write manifest.
 
@@ -1595,17 +1607,13 @@ def cmd_push_arktrace(args: argparse.Namespace) -> int:
         )
         return 1
 
-    import polars as pl
-
     watchlist_paths = [p for p, _, register_as, _ in upload_pairs if register_as == "watchlist.parquet"]
-    for wl_path in watchlist_paths:
-        cols = pl.read_parquet(wl_path, n_rows=0).columns
-        if "ownership_chain" not in cols:
-            print(
-                f"[warn] {wl_path.name} missing ownership_chain column — "
-                "arktrace Ownership chain panel will be empty until scoring is re-run (indago#148)",
-                file=sys.stderr,
-            )
+    for name in _watchlists_missing_ownership_chain(watchlist_paths):
+        print(
+            f"[warn] {name} missing ownership_chain column — "
+            "arktrace Ownership chain panel will be empty until scoring is re-run (indago#148)",
+            file=sys.stderr,
+        )
 
     total_bytes = 0
     for local_path, r2_key, register_as, region_tag in upload_pairs:

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1595,6 +1595,18 @@ def cmd_push_arktrace(args: argparse.Namespace) -> int:
         )
         return 1
 
+    import polars as pl
+
+    watchlist_paths = [p for p, _, register_as, _ in upload_pairs if register_as == "watchlist.parquet"]
+    for wl_path in watchlist_paths:
+        cols = pl.read_parquet(wl_path, n_rows=0).columns
+        if "ownership_chain" not in cols:
+            print(
+                f"[warn] {wl_path.name} missing ownership_chain column — "
+                "arktrace Ownership chain panel will be empty until scoring is re-run (indago#148)",
+                file=sys.stderr,
+            )
+
     total_bytes = 0
     for local_path, r2_key, register_as, region_tag in upload_pairs:
         if not local_path.exists():

--- a/tests/test_ownership_graph.py
+++ b/tests/test_ownership_graph.py
@@ -3,6 +3,8 @@ Tests for ownership graph feature engineering — focusing on the DuckDB sanctio
 fallback introduced in issue #231 and the STS hub degree fixes in issue #233.
 """
 
+import json
+
 import duckdb
 import polars as pl
 import pyarrow as pa
@@ -10,8 +12,11 @@ import pyarrow as pa
 from pipelines.features.ownership_graph import (
     MAX_HOPS,
     _apply_direct_sanctions_fallback,
+    _build_vessel_ownership_chain,
+    _chain_export_mmsis,
     _compute_sanctions_distance,
     _compute_sts_hub_degree,
+    _is_vessel_mmsi,
 )
 from pipelines.ingest.graph_store import NODE_SCHEMAS, REL_SCHEMAS
 
@@ -360,3 +365,101 @@ def test_sanctions_distance_priority_closer_wins():
     )
     result = _compute_sanctions_distance(tables)
     assert result.filter(pl.col("mmsi") == "777777777")["sanctions_distance"][0] == 1
+
+
+# ---------------------------------------------------------------------------
+# _build_vessel_ownership_chain / compute_ownership_chains export (indago#148)
+# ---------------------------------------------------------------------------
+
+
+def _empty_rel(name: str) -> pa.Table:
+    return REL_SCHEMAS[name].empty_table()
+
+
+def _make_chain_tables(
+    *,
+    mmsi: str = "111111111",
+    vessel_name: str = "ADMIRAL STAR",
+    use_manager: bool = False,
+    with_parent: bool = True,
+    with_sanction: bool = True,
+) -> dict:
+    vessel_table = pa.table(
+        {"mmsi": [mmsi], "imo": [""], "name": [vessel_name]},
+        schema=NODE_SCHEMAS["Vessel"],
+    )
+    company_table = pa.table(
+        {
+            "id": ["co-op", "co-parent"],
+            "name": ["Seawind Ltd", "Oceanic Holdings"],
+            "country": ["PA", "VG"],
+        },
+        schema=NODE_SCHEMAS["Company"],
+    )
+    owned_by = _empty_rel("OWNED_BY")
+    managed_by = _empty_rel("MANAGED_BY")
+    if use_manager:
+        managed_by = pa.table(
+            {"src_id": [mmsi], "dst_id": ["co-op"], "since": [""], "until": [""]},
+            schema=REL_SCHEMAS["MANAGED_BY"],
+        )
+    else:
+        owned_by = pa.table(
+            {"src_id": [mmsi], "dst_id": ["co-op"], "since": [""], "until": [""]},
+            schema=REL_SCHEMAS["OWNED_BY"],
+        )
+    controlled_by = _empty_rel("CONTROLLED_BY")
+    if with_parent:
+        controlled_by = pa.table(
+            {"src_id": ["co-op"], "dst_id": ["co-parent"]},
+            schema=REL_SCHEMAS["CONTROLLED_BY"],
+        )
+    sanctioned_by = _empty_rel("SANCTIONED_BY")
+    if with_sanction:
+        sanctioned_by = pa.table(
+            {
+                "src_id": ["co-parent"],
+                "dst_id": ["OFAC SDN"],
+                "list": ["OFAC SDN"],
+                "date": ["2024-11-12"],
+            },
+            schema=REL_SCHEMAS["SANCTIONED_BY"],
+        )
+    return {
+        "Vessel": vessel_table,
+        "Company": company_table,
+        "OWNED_BY": owned_by,
+        "MANAGED_BY": managed_by,
+        "CONTROLLED_BY": controlled_by,
+        "SANCTIONED_BY": sanctioned_by,
+    }
+
+
+def test_chain_export_mmsis_includes_direct_sanction_without_vessel_node():
+    tables = {
+        "Vessel": NODE_SCHEMAS["Vessel"].empty_table(),
+        "Company": NODE_SCHEMAS["Company"].empty_table(),
+        "OWNED_BY": _empty_rel("OWNED_BY"),
+        "MANAGED_BY": _empty_rel("MANAGED_BY"),
+        "CONTROLLED_BY": _empty_rel("CONTROLLED_BY"),
+        "SANCTIONED_BY": pa.table(
+            {
+                "src_id": ["273449240"],
+                "dst_id": ["OFAC SDN"],
+                "list": ["OFAC SDN"],
+                "date": ["2024-11-12"],
+            },
+            schema=REL_SCHEMAS["SANCTIONED_BY"],
+        ),
+    }
+    assert "273449240" in _chain_export_mmsis(tables)
+    chain = _build_vessel_ownership_chain("273449240", tables)
+    assert chain[0]["sanctioned"] is True
+    assert _is_vessel_mmsi("273449240")
+
+
+def test_ownership_chain_operator_parent_and_listing():
+    chain = _build_vessel_ownership_chain("111111111", _make_chain_tables())
+    assert [h["kind"] for h in chain] == ["vessel", "company", "company", "sanction"]
+    parsed = json.loads(json.dumps(chain))
+    assert parsed[-1]["kind"] == "sanction"

--- a/tests/test_push_arktrace.py
+++ b/tests/test_push_arktrace.py
@@ -7,7 +7,6 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import polars as pl
 import pyarrow as pa
 import pyarrow.parquet as pq
 

--- a/tests/test_push_arktrace.py
+++ b/tests/test_push_arktrace.py
@@ -1,0 +1,88 @@
+"""Tests for sync_r2.py push-arktrace and ownership_chain column validation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import polars as pl
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import scripts.sync_r2 as sync_r2
+
+
+def _write_watchlist_parquet(path: Path, *, with_ownership_chain: bool) -> None:
+    schema = pa.schema(
+        [
+            pa.field("mmsi", pa.string()),
+            pa.field("confidence", pa.float64()),
+        ]
+        + ([pa.field("ownership_chain", pa.string())] if with_ownership_chain else [])
+    )
+    table = pa.table(
+        {
+            "mmsi": ["111111111"],
+            "confidence": [0.5],
+            **(
+                {"ownership_chain": [json.dumps([{"hop": 0, "kind": "vessel", "sanctioned": False}])]}
+                if with_ownership_chain
+                else {}
+            ),
+        },
+        schema=schema,
+    )
+    pq.write_table(table, path)
+
+
+def test_watchlists_missing_ownership_chain_detects_absent_column(tmp_path):
+    good = tmp_path / "singapore_watchlist.parquet"
+    bad = tmp_path / "candidate_watchlist.parquet"
+    _write_watchlist_parquet(good, with_ownership_chain=True)
+    _write_watchlist_parquet(bad, with_ownership_chain=False)
+
+    missing = sync_r2._watchlists_missing_ownership_chain([good, bad])
+    assert missing == ["candidate_watchlist.parquet"]
+
+
+def test_watchlists_missing_ownership_chain_empty_when_present(tmp_path):
+    path = tmp_path / "singapore_watchlist.parquet"
+    _write_watchlist_parquet(path, with_ownership_chain=True)
+    assert sync_r2._watchlists_missing_ownership_chain([path]) == []
+
+
+def test_push_arktrace_warns_when_ownership_chain_missing(tmp_path, capsys):
+    _write_watchlist_parquet(
+        tmp_path / "singapore_watchlist.parquet",
+        with_ownership_chain=False,
+    )
+
+    args = argparse.Namespace(data_dir=str(tmp_path))
+    mock_fs = MagicMock()
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=mock_fs):
+        with patch.object(sync_r2, "_upload_file"):
+            result = sync_r2.cmd_push_arktrace(args)
+
+    assert result == 0
+    err = capsys.readouterr().err
+    assert "missing ownership_chain" in err
+    assert "singapore_watchlist.parquet" in err
+
+
+def test_push_arktrace_no_warn_when_ownership_chain_present(tmp_path, capsys):
+    _write_watchlist_parquet(
+        tmp_path / "singapore_watchlist.parquet",
+        with_ownership_chain=True,
+    )
+
+    args = argparse.Namespace(data_dir=str(tmp_path))
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=MagicMock()):
+        with patch.object(sync_r2, "_upload_file"):
+            result = sync_r2.cmd_push_arktrace(args)
+
+    assert result == 0
+    assert "missing ownership_chain" not in capsys.readouterr().err

--- a/tests/test_scoring_pipeline.py
+++ b/tests/test_scoring_pipeline.py
@@ -1,6 +1,8 @@
 import json
+from unittest.mock import patch
 
 import duckdb
+import polars as pl
 
 from pipelines.score.anomaly import ANOMALY_FEATURE_COLUMNS, load_feature_frame, score_anomalies
 from pipelines.score.composite import FEATURE_VALUE_COLUMNS, compute_composite_scores
@@ -161,6 +163,67 @@ def test_composite_and_watchlist_output(tmp_db, tmp_path):
     output_path = tmp_path / "candidate_watchlist.parquet"
     write_candidate_watchlist(watchlist, str(output_path))
     assert output_path.exists()
+
+
+def test_composite_scores_include_ownership_chain_when_graph_export_succeeds(tmp_db):
+    """ownership_chain column is joined from compute_ownership_chains (indago#148)."""
+    _seed_scoring_data(tmp_db)
+    chain_json = json.dumps(
+        [
+            {
+                "hop": 0,
+                "kind": "vessel",
+                "name": "ALPHA",
+                "country": "",
+                "sanctioned": False,
+                "relation": "vessel",
+            }
+        ]
+    )
+    chains_df = pl.DataFrame(
+        {
+            "mmsi": ["111111111", "222222222"],
+            "ownership_chain": [chain_json, None],
+        }
+    )
+
+    with patch(
+        "pipelines.features.ownership_graph.compute_ownership_chains",
+        return_value=chains_df,
+    ):
+        composite = compute_composite_scores(tmp_db)
+
+    assert "ownership_chain" in composite.columns
+    row = composite.filter(pl.col("mmsi") == "111111111").row(0, named=True)
+    assert row["ownership_chain"] == chain_json
+    assert json.loads(row["ownership_chain"])[0]["name"] == "ALPHA"
+    assert composite.filter(pl.col("mmsi") == "222222222")["ownership_chain"][0] is None
+
+
+def test_watchlist_parquet_written_with_ownership_chain_column(tmp_db, tmp_path):
+    _seed_scoring_data(tmp_db)
+    chains_df = pl.DataFrame(
+        {
+            "mmsi": ["111111111"],
+            "ownership_chain": [
+                json.dumps([{"hop": 0, "kind": "vessel", "name": "ALPHA", "sanctioned": True}])
+            ],
+        }
+    )
+
+    with patch(
+        "pipelines.features.ownership_graph.compute_ownership_chains",
+        return_value=chains_df,
+    ):
+        watchlist = build_candidate_watchlist(tmp_db)
+
+    assert "ownership_chain" in watchlist.columns
+    out = tmp_path / "candidate_watchlist.parquet"
+    write_candidate_watchlist(watchlist, str(out))
+    cols = pl.read_parquet(out, n_rows=0).columns
+    assert "ownership_chain" in cols
+    saved = pl.read_parquet(out).filter(pl.col("mmsi") == "111111111")
+    assert saved["ownership_chain"][0] is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements [indago#148](https://github.com/edgesentry/indago/issues/148) — publish path for arktrace Ownership chain UI ([arktrace#575](https://github.com/edgesentry/arktrace/issues/575)).

- **Scoring:** Port `compute_ownership_chains` / `_build_vessel_ownership_chain` from arktrace (including MMSIs on `SANCTIONED_BY` without a `Vessel` node).
- **Watchlist:** `compute_composite_scores()` joins `ownership_chain` + refreshes `sanctions_distance` from `vessel_features`.
- **Publish:** `push-arktrace` warns when `*_watchlist.parquet` lacks `ownership_chain`.
- **Docs:** `AGENTS.md` — arktrace dashboard uses `push-arktrace` → `score/*.parquet`, not `push-ducklake-public`.

## Test plan

- [x] `pytest tests/test_ownership_graph.py` — 19 passed
- [ ] Merge after [arktrace#576](https://github.com/edgesentry/arktrace/pull/576) (or align export logic if diverged)
- [ ] Run `data-publish` or manual: score region → `push-arktrace` → verify R2 `score/*_watchlist.parquet` has `ownership_chain`
- [ ] arktrace dashboard: MMSI 273449240 shows chain or registry empty-state after OPFS refresh

Closes #148

Made with [Cursor](https://cursor.com)