### PR TITLE
feat(gdelt): wire GDELT into watchlist and OSINT report (closes #156)

### DIFF
--- a/docs/ref-pipeline.md
+++ b/docs/ref-pipeline.md
@@ -136,6 +136,8 @@ uv run python scripts/sync_r2.py push-ais-parquet \
 gh workflow run gdelt-ingest.yml --repo edgesentry/indago
 ```
 
+**Watchlist wiring (indago#156):** After `pull-gdelt`, `compute_composite_scores()` calls `query_gdelt_context()` per vessel (cached by flag + name) and writes `gdelt_context_json` / `gdelt_event_count` on the watchlist Parquet. GDELT does **not** change composite scores — citations only. OSINT email (`scripts/generate_osint_report.py`) renders a GDELT section from those columns.
+
 ---
 
 ## Stage 4 — CI pipeline (data-publish.yml, daily 01:00 UTC)

--- a/pipelines/score/composite.py
+++ b/pipelines/score/composite.py
@@ -496,6 +496,10 @@ def compute_composite_scores(
     geo_filter_path: str | None = None,
     auto_calibrate: bool = False,
     propagation_path: str | None = None,
+    gdelt_lance_path: str | None = None,
+    skip_gdelt: bool = False,
+    gdelt_top_n: int = 3,
+    gdelt_days_window: int = 90,
 ) -> pl.DataFrame:
     if auto_calibrate:
         print("Auto-calibrating graph risk weight using C3 causal model...")
@@ -600,6 +604,23 @@ def compute_composite_scores(
         print(f"Warning: ownership_chain export skipped ({exc})")
         scored = scored.with_columns(pl.lit(None, dtype=pl.Utf8).alias("ownership_chain"))
 
+    from pipelines.score.gdelt_enrichment import enrich_watchlist_gdelt
+
+    try:
+        scored = enrich_watchlist_gdelt(
+            scored,
+            lance_path=gdelt_lance_path,
+            n=gdelt_top_n,
+            days_window=gdelt_days_window,
+            skip_gdelt=skip_gdelt,
+        )
+    except Exception as exc:
+        print(f"Warning: GDELT context enrichment skipped ({exc})")
+        scored = scored.with_columns(
+            pl.lit(None, dtype=pl.Utf8).alias("gdelt_context_json"),
+            pl.lit(0, dtype=pl.Int32).alias("gdelt_event_count"),
+        )
+
     return scored.select(
         [
             "mmsi",
@@ -624,6 +645,8 @@ def compute_composite_scores(
             "owner_changes_2y",
             "sanctions_distance",
             "ownership_chain",
+            "gdelt_context_json",
+            "gdelt_event_count",
             "shared_address_centrality",
             "sts_hub_degree",
             "cluster_label",

--- a/pipelines/score/gdelt_enrichment.py
+++ b/pipelines/score/gdelt_enrichment.py
@@ -1,0 +1,120 @@
+"""Attach GDELT geopolitical context to watchlist rows (indago#156).
+
+GDELT does not alter composite scores — only enriches analyst-facing columns.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from typing import Any
+
+import polars as pl
+
+from pipelines.storage.config import lance_db_uri
+
+# Fields exported to watchlist JSON (keep parquet rows compact).
+_GDELT_EXPORT_FIELDS = (
+    "event_id",
+    "event_date",
+    "description",
+    "source_url",
+    "actor1_country",
+    "actor2_country",
+    "event_root_code",
+)
+
+_GDELT_STRUCT = pl.Struct(
+    {
+        "gdelt_context_json": pl.Utf8,
+        "gdelt_event_count": pl.Int32,
+    }
+)
+
+
+def _slim_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [{k: ev[k] for k in _GDELT_EXPORT_FIELDS if k in ev} for ev in events]
+
+
+def _filter_by_window(events: list[dict[str, Any]], days_window: int) -> list[dict[str, Any]]:
+    if days_window <= 0 or not events:
+        return events
+    cutoff = (date.today() - timedelta(days=days_window)).strftime("%Y%m%d")
+    return [e for e in events if str(e.get("event_date") or "") >= cutoff]
+
+
+def lookup_gdelt_context(
+    flag_country: str,
+    vessel_name: str = "",
+    *,
+    lance_path: str | None = None,
+    n: int = 3,
+    days_window: int = 90,
+    _cache: dict[tuple[str, str], list[dict[str, Any]]] | None = None,
+) -> tuple[str | None, int]:
+    """Return (gdelt_context_json, gdelt_event_count) for one vessel."""
+    from pipelines.ingest.gdelt import query_gdelt_context
+
+    flag = (flag_country or "").strip().upper()
+    name = (vessel_name or "").strip()
+    if not flag and not name:
+        return None, 0
+
+    key = (flag, name)
+    cache = _cache if _cache is not None else {}
+    if key not in cache:
+        path = lance_path or lance_db_uri()
+        try:
+            raw = query_gdelt_context(flag, name, n=n, lance_path=path, days_window=days_window)
+        except Exception:
+            raw = []
+        cache[key] = _filter_by_window(raw, days_window)
+
+    events = _slim_events(cache[key])
+    if not events:
+        return None, 0
+    return json.dumps(events), len(events)
+
+
+def enrich_watchlist_gdelt(
+    df: pl.DataFrame,
+    *,
+    lance_path: str | None = None,
+    n: int = 3,
+    days_window: int = 90,
+    skip_gdelt: bool = False,
+) -> pl.DataFrame:
+    """Add ``gdelt_context_json`` and ``gdelt_event_count`` without changing scores."""
+    if skip_gdelt or df.is_empty():
+        return df.with_columns(
+            pl.lit(None, dtype=pl.Utf8).alias("gdelt_context_json"),
+            pl.lit(0, dtype=pl.Int32).alias("gdelt_event_count"),
+        )
+
+    drop_cols = [c for c in ("gdelt_context_json", "gdelt_event_count") if c in df.columns]
+    if drop_cols:
+        df = df.drop(drop_cols)
+
+    if "flag" not in df.columns:
+        df = df.with_columns(pl.lit("").alias("flag"))
+    if "vessel_name" not in df.columns:
+        df = df.with_columns(pl.lit("").alias("vessel_name"))
+
+    cache: dict[tuple[str, str], list[dict[str, Any]]] = {}
+
+    def _row(r: dict[str, Any]) -> dict[str, Any]:
+        j, c = lookup_gdelt_context(
+            r.get("flag") or "",
+            r.get("vessel_name") or "",
+            lance_path=lance_path,
+            n=n,
+            days_window=days_window,
+            _cache=cache,
+        )
+        return {"gdelt_context_json": j, "gdelt_event_count": c}
+
+    return df.with_columns(
+        pl.struct(["flag", "vessel_name"])
+        .map_elements(_row, return_dtype=_GDELT_STRUCT)
+        .alias("_gdelt")
+    ).unnest("_gdelt")

--- a/scripts/generate_osint_report.py
+++ b/scripts/generate_osint_report.py
@@ -36,6 +36,7 @@ GITHUB_REPOSITORY Injected automatically by GitHub Actions
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import smtplib
 import sys
@@ -199,6 +200,45 @@ def _ofac_url(name: str) -> str:
     return f"https://sanctionssearch.ofac.treas.gov/?q={q}"
 
 
+def _parse_gdelt_context(raw: object) -> list[dict]:
+    """Parse ``gdelt_context_json`` from watchlist parquet (indago#156)."""
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, list):
+        return raw
+    try:
+        parsed = json.loads(str(raw))
+        return parsed if isinstance(parsed, list) else []
+    except json.JSONDecodeError:
+        return []
+
+
+def _gdelt_report_lines(rows: list[dict], max_vessels: int = 10) -> list[str]:
+    """Markdown bullets for vessels with GDELT context in the top-N list."""
+    lines: list[str] = []
+    shown = 0
+    for r in rows:
+        if shown >= max_vessels:
+            break
+        events = _parse_gdelt_context(r.get("gdelt_context_json"))
+        if not events:
+            continue
+        shown += 1
+        label = r.get("_name") if r.get("_name") and r.get("_name") != "—" else r.get("_mmsi", "")
+        lines.append(f"### {label} (`{r.get('_mmsi', '')}`)")
+        for ev in events[:2]:
+            desc = str(ev.get("description") or "")[:240]
+            url = str(ev.get("source_url") or "").strip()
+            if url:
+                lines.append(f"- {desc} ([source]({url}))")
+            else:
+                lines.append(f"- {desc}")
+        lines.append("")
+    if shown == 0:
+        lines.append("_No GDELT matches in top-N (gdelt.lance absent or no FTS hits)._")
+    return lines
+
+
 def _resolve_watchlist_path(cli_path: str | None) -> Path:
     if cli_path:
         return Path(cli_path).resolve()
@@ -302,12 +342,20 @@ def generate_report(df: pl.DataFrame, top_n: int) -> str:
             f"| {sd_str} | {links} |"
         )
 
+    lines += [
+        "",
+        "## GDELT geopolitical context",
+        "",
+        *_gdelt_report_lines(rows),
+    ]
+
     header = [
         f"# [OSINT Check] Watchlist — {today}",
         "",
         f"Top-{top_n} candidates from `candidate_watchlist.parquet`.",
         "Analysts: click links to verify on MarineTraffic / VesselFinder / OFAC.",
         "Stateless MMSIs (⚠) have unallocated ITU MID prefixes — likely spoofed identity.",
+        "GDELT citations are context only — they do not change model scores.",
         "",
     ]
     return "\n".join(header + lines) + "\n"

--- a/tests/test_gdelt_enrichment.py
+++ b/tests/test_gdelt_enrichment.py
@@ -1,0 +1,78 @@
+"""Tests for pipelines.score.gdelt_enrichment (indago#156)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import polars as pl
+
+from pipelines.score.gdelt_enrichment import enrich_watchlist_gdelt, lookup_gdelt_context
+
+
+def _sample_events() -> list[dict]:
+    return [
+        {
+            "event_id": "99",
+            "event_date": "20260410",
+            "description": "Iran reduced relations with Cambodia in South China Sea on 2026-04-10.",
+            "source_url": "http://example.com/ir-kh",
+            "actor1_country": "IR",
+            "actor2_country": "KH",
+            "event_root_code": "16",
+            "goldstein_scale": -7.0,
+        }
+    ]
+
+
+@patch("pipelines.ingest.gdelt.query_gdelt_context")
+def test_lookup_returns_json_and_count(mock_query):
+    mock_query.return_value = _sample_events()
+    ctx, count = lookup_gdelt_context("IR", "ALPHA TANKER", lance_path="/tmp/gdelt.lance")
+    assert count == 1
+    assert ctx is not None
+    parsed = json.loads(ctx)
+    assert parsed[0]["actor1_country"] == "IR"
+    assert "Iran" in parsed[0]["description"]
+
+
+@patch("pipelines.ingest.gdelt.query_gdelt_context")
+def test_lookup_caches_by_flag_and_name(mock_query):
+    mock_query.return_value = _sample_events()
+    cache: dict = {}
+    lookup_gdelt_context("IR", "VESSEL A", _cache=cache)
+    lookup_gdelt_context("IR", "VESSEL A", _cache=cache)
+    assert mock_query.call_count == 1
+
+
+@patch("pipelines.ingest.gdelt.query_gdelt_context")
+def test_lookup_empty_when_query_fails(mock_query):
+    mock_query.side_effect = RuntimeError("no lance")
+    ctx, count = lookup_gdelt_context("IR", "ALPHA")
+    assert ctx is None
+    assert count == 0
+
+
+@patch("pipelines.ingest.gdelt.query_gdelt_context")
+def test_enrich_watchlist_adds_columns(mock_query):
+    mock_query.return_value = _sample_events()
+    df = pl.DataFrame(
+        {
+            "mmsi": ["111111111"],
+            "flag": ["IR"],
+            "vessel_name": ["ALPHA"],
+            "confidence": [0.5],
+        }
+    )
+    out = enrich_watchlist_gdelt(df, lance_path="/tmp/gdelt.lance")
+    assert "gdelt_context_json" in out.columns
+    assert "gdelt_event_count" in out.columns
+    assert out["gdelt_event_count"][0] == 1
+    assert out["gdelt_context_json"][0] is not None
+
+
+def test_skip_gdelt_leaves_null_context():
+    df = pl.DataFrame({"mmsi": ["1"], "flag": ["IR"], "vessel_name": ["A"], "confidence": [0.5]})
+    out = enrich_watchlist_gdelt(df, skip_gdelt=True)
+    assert out["gdelt_event_count"][0] == 0
+    assert out["gdelt_context_json"][0] is None

--- a/tests/test_generate_osint_report.py
+++ b/tests/test_generate_osint_report.py
@@ -1,3 +1,5 @@
+import json
+
 import polars as pl
 import pytest
 
@@ -129,6 +131,37 @@ def test_report_is_string(sample_watchlist):
 
 def test_report_header(sample_watchlist):
     assert "[OSINT Check] Watchlist" in generate_report(sample_watchlist, top_n=50)
+
+
+def test_report_includes_gdelt_section():
+    events = [
+        {
+            "event_id": "1",
+            "event_date": "20260401",
+            "description": "Iran reduced relations with Cambodia in Strait of Malacca.",
+            "source_url": "http://example.com/news",
+            "actor1_country": "IR",
+            "actor2_country": "KH",
+            "event_root_code": "16",
+        }
+    ]
+    df = pl.DataFrame(
+        {
+            "mmsi": ["111111111"],
+            "imo": ["IMO111"],
+            "vessel_name": ["ALPHA"],
+            "vessel_type": ["Tanker"],
+            "flag": ["IR"],
+            "confidence": [0.9],
+            "sanctions_distance": [1],
+            "gdelt_context_json": [json.dumps(events)],
+            "gdelt_event_count": [1],
+        }
+    )
+    report = generate_report(df, top_n=10)
+    assert "## GDELT geopolitical context" in report
+    assert "Strait of Malacca" in report
+    assert "http://example.com/news" in report
 
 
 def test_sanctioned_section_count(sample_watchlist):

--- a/tests/test_scoring_pipeline.py
+++ b/tests/test_scoring_pipeline.py
@@ -200,6 +200,32 @@ def test_composite_scores_include_ownership_chain_when_graph_export_succeeds(tmp
     assert composite.filter(pl.col("mmsi") == "222222222")["ownership_chain"][0] is None
 
 
+@patch(
+    "pipelines.ingest.gdelt.query_gdelt_context",
+    return_value=[
+        {
+            "event_id": "1",
+            "event_date": "20260401",
+            "description": "IR conflict event",
+            "source_url": "http://example.com",
+            "actor1_country": "IR",
+            "actor2_country": "KH",
+            "event_root_code": "16",
+        }
+    ],
+)
+def test_composite_includes_gdelt_columns_without_changing_confidence(mock_query, tmp_db):
+    _seed_scoring_data(tmp_db)
+    with_gdelt = compute_composite_scores(tmp_db)
+    without = compute_composite_scores(tmp_db, skip_gdelt=True)
+    assert "gdelt_context_json" in with_gdelt.columns
+    assert "gdelt_event_count" in with_gdelt.columns
+    assert with_gdelt["confidence"].to_list() == without["confidence"].to_list()
+    ir_row = with_gdelt.filter(pl.col("mmsi") == "111111111")
+    assert ir_row["gdelt_event_count"][0] >= 1
+    assert ir_row["gdelt_context_json"][0] is not None
+
+
 def test_watchlist_parquet_written_with_ownership_chain_column(tmp_db, tmp_path):
     _seed_scoring_data(tmp_db)
     chains_df = pl.DataFrame(


### PR DESCRIPTION
## Summary

Closes #156 — connects existing GDELT LanceDB ingest to analyst-facing outputs.

- **`pipelines/score/gdelt_enrichment.py`** — cached `query_gdelt_context()` per (flag, vessel_name)
- **`compute_composite_scores()`** — adds `gdelt_context_json`, `gdelt_event_count` (scores unchanged; `skip_gdelt` for tests)
- **`scripts/generate_osint_report.py`** — new **GDELT geopolitical context** section with citations
- **`docs/ref-pipeline.md`** — documents watchlist wiring after `pull-gdelt`

## Acceptance criteria

- [x] `query_gdelt_context` used from scoring/export path
- [x] Watchlist Parquet includes `gdelt_context_json` when GDELT store present (mocked in tests)
- [x] OSINT report shows GDELT citation for test vessel
- [x] Scores unchanged when GDELT skipped / absent
- [x] CI tests pass without network

## Test plan

- [x] `uv run pytest` (697 passed)
- [ ] Run pipeline on region with `gdelt.lance` pulled; verify `*_watchlist.parquet` columns
- [ ] `uv run python scripts/generate_osint_report.py` on production watchlist


Made with [Cursor](https://cursor.com)