### PR TITLE
fix: push-arktrace prefers score/ watchlists (ownership_chain on regional R2)

### DIFF
--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -821,15 +821,8 @@ def cmd_push_watchlists(args: argparse.Namespace) -> int:
     data_dir = Path(args.data_dir)
     r2_path = f"{bucket}/{_WATCHLISTS_R2_KEY}"
 
-    # Search both data_dir root and data_dir/score/ (where run_pipeline.py writes them).
-    # Use rglob to find all *_watchlist.parquet recursively; arcname=f.name in the zip
-    # ensures they all extract to the top level of data_dir on pull.
-    seen: set[Path] = set()
-    watchlist_files = []
-    for f in sorted(data_dir.rglob("*_watchlist.parquet")):
-        if f not in seen:
-            seen.add(f)
-            watchlist_files.append(f)
+    # Prefer score/ over flat root when both exist (same rule as push-arktrace).
+    watchlist_files = _resolve_watchlist_paths_for_push(data_dir)
 
     if not watchlist_files:
         print(
@@ -1548,6 +1541,41 @@ _MANIFEST_REGION_TAG: dict[str, str] = {
 }
 
 
+def _resolve_score_artifact(data_dir: Path, name: str) -> Path | None:
+    """Return score/{name} when present, else flat data_dir/{name}."""
+    score_path = data_dir / "score" / name
+    if score_path.exists():
+        return score_path
+    flat_path = data_dir / name
+    if flat_path.exists():
+        return flat_path
+    return None
+
+
+def _resolve_watchlist_paths_for_push(data_dir: Path) -> list[Path]:
+    """Pick one watchlist Parquet per filename; prefer data_dir/score/ over flat root.
+
+    run_pipeline.py writes regional watchlists under score/; pull-watchlists may leave
+    stale copies at the data_dir root. push-arktrace must upload the pipeline output.
+    """
+    by_name: dict[str, list[Path]] = {}
+    for wl_path in data_dir.rglob("*_watchlist.parquet"):
+        by_name.setdefault(wl_path.name, []).append(wl_path)
+
+    score_dir = data_dir / "score"
+    chosen: list[Path] = []
+    for name in sorted(by_name):
+        candidates = by_name[name]
+        in_score = [p for p in candidates if p.parent == score_dir]
+        if in_score:
+            chosen.append(in_score[0])
+        elif len(candidates) == 1:
+            chosen.append(candidates[0])
+        else:
+            chosen.append(sorted(candidates, key=lambda p: len(p.parts))[0])
+    return chosen
+
+
 def _watchlists_missing_ownership_chain(watchlist_paths: list[Path]) -> list[str]:
     """Return watchlist filenames that lack the ownership_chain column (indago#148)."""
     import polars as pl
@@ -1583,21 +1611,21 @@ def cmd_push_arktrace(args: argparse.Namespace) -> int:
     ] = []  # (local, r2_key, register_as, region)
 
     # Region-scoped watchlists: singapore_watchlist.parquet → region tag "singapore"
-    for wl_path in sorted(data_dir.glob("*_watchlist.parquet")):
+    for wl_path in _resolve_watchlist_paths_for_push(data_dir):
         stem = wl_path.stem.replace("_watchlist", "")
         region_tag = _MANIFEST_REGION_TAG.get(stem)
         r2_key = f"score/{wl_path.name}"
         upload_pairs.append((wl_path, r2_key, "watchlist.parquet", region_tag))
 
-    # Shared (non-region) score files
+    # Shared (non-region) score files — prefer score/ subdir when present
     for name, register_as in [
         ("composite_scores.parquet", "composite_scores.parquet"),
         ("causal_effects.parquet", "causal_effects.parquet"),
         ("score_history.parquet", "score_history.parquet"),
         ("validation_metrics.parquet", "validation_metrics.parquet"),
     ]:
-        p = data_dir / name
-        if p.exists():
+        p = _resolve_score_artifact(data_dir, name)
+        if p is not None:
             upload_pairs.append((p, f"score/{name}", register_as, None))
 
     if not upload_pairs:

--- a/tests/test_push_arktrace.py
+++ b/tests/test_push_arktrace.py
@@ -71,6 +71,43 @@ def test_push_arktrace_warns_when_ownership_chain_missing(tmp_path, capsys):
     assert "singapore_watchlist.parquet" in err
 
 
+def test_resolve_watchlist_paths_prefers_score_subdir(tmp_path):
+    score_dir = tmp_path / "score"
+    score_dir.mkdir()
+    _write_watchlist_parquet(tmp_path / "singapore_watchlist.parquet", with_ownership_chain=False)
+    _write_watchlist_parquet(score_dir / "singapore_watchlist.parquet", with_ownership_chain=True)
+    _write_watchlist_parquet(tmp_path / "candidate_watchlist.parquet", with_ownership_chain=True)
+
+    resolved = sync_r2._resolve_watchlist_paths_for_push(tmp_path)
+    by_name = {p.name: p for p in resolved}
+
+    assert by_name["singapore_watchlist.parquet"] == score_dir / "singapore_watchlist.parquet"
+    assert by_name["candidate_watchlist.parquet"] == tmp_path / "candidate_watchlist.parquet"
+
+
+def test_push_arktrace_uploads_score_watchlist_when_stale_root_exists(tmp_path, capsys):
+    score_dir = tmp_path / "score"
+    score_dir.mkdir()
+    _write_watchlist_parquet(tmp_path / "singapore_watchlist.parquet", with_ownership_chain=False)
+    _write_watchlist_parquet(score_dir / "singapore_watchlist.parquet", with_ownership_chain=True)
+
+    args = argparse.Namespace(data_dir=str(tmp_path))
+    uploaded: list[Path] = []
+
+    def capture_upload(_fs, local_path: Path, _r2_path: str) -> int:
+        uploaded.append(local_path)
+        return local_path.stat().st_size
+
+    with patch.object(sync_r2, "_build_r2_fs", return_value=MagicMock()):
+        with patch.object(sync_r2, "_upload_file", side_effect=capture_upload):
+            result = sync_r2.cmd_push_arktrace(args)
+
+    assert result == 0
+    assert score_dir / "singapore_watchlist.parquet" in uploaded
+    assert tmp_path / "singapore_watchlist.parquet" not in uploaded
+    assert "missing ownership_chain" not in capsys.readouterr().err
+
+
 def test_push_arktrace_no_warn_when_ownership_chain_present(tmp_path, capsys):
     _write_watchlist_parquet(
         tmp_path / "singapore_watchlist.parquet",


### PR DESCRIPTION
## Summary

Regional watchlists on `arktrace-public` were missing the `ownership_chain` column even after indago#149, while `candidate_watchlist.parquet` had it.

**Root cause:** `run_pipeline.py` writes `data/processed/score/{region}_watchlist.parquet`, but `push-arktrace` only globbed `data/processed/*_watchlist.parquet` at the root (stale copies from `pull-watchlists`). The SPA still worked because `opfs.ts` prefers the global `candidate_watchlist` manifest entry.

**Fix:**
- `_resolve_watchlist_paths_for_push()` — rglob + prefer `score/` over flat root per filename
- `_resolve_score_artifact()` — same for shared score Parquets
- `push-watchlists` zip uses the same resolution so CI does not re-publish stale root copies

## Test plan

- [x] `uv run pytest tests/test_push_arktrace.py -q` (6 passed)
- [ ] Merge → run `data-publish` on `main`
- [ ] Verify `https://arktrace-public.edgesentry.io/score/singapore_watchlist.parquet` has `ownership_chain` column
- [ ] Optional: regional `sync_r2.py pull --region singapore` in arktrace shows chains


Made with [Cursor](https://cursor.com)