### PR TITLE
fix(ci): place merged watchlist artifacts under score/

### DIFF
--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -145,8 +145,13 @@ jobs:
           path: data/processed/score
           merge-multiple: true
 
-      - name: Verify regional watchlists
+      - name: Normalize and verify regional watchlists
         run: |
+          mkdir -p data/processed/score
+          shopt -s nullglob
+          for f in *_watchlist.parquet; do
+            mv -v "$f" data/processed/score/
+          done
           missing=0
           for stem in singapore japansea blacksea middleeast europe; do
             f="data/processed/score/${stem}_watchlist.parquet"

--- a/.github/workflows/data-publish.yml
+++ b/.github/workflows/data-publish.yml
@@ -136,12 +136,28 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
+      # upload-artifact strips the common ancestor (score/), so each zip contains
+      # bare *_watchlist.parquet files — extract directly into score/.
       - name: Download region pipeline artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: pipeline-*
-          path: .
+          path: data/processed/score
           merge-multiple: true
+
+      - name: Verify regional watchlists
+        run: |
+          missing=0
+          for stem in singapore japansea blacksea middleeast europe; do
+            f="data/processed/score/${stem}_watchlist.parquet"
+            if [ -f "$f" ]; then
+              echo "  ✓ $f"
+            else
+              echo "::error::missing $f"
+              missing=1
+            fi
+          done
+          exit $missing
 
       - name: Run backtest (skip pipeline, use fresh watchlists)
         run: |

--- a/scripts/run_public_backtest_batch.py
+++ b/scripts/run_public_backtest_batch.py
@@ -57,12 +57,23 @@ _REGION_STEM: dict[str, str] = {
 WATCHLIST_BY_REGION: frozenset[str] = frozenset(_REGION_STEM)
 
 
-def _get_watchlist_path(region: str) -> Path:
-    """Resolve watchlist path at runtime so score/ is checked after the pipeline writes it."""
+def _watchlist_candidates(region: str) -> list[Path]:
+    """Paths to check for a regional watchlist (pipeline, R2 pull, CI artifact layouts)."""
     stem = _REGION_STEM.get(region, region)
-    score_path = _data_dir / "score" / f"{stem}_watchlist.parquet"
-    flat_path = _data_dir / f"{stem}_watchlist.parquet"
-    return score_path if score_path.exists() else flat_path
+    name = f"{stem}_watchlist.parquet"
+    return [
+        _data_dir / "score" / name,
+        _data_dir / name,
+        Path.cwd() / name,
+    ]
+
+
+def _get_watchlist_path(region: str) -> Path:
+    """Return the first existing watchlist path, or the canonical score/ path for errors."""
+    for path in _watchlist_candidates(region):
+        if path.is_file():
+            return path
+    return _watchlist_candidates(region)[0]
 
 
 def _run_pipeline_for_region(
@@ -346,9 +357,10 @@ def main() -> None:
     label_counts: dict[str, int] = {}
     for region in regions:
         watchlist_path = _get_watchlist_path(region).resolve()
-        if not watchlist_path.exists():
+        if not watchlist_path.is_file():
+            tried = "\n".join(f"  - {p}" for p in _watchlist_candidates(region))
             print(
-                f"[error] {region}: watchlist not found at {watchlist_path}\n"
+                f"[error] {region}: watchlist not found. Tried:\n{tried}\n"
                 "  Run the pipeline first or pull watchlists from R2:\n"
                 "  uv run python scripts/sync_r2.py pull-watchlists",
                 flush=True,


### PR DESCRIPTION
## Summary

[Run #93](https://github.com/edgesentry/indago/actions/runs/25982417046) — all 5 `pipeline-region` jobs succeeded, but `publish` failed:

```
[error] singapore: watchlist not found at data/processed/singapore_watchlist.parquet
```

`download-artifact` with `path: .` extracted bare `*_watchlist.parquet` at repo root (upload-artifact strips `data/processed/score/`). Backtest expects `data/processed/score/{stem}_watchlist.parquet`.

- Download to `data/processed/score` instead of `.`
- Add verify step listing all 5 regional watchlists before backtest

## Test plan

- [ ] Merge and re-run failed `Push to R2` on run #93 (artifacts still available)


Made with [Cursor](https://cursor.com)