### PR TITLE
docs: data-publish metrics interpretation guide and agent skill

### DIFF
--- a/.agents/skills/indago-interpret-metrics/SKILL.md
+++ b/.agents/skills/indago-interpret-metrics/SKILL.md
@@ -7,6 +7,14 @@ metadata:
   repo: indago
 ---
 
+## When to use this skill
+
+- After **data-publish** CI completes (email summary).
+- Before updating **commercial**, outreach, or Cap Vista docs that cite P@50, recall, or lead time.
+- When a doc shows a **dated** metrics table — treat it as stale; fetch instead.
+
+**Do not** copy live metrics from `docs/` into submissions. Run this skill (or the commands below) and interpret with [references/metrics-interpretation.md](references/metrics-interpretation.md).
+
 ## Quick fetch (latest from R2)
 
 ```bash
@@ -36,7 +44,7 @@ https://pub-e088008b61ee432b906ef710d52af28c.r2.dev/metrics/YYYYMMDD.json
 1. **P@50 drop &lt; 0.02** day-over-day → noise (e.g. 0.400 → 0.396).
 2. **Recall@200 &lt; 1.0** → at least one known positive fell below rank 200 — investigate region windows.
 3. **skipped_regions** non-empty → partial backtest; do not quote overall metrics as full coverage.
-4. **Two P@50 definitions** — email = mean of 5 regional P@50; Cap Vista docs often use global `candidate_watchlist` (~0.40).
+4. **Two P@50 definitions** — email = mean of 5 regional P@50; Cap Vista docs often use global `candidate_watchlist` (fetch both; they may differ by ~0.00x).
 5. **Contractual gate** ≥ 0.60 is trial/partner labels — not the daily email value.
 
 Full guide: [references/metrics-interpretation.md](references/metrics-interpretation.md) · [docs/ref-data-publish-metrics.md](../../../docs/ref-data-publish-metrics.md)

--- a/.agents/skills/indago-interpret-metrics/SKILL.md
+++ b/.agents/skills/indago-interpret-metrics/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: indago-interpret-metrics
+description: Fetch and interpret indago data-publish metrics (P@50 email, R2 snapshots, lead time). Use after data-publish CI, when explaining metric deltas, or before updating external docs.
+license: Apache-2.0
+compatibility: Network access to public R2 metrics mirror; optional local data/processed/ for a single run
+metadata:
+  repo: indago
+---
+
+## Quick fetch (latest from R2)
+
+```bash
+uv run python scripts/fetch_publish_metrics.py --interpret
+uv run python scripts/fetch_publish_metrics.py --days 7
+uv run python scripts/fetch_publish_metrics.py --json
+```
+
+Public URLs (same data as maintainer dashboard):
+
+```text
+https://pub-e088008b61ee432b906ef710d52af28c.r2.dev/metrics/index.json
+https://pub-e088008b61ee432b906ef710d52af28c.r2.dev/metrics/YYYYMMDD.json
+```
+
+## Local files after a CI run or pipeline
+
+| File | Contents |
+|------|----------|
+| `data/processed/backtest_public_integration_summary.json` | Same source as email `metrics_summary` |
+| `data/processed/validation_metrics.json` | Global candidate_watchlist P@50 (may differ slightly from email) |
+| `data/processed/lead_time_report.json` | Pre-designation lead times |
+| `data/processed/metrics_trend.json` | Previous P@50 for regression email logic |
+
+## Interpretation checklist
+
+1. **P@50 drop &lt; 0.02** day-over-day → noise (e.g. 0.400 → 0.396).
+2. **Recall@200 &lt; 1.0** → at least one known positive fell below rank 200 — investigate region windows.
+3. **skipped_regions** non-empty → partial backtest; do not quote overall metrics as full coverage.
+4. **Two P@50 definitions** — email = mean of 5 regional P@50; Cap Vista docs often use global `candidate_watchlist` (~0.40).
+5. **Contractual gate** ≥ 0.60 is trial/partner labels — not the daily email value.
+
+Full guide: [references/metrics-interpretation.md](references/metrics-interpretation.md) · [docs/ref-data-publish-metrics.md](../../../docs/ref-data-publish-metrics.md)
+
+## Analyst UI
+
+Watchlist, SHAP, ownership chain: [arktrace.edgesentry.io](https://arktrace.edgesentry.io) — not stored in `metrics/*.json`.

--- a/.agents/skills/indago-interpret-metrics/references/metrics-interpretation.md
+++ b/.agents/skills/indago-interpret-metrics/references/metrics-interpretation.md
@@ -1,0 +1,43 @@
+# Metrics interpretation quick reference
+
+## Regression rules
+
+| Rule | Threshold |
+|------|-----------|
+| Email regression banner | P@50 down **> 0.02** vs previous snapshot |
+| CI integration floor | Combined watchlist P@50 **≥ 0.25** |
+| Cap Vista contractual gate | Partner validation P@50 **≥ 0.60** (not daily email) |
+| Demonstrated CI ceiling | Multi-region **≥ 0.68** (regression gate in docs) |
+
+## Email field → code
+
+| Email | Source script | Field |
+|-------|--------------|-------|
+| Precision@50 + CI | `run_public_backtest_batch.py` → `summary.precision_at_50` | mean + CI across 5 regions |
+| Recall@200 | same | `recall_at_200.mean` |
+| Known positives | same | `total_known_cases` |
+| Pre-designation / lead | `validate_lead_time_ofac.py` | `lead_time_report.json` |
+| Per-region table | backtest `region_summary` | matched / recall in watchlist |
+
+## Common misreadings
+
+| Observation | Wrong conclusion | Correct read |
+|-------------|------------------|--------------|
+| P@50 0.396 vs 0.400 in docs | Model broke | Same band; ~1 top-50 slot; check CI |
+| Lead median 14 → 22 in one day | Ranking worse | Cohort of pre-designation cases changed |
+| ownership_chain deploy | P@50 must drop | Column add rarely moves rank much; check Recall@200 |
+| Singapore-only P@50 = 0.06 | Model useless | Structural ceiling with 3 labels; use AUROC |
+
+## Commands
+
+```bash
+# Public trend
+uv run python scripts/fetch_publish_metrics.py --days 7 --interpret
+
+# Reproduce email inputs locally (after data-publish artifacts downloaded)
+cat data/processed/backtest_public_integration_summary.json | jq '.metrics_summary'
+cat data/processed/lead_time_report.json | jq '{pre_designation_count, median_lead_days, mean_lead_days}'
+
+# Global watchlist metric (marketing / Cap Vista)
+cat data/processed/validation_metrics.json
+```

--- a/.agents/skills/indago-interpret-metrics/references/metrics-interpretation.md
+++ b/.agents/skills/indago-interpret-metrics/references/metrics-interpretation.md
@@ -1,5 +1,7 @@
 # Metrics interpretation quick reference
 
+**Source of truth for live values:** `fetch_publish_metrics.py` / R2 `metrics/*.json` — not markdown tables in `docs/` or commercial submission files.
+
 ## Regression rules
 
 | Rule | Threshold |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,9 @@ Multi-domain OSINT data layer. indago ingests raw signals from maritime, corpora
 | `scripts/run_backtracking.py` | Delayed-label intelligence loop |
 | `scripts/generate_osint_report.py` | OSINT intelligence report generation |
 | `scripts/check_score_regression.py` | Model regression validation |
+| `scripts/push_metrics_snapshot.py` | Daily metrics JSON → `maridb-public/metrics/` |
+| `scripts/notify_metrics.py` | Data-publish summary email |
+| `scripts/fetch_publish_metrics.py` | Fetch latest metrics from public R2 (no credentials) |
 | `config/sanction_regimes.yaml` | Configurable sanction regime definitions |
 | `config/geopolitical_events.json` | Geopolitical filter zones |
 
@@ -58,6 +61,18 @@ Watchlists for [arktrace](https://arktrace.edgesentry.io) are **plain Parquet** 
 3. `uv run python scripts/sync_r2.py push-arktrace --data-dir data/processed` — uploads watchlists (prefers `score/` over stale flat copies from `pull-watchlists`) + `ducklake_manifest.json`.
 
 Do **not** use `push-ducklake-public` for the browser app; that path is legacy DuckLake catalog storage only.
+
+## Data-publish metrics
+
+After `data-publish.yml`, maintainers receive an email and R2 snapshots under `maridb-public/metrics/YYYYMMDD.json` (public mirror: `pub-*.r2.dev/metrics/`).
+
+```bash
+uv run python scripts/fetch_publish_metrics.py --interpret
+```
+
+- **Definitions**: [docs/ref-evaluation-metrics.md](docs/ref-evaluation-metrics.md)
+- **Interpretation** (email vs global P@50, regression threshold 0.02): [docs/ref-data-publish-metrics.md](docs/ref-data-publish-metrics.md)
+- **Agent skill**: `.agents/skills/indago-interpret-metrics/SKILL.md`
 
 ## Key design decisions
 
@@ -100,3 +115,4 @@ npx skills add edgesentry/indago
 | `/indago-sync-r2` | Publishing new Parquet partitions; preparing demo bundles |
 | `/indago-run-osint` | Investigating a flagged vessel; preparing weekly analyst report |
 | `/indago-run-backtrack` | New analyst labels available; rewinding causal reasoning |
+| `/indago-interpret-metrics` | Data-publish email; P@50 deltas; R2 metrics trend |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ uv run python scripts/fetch_publish_metrics.py --interpret
 
 - **Definitions**: [docs/ref-evaluation-metrics.md](docs/ref-evaluation-metrics.md)
 - **Interpretation** (email vs global P@50, regression threshold 0.02): [docs/ref-data-publish-metrics.md](docs/ref-data-publish-metrics.md)
-- **Agent skill**: `.agents/skills/indago-interpret-metrics/SKILL.md`
+- **Agent skill**: `.agents/skills/indago-interpret-metrics/SKILL.md` — **fetch latest values here**; do not copy metrics from docs
 
 ## Key design decisions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ English is the single source of truth for all documentation.
 4. **`docs/`** — reference material only (design decisions, data contracts, model specs)
 5. **No duplication** — each fact lives in exactly one place
 6. **No cargo doc territory** — don't duplicate types, fields, or method signatures from code
+7. **No stale live metrics** — do not commit point-in-time P@50, recall, or lead-time values in `docs/` (thresholds and historical blind-run examples are fine). Point readers to **`/indago-interpret-metrics`** or `scripts/fetch_publish_metrics.py --interpret`
 
 ### File naming
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ Runs daily via GitHub Actions across 5 regions. See [`/indago-run-pipeline`](htt
 
 - [ref-backtesting.md](ref-backtesting.md) — historical evaluation workflow
 - [ref-evaluation-metrics.md](ref-evaluation-metrics.md) — Precision@K, AUROC, acceptance thresholds
+- [ref-data-publish-metrics.md](ref-data-publish-metrics.md) — data-publish email and R2 snapshot interpretation
 - [ref-precision-plan.md](ref-precision-plan.md) — P@50 improvement strategy
 - [ref-prelabel-governance.md](ref-prelabel-governance.md) — analyst pre-label holdout policy
 

--- a/docs/ref-data-publish-metrics.md
+++ b/docs/ref-data-publish-metrics.md
@@ -1,0 +1,137 @@
+# Data Publish Metrics — Interpretation Guide
+
+How to read the **indago data publish** email, R2 daily snapshots, and local backtest artifacts after `data-publish.yml` runs. Metric *definitions* live in [ref-evaluation-metrics.md](ref-evaluation-metrics.md); this doc explains *what each published number means* and when to worry.
+
+---
+
+## Where metrics come from
+
+| Source | Path / trigger | Audience |
+|--------|----------------|----------|
+| **Email** | `scripts/notify_metrics.py` after CI | Maintainers (`NOTIFY_EMAIL`) |
+| **R2 snapshots** | `scripts/push_metrics_snapshot.py` → `maridb-public/metrics/YYYYMMDD.json` | Dashboard, agents, trend scripts |
+| **Local (CI artifact)** | `data/processed/backtest_public_integration_summary.json` | Debugging a single run |
+| **Local (AIS validate)** | `data/processed/validation_metrics.json` | Single-corpus quick check |
+| **Lead time** | `data/processed/lead_time_report.json` | Pre-designation case studies |
+
+Public read (no credentials):
+
+```text
+https://pub-e088008b61ee432b906ef710d52af28c.r2.dev/metrics/index.json
+https://pub-e088008b61ee432b906ef710d52af28c.r2.dev/metrics/20260516.json
+```
+
+Fetch locally:
+
+```bash
+uv run python scripts/fetch_publish_metrics.py
+uv run python scripts/fetch_publish_metrics.py --days 7 --json
+```
+
+---
+
+## Email sections mapped to data
+
+### Overall Metrics
+
+| Email row | Snapshot field | Computation |
+|-----------|----------------|-------------|
+| **Precision@50** | `precision_at_50` + CI | **Mean** of per-region P@50 from `run_public_backtest_batch.py` windows; CI = 95% across those 5 regional values (not bootstrap on vessels) |
+| **Recall@200** | `recall_at_200` | Mean regional recall@200 — fraction of known positives appearing in top 200 per region |
+| **Known positives** | `known_positives` | Total labeled OFAC/EU/UN positives in the evaluation manifest (typically 99 multi-region) |
+| **vs prev day** | R2 `metrics/YYYYMMDD.json` delta | Day-over-day change in stored snapshot |
+| **7-day trend** | Oldest vs newest in `metrics/index.json` | Rolling comparison (up to 30 entries retained in index) |
+
+### Lead Time — Pre-Designation Detection
+
+From `validate_lead_time_ofac.py` on `candidate_watchlist.parquet`:
+
+| Email row | Field | Meaning |
+|-----------|-------|---------|
+| **Pre-designation detections** | `pre_designation_count` | Vessels flagged **before** public OFAC/EU listing date (watchlist `first_flagged_at` vs designation) |
+| **Mean / median lead time** | `mean_lead_days`, `median_lead_days` | Days between first flag and designation (positive = early warning) |
+| **p25 / p75** | `p25_lead_days`, `p75_lead_days` | Spread of lead times across cases |
+
+### Per-Region Coverage
+
+| Email column | Backtest field | Meaning |
+|--------------|----------------|---------|
+| **Positives matched** | `matched_total` / `source_positive_total` | Known positives for that region found in the scored watchlist |
+| **Recall in watchlist** | `source_recall_in_watchlist` | Share of regional positives that appear anywhere in the ranked list (not only top 50) |
+
+Skipped regions (`skipped_regions`) were below `--min-watchlist-size` or missing parquet — **do not** treat their absence as zero performance.
+
+---
+
+## Two different “Precision@50” numbers (do not confuse)
+
+| Metric | How computed | Typical value (May 2026) | Use for |
+|--------|--------------|---------------------------|---------|
+| **Email / backtest summary** | Average of **5 regional** P@50 values | ~0.37–0.40 | Daily publish email, `metrics/*.json`, trend |
+| **Global `candidate_watchlist`** | Single ranked list after dedup; top-50 / labeled | ~0.40 | Cap Vista docs, `validation_metrics.json`, arktrace marketing |
+
+A gap of **0.00x** between them is normal (≈ one vessel rank swap in top-50). Do **not** call a drop from 0.400 → 0.396 a regression unless it exceeds the rules below.
+
+---
+
+## When is a change a real regression?
+
+`notify_metrics.py` flags regression only when **day-over-day P@50 drops by more than 0.02** (2 percentage points on the regional mean).
+
+| Change | Verdict |
+|--------|---------|
+| 0.400 → 0.396 | **Noise** — within CI; ~1 fewer hit in top-50 |
+| 0.40 → 0.37 over 7 days | **Review** — check AIS ingest, skipped regions, scoring changes |
+| Recall@200 &lt; 1.0 | **Investigate** — a known positive fell below rank 200 in some region |
+| Pre-designation count drops sharply | **Review** — graph/sanctions ingest or `first_flagged_at` logic |
+| Skipped regions non-empty | **Action** — pipeline or watchlist too small; backtest partial |
+
+CI also enforces `tests/test_public_data_backtest_integration.py` floor **P@50 ≥ 0.25** on multi-region combined watchlist.
+
+Contractual / trial gates (Cap Vista): **≥ 0.60** on partner validation set — not the daily email number.
+
+---
+
+## Latest published snapshot (example: 2026-05-16)
+
+Fetched from R2 after data-publish run on `main` (ownership_chain + `score/` publish path):
+
+| Metric | 2026-05-16 | 2026-05-15 | 2026-05-11 (7d) |
+|--------|------------|------------|-----------------|
+| Precision@50 (mean) | **0.396** | 0.396 | 0.372 |
+| CI 95% | 0.32 – 0.48 | same | 0.31 – 0.44 |
+| Recall@200 | 1.000 | 1.000 | 1.000 |
+| Known positives | 99 | 99 | 93 |
+| Pre-designation count | 11 | 11 | 10 |
+| Median lead (days) | 22 | 14 | 20 |
+| Mean lead (days) | 18 | 13 | 18 |
+
+**Interpretation:**
+
+- **P@50 stable** day-over-day; **7-day trend up** (+0.024) — healthy.
+- **Recall@200 = 1.0** — all 99 known positives still recovered in top 200 per region.
+- **Lead time median rose** 14 → 22 vs prior day — often cohort mix (which cases enter the 11 pre-designation set), not necessarily worse ranking.
+- Compare to **global** `candidate_watchlist` P@50 ≈ 0.40 when writing external docs.
+
+Re-fetch before acting:
+
+```bash
+uv run python scripts/fetch_publish_metrics.py --interpret
+```
+
+---
+
+## Maintainer dashboard
+
+Pipeline health (gate pass/fail, skipped regions): indago dashboard (`dashboard/`) using the same `metrics/*.json` files.
+
+Analyst-facing SHAP, ownership chain, and watchlist UI: [arktrace.edgesentry.io](https://arktrace.edgesentry.io) — not this metrics bundle.
+
+---
+
+## Related docs
+
+- [ref-evaluation-metrics.md](ref-evaluation-metrics.md) — definitions and thresholds
+- [ref-backtesting.md](ref-backtesting.md) — how backtest windows are built
+- [ref-precision-plan.md](ref-precision-plan.md) — improving P@50
+- [ref-r2-data-layout.md](ref-r2-data-layout.md) — `metrics/` prefix on `maridb-public`

--- a/docs/ref-data-publish-metrics.md
+++ b/docs/ref-data-publish-metrics.md
@@ -2,6 +2,8 @@
 
 How to read the **indago data publish** email, R2 daily snapshots, and local backtest artifacts after `data-publish.yml` runs. Metric *definitions* live in [ref-evaluation-metrics.md](ref-evaluation-metrics.md); this doc explains *what each published number means* and when to worry.
 
+> **Live metrics:** Daily publish values change after each `data-publish` run. **Do not copy P@50, recall, or lead-time numbers from this doc** into reports, outreach, or commercial submissions. Use the **`/indago-interpret-metrics`** skill (or `uv run python scripts/fetch_publish_metrics.py --interpret`) for the latest snapshot and interpretation.
+
 ---
 
 ## Where metrics come from
@@ -18,15 +20,17 @@ Public read (no credentials):
 
 ```text
 https://pub-e088008b61ee432b906ef710d52af28c.r2.dev/metrics/index.json
-https://pub-e088008b61ee432b906ef710d52af28c.r2.dev/metrics/20260516.json
+https://pub-e088008b61ee432b906ef710d52af28c.r2.dev/metrics/YYYYMMDD.json
 ```
 
-Fetch locally:
+Fetch locally (preferred over reading stale values in docs):
 
 ```bash
-uv run python scripts/fetch_publish_metrics.py
+uv run python scripts/fetch_publish_metrics.py --interpret
 uv run python scripts/fetch_publish_metrics.py --days 7 --json
 ```
+
+Agent skill: [`.agents/skills/indago-interpret-metrics/`](../.agents/skills/indago-interpret-metrics/SKILL.md) (`/indago-interpret-metrics`).
 
 ---
 
@@ -92,32 +96,18 @@ Contractual / trial gates (Cap Vista): **≥ 0.60** on partner validation set �
 
 ---
 
-## Latest published snapshot (example: 2026-05-16)
+## Latest published snapshot
 
-Fetched from R2 after data-publish run on `main` (ownership_chain + `score/` publish path):
-
-| Metric | 2026-05-16 | 2026-05-15 | 2026-05-11 (7d) |
-|--------|------------|------------|-----------------|
-| Precision@50 (mean) | **0.396** | 0.396 | 0.372 |
-| CI 95% | 0.32 – 0.48 | same | 0.31 – 0.44 |
-| Recall@200 | 1.000 | 1.000 | 1.000 |
-| Known positives | 99 | 99 | 93 |
-| Pre-designation count | 11 | 11 | 10 |
-| Median lead (days) | 22 | 14 | 20 |
-| Mean lead (days) | 18 | 13 | 18 |
-
-**Interpretation:**
-
-- **P@50 stable** day-over-day; **7-day trend up** (+0.024) — healthy.
-- **Recall@200 = 1.0** — all 99 known positives still recovered in top 200 per region.
-- **Lead time median rose** 14 → 22 vs prior day — often cohort mix (which cases enter the 11 pre-designation set), not necessarily worse ranking.
-- Compare to **global** `candidate_watchlist` P@50 ≈ 0.40 when writing external docs.
-
-Re-fetch before acting:
+**Do not maintain a dated metrics table in this doc.** After each publish, fetch and interpret:
 
 ```bash
-uv run python scripts/fetch_publish_metrics.py --interpret
+uv run python scripts/fetch_publish_metrics.py --interpret   # human summary + regression hints
+uv run python scripts/fetch_publish_metrics.py --days 7        # day-over-day table
 ```
+
+Or invoke **`/indago-interpret-metrics`** so an agent runs the same commands and applies the checklist in [metrics-interpretation.md](../.agents/skills/indago-interpret-metrics/references/metrics-interpretation.md).
+
+When writing external copy, also check **global** `validation_metrics.json` / `candidate_watchlist` P@50 (often ~0.01 higher than the email’s regional mean) — the skill doc explains both.
 
 ---
 

--- a/docs/ref-data-publish-metrics.md
+++ b/docs/ref-data-publish-metrics.md
@@ -30,7 +30,7 @@ uv run python scripts/fetch_publish_metrics.py --interpret
 uv run python scripts/fetch_publish_metrics.py --days 7 --json
 ```
 
-Agent skill: [`.agents/skills/indago-interpret-metrics/`](../.agents/skills/indago-interpret-metrics/SKILL.md) (`/indago-interpret-metrics`).
+Agent skill: [`indago-interpret-metrics`](https://github.com/edgesentry/indago/blob/main/.agents/skills/indago-interpret-metrics/SKILL.md) (`/indago-interpret-metrics`).
 
 ---
 
@@ -105,7 +105,7 @@ uv run python scripts/fetch_publish_metrics.py --interpret   # human summary + r
 uv run python scripts/fetch_publish_metrics.py --days 7        # day-over-day table
 ```
 
-Or invoke **`/indago-interpret-metrics`** so an agent runs the same commands and applies the checklist in [metrics-interpretation.md](../.agents/skills/indago-interpret-metrics/references/metrics-interpretation.md).
+Or invoke **`/indago-interpret-metrics`** so an agent runs the same commands and applies the checklist in [metrics-interpretation.md](https://github.com/edgesentry/indago/blob/main/.agents/skills/indago-interpret-metrics/references/metrics-interpretation.md).
 
 When writing external copy, also check **global** `validation_metrics.json` / `candidate_watchlist` P@50 (often ~0.01 higher than the email’s regional mean) — the skill doc explains both.
 

--- a/docs/ref-evaluation-metrics.md
+++ b/docs/ref-evaluation-metrics.md
@@ -2,6 +2,8 @@
 
 This document describes the evaluation framework, metric definitions, acceptance thresholds, and how to reproduce results. Current metric values are produced by the CI pipeline and stored in `data/processed/validation_metrics.json` — do not read specific numbers from this doc.
 
+For **daily data-publish email** and R2 snapshot fields (regional mean P@50 vs global watchlist, regression rules, lead time), see [ref-data-publish-metrics.md](ref-data-publish-metrics.md). Agent skill: `.agents/skills/indago-interpret-metrics/`.
+
 ---
 
 ## Metric Definitions

--- a/docs/ref-evaluation-metrics.md
+++ b/docs/ref-evaluation-metrics.md
@@ -2,7 +2,9 @@
 
 This document describes the evaluation framework, metric definitions, acceptance thresholds, and how to reproduce results. Current metric values are produced by the CI pipeline and stored in `data/processed/validation_metrics.json` — do not read specific numbers from this doc.
 
-For **daily data-publish email** and R2 snapshot fields (regional mean P@50 vs global watchlist, regression rules, lead time), see [ref-data-publish-metrics.md](ref-data-publish-metrics.md). Agent skill: `.agents/skills/indago-interpret-metrics/`.
+For **daily data-publish email** and R2 snapshot fields (regional mean P@50 vs global watchlist, regression rules, lead time), see [ref-data-publish-metrics.md](ref-data-publish-metrics.md).
+
+> **Current P@50 / recall / lead time:** Use **`/indago-interpret-metrics`** or `uv run python scripts/fetch_publish_metrics.py --interpret`. Numbers below are thresholds, historical blind runs, or pedagogical examples — not live publish values.
 
 ---
 
@@ -62,9 +64,9 @@ arktrace distinguishes two evaluation modes. These must not be conflated when re
 
 **Why seeded metrics are higher:** The 10 injected vessels (CELINE, ELINE, REX 1, ANHONA, etc.) are confirmed OFAC positives with synthetic AIS positions crafted to produce high anomaly scores. A seeded run guarantees these vessels surface in the top-50, mechanically inflating AUROC, P@50, and Recall.
 
-### Documented Blind Run Results
+### Documented Blind Run Results (historical point-in-time)
 
-Most recent blind evaluation (singapore, 2026-04-14, `validation_metrics.json`):
+Single-region blind run retained for structural-ceiling illustration (singapore, 2026-04-14, `validation_metrics.json`). For **latest multi-region publish metrics**, use `/indago-interpret-metrics` instead of this table:
 
 | Metric | Value | Notes |
 |---|---|---|

--- a/docs/ref-precision-plan.md
+++ b/docs/ref-precision-plan.md
@@ -2,6 +2,8 @@
 
 This document explains the two distinct P@50 thresholds used in arktrace, the current baseline, and the steps taken to reach the demonstrated technical ceiling. No code knowledge required.
 
+> **Current daily metrics:** The **0.62** figure in the title is a historical Singapore full-run baseline, not the live data-publish value. Fetch latest P@50, recall, and lead time via **`/indago-interpret-metrics`** or `uv run python scripts/fetch_publish_metrics.py --interpret` in the indago repo.
+
 ---
 
 ## P@50 Threshold Glossary

--- a/docs/ref-study-guide.md
+++ b/docs/ref-study-guide.md
@@ -181,7 +181,7 @@ For developers, it's important to note that we implement this directly in NumPy 
 ### Day 14: Validation & Evaluation Metrics (Precision@50)
 How do we know Arktrace actually works? In data science, you can't just trust your results; you have to validate them against **Ground Truth**. Our ground truth is the official historical record of OFAC sanctions designations. If our model identifies a vessel as high-risk *months before* it actually appeared on a sanctions list, we have verified our value.
 
-Our primary metric is **Precision@50**. In a fleet of 5,000 vessels, if an analyst reviews our top 50 candidates, how many will they find are confirmed sanctioned vessels? We currently achieve 0.62 (31 out of 50), which is a 6x "lift" over a random baseline. This is the number that proves our model is an effective "force multiplier" for limited human resources.
+Our primary metric is **Precision@50**. In a fleet of 5,000 vessels, if an analyst reviews our top 50 candidates, how many will they find are confirmed sanctioned vessels? We historically achieved ~0.62 on a full Singapore run (31 out of 50), which is a 6x "lift" over a random baseline. For **current** publish metrics, use `/indago-interpret-metrics` in indago — do not cite 0.62 as today's number. This is the number that proves our model is an effective "force multiplier" for limited human resources.
 
 We also use **Recall@200** and **AUROC**. Recall tells us what percentage of *all* sanctioned vessels we managed to surface. AUROC (Area Under the Receiver Operating Characteristic curve) measures how well our model ranks a "randomly chosen positive" vessel higher than a "randomly chosen negative" one. It is the definitive measure of our model's ranking quality.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Validation:
     - Backtesting: ref-backtesting.md
     - Evaluation Metrics: ref-evaluation-metrics.md
+    - Data Publish Metrics: ref-data-publish-metrics.md
     - Precision Plan: ref-precision-plan.md
     - Pre-Label Governance: ref-prelabel-governance.md
   - Reference:

--- a/scripts/fetch_publish_metrics.py
+++ b/scripts/fetch_publish_metrics.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Fetch and print indago data-publish metrics from public R2 snapshots.
+
+Reads maridb-public/metrics/index.json and the newest daily JSON files.
+No AWS credentials required (uses the public r2.dev mirror used by dashboard/).
+
+Usage
+-----
+    uv run python scripts/fetch_publish_metrics.py
+    uv run python scripts/fetch_publish_metrics.py --days 7
+    uv run python scripts/fetch_publish_metrics.py --interpret
+    uv run python scripts/fetch_publish_metrics.py --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+_DEFAULT_BASE = "https://pub-e088008b61ee432b906ef710d52af28c.r2.dev"
+_REGRESSION_THRESHOLD = 0.02
+
+
+def _get(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"User-Agent": "indago-fetch-publish-metrics/1.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"HTTP {e.code} for {url}") from e
+    except urllib.error.URLError as e:
+        raise SystemExit(f"Failed to fetch {url}: {e}") from e
+
+
+def _fetch_snapshots(base: str, days: int) -> list[dict]:
+    index = _get(f"{base}/metrics/index.json")
+    entries: list[str] = index.get("entries", [])[:days]
+    snaps: list[dict] = []
+    for key in entries:
+        snap = _get(f"{base}/metrics/{key}.json")
+        snap.setdefault("date", key)
+        snaps.append(snap)
+    return snaps
+
+
+def _delta_str(new: float | int | None, old: float | int | None, fmt: str = ".4f") -> str:
+    if new is None or old is None:
+        return "—"
+    d = float(new) - float(old)
+    if abs(d) < 1e-9:
+        return "→ 0"
+    arrow = "↑" if d > 0 else "↓"
+    return f"{arrow} {abs(d):{fmt}}"
+
+
+def _interpret(snaps: list[dict]) -> list[str]:
+    if not snaps:
+        return ["No snapshots found."]
+    lines: list[str] = []
+    latest = snaps[0]
+    prev = snaps[1] if len(snaps) > 1 else None
+    old = snaps[-1] if len(snaps) > 1 else None
+
+    p50 = latest.get("precision_at_50")
+    lines.append(f"Latest date: {latest.get('date')} (generated {latest.get('generated_at_utc', '?')[:19]})")
+    if p50 is not None:
+        ci_lo, ci_hi = latest.get("precision_at_50_ci_low"), latest.get("precision_at_50_ci_high")
+        ci = f" (CI 95%: {ci_lo:.4f}–{ci_hi:.4f})" if ci_lo is not None and ci_hi is not None else ""
+        lines.append(f"  Precision@50 (regional mean): {p50:.4f}{ci}")
+        if prev and prev.get("precision_at_50") is not None:
+            d = float(p50) - float(prev["precision_at_50"])
+            if d < -_REGRESSION_THRESHOLD:
+                lines.append(f"  ⚠️  Regression vs prior day ({d:+.4f}, threshold −{_REGRESSION_THRESHOLD})")
+            elif d > _REGRESSION_THRESHOLD:
+                lines.append(f"  ✅ Improved vs prior day ({d:+.4f})")
+            else:
+                lines.append(f"  → Stable vs prior day ({d:+.4f} — normal noise if |d| < {_REGRESSION_THRESHOLD})")
+        if old and old.get("precision_at_50") is not None and len(snaps) > 2:
+            d7 = float(p50) - float(old["precision_at_50"])
+            lines.append(
+                f"  7d+ trend ({old.get('date')} → {latest.get('date')}): {old['precision_at_50']:.4f} → {p50:.4f} ({d7:+.4f})"
+            )
+    if latest.get("recall_at_200") is not None:
+        lines.append(f"  Recall@200: {latest['recall_at_200']:.4f}")
+        if float(latest["recall_at_200"]) < 1.0:
+            lines.append("  ⚠️  Recall@200 < 1.0 — investigate ranking in at least one region")
+    if latest.get("known_positives") is not None:
+        lines.append(f"  Known positives: {latest['known_positives']}")
+    skipped = latest.get("skipped_regions") or []
+    if skipped:
+        lines.append(f"  ⚠️  Skipped regions: {', '.join(skipped)}")
+    else:
+        lines.append(f"  Regions: {', '.join(latest.get('regions') or [])}")
+    if latest.get("pre_designation_count") is not None:
+        lines.append(
+            f"  Pre-designation: {latest['pre_designation_count']} cases; "
+            f"median lead {latest.get('median_lead_days', '—')}d, "
+            f"mean {latest.get('mean_lead_days', '—')}d"
+        )
+    lines.append("")
+    lines.append("Note: email P@50 is the mean of 5 regional P@50 values; global candidate_watchlist P@50 may differ by ~0.00x.")
+    lines.append("See docs/ref-data-publish-metrics.md for full interpretation.")
+    return lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch indago publish metrics from public R2")
+    parser.add_argument("--base", default=_DEFAULT_BASE, help="R2 public base URL")
+    parser.add_argument("--days", type=int, default=3, help="Number of daily snapshots (newest first)")
+    parser.add_argument("--json", action="store_true", help="Emit JSON array only")
+    parser.add_argument("--interpret", action="store_true", help="Print human interpretation")
+    args = parser.parse_args()
+
+    snaps = _fetch_snapshots(args.base, max(1, args.days))
+    if args.json:
+        print(json.dumps(snaps, indent=2))
+        return 0
+    if args.interpret:
+        for line in _interpret(snaps):
+            print(line)
+        return 0
+
+    for i, s in enumerate(snaps):
+        prev = snaps[i + 1] if i + 1 < len(snaps) else None
+        print(f"\n=== {s.get('date')} ===")
+        for key in (
+            "precision_at_50",
+            "precision_at_50_ci_low",
+            "precision_at_50_ci_high",
+            "recall_at_200",
+            "auroc",
+            "known_positives",
+            "pre_designation_count",
+            "mean_lead_days",
+            "median_lead_days",
+            "regions",
+            "skipped_regions",
+        ):
+            if key in s and s[key] is not None:
+                extra = ""
+                if prev and key in prev and prev[key] is not None and key == "precision_at_50":
+                    extra = f"  ({_delta_str(s[key], prev[key])} vs prior)"
+                print(f"  {key}: {s[key]}{extra}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `docs/ref-data-publish-metrics.md` explaining data-publish email fields, R2 `metrics/YYYYMMDD.json` snapshots, regional mean vs global P@50, and regression rules (Δ > 0.02).
- Add `scripts/fetch_publish_metrics.py` to pull latest metrics from the public R2 mirror (`--interpret`, `--days`, `--json`).
- Add Agent Skill `.agents/skills/indago-interpret-metrics/` for agents and maintainers.
- Link from `AGENTS.md`, `docs/index.md`, and `docs/ref-evaluation-metrics.md`.

## Test plan

- [x] `uv run python scripts/fetch_publish_metrics.py --interpret` returns 2026-05-16 snapshot
- [ ] Review doc table mapping email rows → snapshot fields
- [ ] Merge and verify skill discoverable via `npx skills add edgesentry/indago`


Made with [Cursor](https://cursor.com)