### PR TITLE
fix(ci): correct download-artifact action SHA in data-publish

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -137,7 +137,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Download region pipeline artifacts
-        uses: actions/download-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: pipeline-*
           path: .


### PR DESCRIPTION
## Summary

`publish` job in [run #92](https://github.com/edgesentry/indago/actions/runs/25982222900) failed at setup:

```
Unable to resolve action `actions/download-artifact@ea165f8...`
```

`ea165f8` is the **upload-artifact** v4 SHA, not download-artifact. Use `d3f86a1` (download-artifact v4) instead.

## Test plan

- [ ] Merge and **Re-run failed jobs** on run #92 (`Push to R2` only) — region artifacts should still be available
- [ ] Or trigger fresh `workflow_dispatch` if artifacts expired


Made with [Cursor](https://cursor.com)