### PR TITLE
docs: ownership chain docs without hardcoded demo MMSI

### DIFF
--- a/.agents/skills/indago-inspect-watchlist/SKILL.md
+++ b/.agents/skills/indago-inspect-watchlist/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 ## When to use this skill
 
 - After **data-publish** — confirm watchlists landed on R2 and columns look right.
-- Before **arktrace** demo / Cap Vista video — find MMSIs with `sanctions_distance` 1–2 and multi-hop `ownership_chain`.
+- Before **arktrace** demo / Cap Vista video — run `--min-chain-hops 2` and pick an MMSI from output (do not rely on a fixed ID in docs).
 - When a vessel shows only one Ownership chain row in the UI — inspect Parquet, not guess.
 
 **Related:** `/indago-interpret-metrics` (P@50 / recall) · `/indago-sync-r2` (upload) · `/indago-run-osint` (analyst report).

--- a/.agents/skills/indago-inspect-watchlist/references/watchlist-inspection.md
+++ b/.agents/skills/indago-inspect-watchlist/references/watchlist-inspection.md
@@ -12,16 +12,18 @@
 
 If `ownership_chain` column is missing, re-run scoring after indago#148 and `push-arktrace`.
 
-## Demo MMSI search
+## Demo vessel search (do not hardcode MMSI in docs)
 
 **Multi-hop ownership (ideal for C1 video shot 3):**
 
 ```bash
 uv run python .agents/skills/indago-inspect-watchlist/scripts/inspect_watchlist.py \
-  --sanctions-distance 1 2 --min-chain-hops 2 --limit 20
+  --min-chain-hops 2 --limit 20
 ```
 
-When `Demo-ready: 0`, use Feature attribution (SHAP) instead, or narrate direct sanction (distance 0, one node).
+After Equasis seed in CI, many designated vessels show `sanctions_distance = 0` with `chain_hops >= 2` (vessel → operator → listing). The script’s `Demo-ready (distance 1–2, chain_hops >= 2)` filter may be zero — use `--min-chain-hops 2` instead.
+
+When no multi-hop rows exist, use Feature attribution (SHAP) or expand `config/equasis/ownership_seed.csv`.
 
 **Single vessel deep-dive:**
 

--- a/config/equasis/README.md
+++ b/config/equasis/README.md
@@ -26,27 +26,16 @@ Curated vessel → company links for `vessel_registry --equasis-csv`. Company na
 2. Add one CSV line: `mmsi`, `imo`, `vessel_name`, optional `owner_name`, `manager_name`, `parent_owner_name`.
 3. Confirm the company string resolves on OpenSanctions (sanctioned company, not PSC-only records).
 4. Open a PR; after merge, run **Actions → data-publish** (`workflow_dispatch`) or wait for the weekly schedule.
-5. Verify:
+5. Verify (pick MMSI from output — do not assume a fixed demo vessel):
 
 ```bash
 uv run python -m pipelines.ingest.equasis_ownership --db data/processed/ais/singapore.duckdb
 uv run python .agents/skills/indago-inspect-watchlist/scripts/inspect_watchlist.py \
-  --sanctions-distance 1 2 --min-chain-hops 2
+  --min-chain-hops 2 --limit 20
 ```
 
-## Seed coverage (2026-05)
+## Seed rows
 
-| MMSI | Vessel | `manager_name` / `owner_name` | Notes |
-|------|--------|-------------------------------|--------|
-| 314189000 | Bangus | Costin Shipping Limited (owner) | C1 case study; OFAC 2026-04-24 |
-| 352179000 | Horae | Fleet Tanqo Private Limited | C1 |
-| 352001906 | Anaya | Fleet Tanqo Private Limited | C1 |
-| 352002243 | Anika | Anika Lines Inc. | C1 |
-| 352001849 | Bellaris | Nardie International S.A. | C1 |
-| 352001907 | Versa | Fleet Tanqo Private Limited | C1 |
-| 312171000 | ANHONA | Harry Victor Ship Management | Manager hop demo |
-| 457133000 | PIONEER 92 | Logos Marine Pte. Ltd. | Arktrace test case |
-| 273449240 | DOBRYNYA | Rosnefteflot | Direct sanction + operator |
-| 273312060 | SCF ENTERPRISE | Sovcomflot | Direct sanction + operator |
+Curated rows live in **`ownership_seed.csv`** in this directory. Row count and MMSI list change over time — read the CSV and `tests/test_equasis_ownership.py` (`EXPECTED_SEED_MMSIS`) rather than duplicating identifiers in docs.
 
 `parent_owner_name` is optional; when set and resolved, `vessel_registry` emits `CONTROLLED_BY` for a third graph hop.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,8 @@ Runs daily via GitHub Actions across 5 regions. See [`/indago-run-pipeline`](htt
 
 ## Operations
 
+- [config/equasis/README.md](../config/equasis/README.md) — Equasis ownership seed → graph edges (indago#169)
+- [ref-knowledge-graph.md](ref-knowledge-graph.md) — sanctions path query + `ownership_chain` export
 - [ref-pipeline.md](ref-pipeline.md) — pipeline overview and data flow
 - [ref-pipeline-catalog.md](ref-pipeline-catalog.md) — 8 pipeline types and when to use each
 - [ref-regional-playbooks.md](ref-regional-playbooks.md) — per-region operational notes

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Runs daily via GitHub Actions across 5 regions. See [`/indago-run-pipeline`](htt
 
 ## Operations
 
-- [config/equasis/README.md](../config/equasis/README.md) — Equasis ownership seed → graph edges (indago#169)
+- [config/equasis/README.md](https://github.com/edgesentry/indago/blob/main/config/equasis/README.md) — Equasis ownership seed → graph edges (indago#169)
 - [ref-knowledge-graph.md](ref-knowledge-graph.md) — sanctions path query + `ownership_chain` export
 - [ref-pipeline.md](ref-pipeline.md) — pipeline overview and data flow
 - [ref-pipeline-catalog.md](ref-pipeline-catalog.md) — 8 pipeline types and when to use each

--- a/docs/ref-knowledge-graph.md
+++ b/docs/ref-knowledge-graph.md
@@ -9,6 +9,8 @@
 
 Detection logic remains in `pipelines.features.ownership_graph`; arktrace is visualization-only.
 
+**Ownership edges in CI:** After sanctions ingest, `pipelines.ingest.equasis_ownership` builds `ownership_chains.csv` from [`config/equasis/ownership_seed.csv`](../config/equasis/ownership_seed.csv) (see [`config/equasis/README.md`](../config/equasis/README.md)), then `vessel_registry --equasis-csv` adds `MANAGED_BY` / `OWNED_BY` to the Lance graph. `compute_composite_scores()` embeds per-MMSI paths into watchlist `ownership_chain` for arktrace.
+
 Graph storage uses **`lance`** columnar datasets (`graph_store.py`), not the PyPI **`lance-graph`** package (removed as unused direct dependency).
 
 ## CLI
@@ -46,5 +48,8 @@ Uploaded by `scripts/sync_r2.py push-arktrace` to `arktrace-public/score/{region
 
 ## Related
 
+- [config/equasis/README.md](../config/equasis/README.md) — manual seed cadence (no MMSI list in prose)
 - [ref-pipeline.md](ref-pipeline.md) — pipeline orchestration
+- [ref-pipeline-catalog.md](ref-pipeline-catalog.md) — data-publish includes Equasis ownership step
 - [ref-r2-buckets.md](ref-r2-buckets.md) — `ownership/graph.parquet` layout
+- [arktrace ownership chain UI](https://github.com/edgesentry/arktrace/blob/main/docs/ref-ownership-chain-ui.md)

--- a/docs/ref-knowledge-graph.md
+++ b/docs/ref-knowledge-graph.md
@@ -9,7 +9,7 @@
 
 Detection logic remains in `pipelines.features.ownership_graph`; arktrace is visualization-only.
 
-**Ownership edges in CI:** After sanctions ingest, `pipelines.ingest.equasis_ownership` builds `ownership_chains.csv` from [`config/equasis/ownership_seed.csv`](../config/equasis/ownership_seed.csv) (see [`config/equasis/README.md`](../config/equasis/README.md)), then `vessel_registry --equasis-csv` adds `MANAGED_BY` / `OWNED_BY` to the Lance graph. `compute_composite_scores()` embeds per-MMSI paths into watchlist `ownership_chain` for arktrace.
+**Ownership edges in CI:** After sanctions ingest, `pipelines.ingest.equasis_ownership` builds `ownership_chains.csv` from [`config/equasis/ownership_seed.csv`](https://github.com/edgesentry/indago/blob/main/config/equasis/ownership_seed.csv) (see [`config/equasis/README.md`](https://github.com/edgesentry/indago/blob/main/config/equasis/README.md)), then `vessel_registry --equasis-csv` adds `MANAGED_BY` / `OWNED_BY` to the Lance graph. `compute_composite_scores()` embeds per-MMSI paths into watchlist `ownership_chain` for arktrace.
 
 Graph storage uses **`lance`** columnar datasets (`graph_store.py`), not the PyPI **`lance-graph`** package (removed as unused direct dependency).
 
@@ -48,7 +48,7 @@ Uploaded by `scripts/sync_r2.py push-arktrace` to `arktrace-public/score/{region
 
 ## Related
 
-- [config/equasis/README.md](../config/equasis/README.md) — manual seed cadence (no MMSI list in prose)
+- [config/equasis/README.md](https://github.com/edgesentry/indago/blob/main/config/equasis/README.md) — manual seed cadence (no MMSI list in prose)
 - [ref-pipeline.md](ref-pipeline.md) — pipeline orchestration
 - [ref-pipeline-catalog.md](ref-pipeline-catalog.md) — data-publish includes Equasis ownership step
 - [ref-r2-buckets.md](ref-r2-buckets.md) — `ownership/graph.parquet` layout

--- a/docs/ref-pipeline-catalog.md
+++ b/docs/ref-pipeline-catalog.md
@@ -274,7 +274,7 @@ pipeline locally.
 ### Pipeline Steps
 
 1. Pull custom feeds from `arktrace-private-capvista` → `_inputs/custom_feeds/` (`continue-on-error`).
-2. Optional: `sync_r2.py pull-equasis-ownership` — cache prior `ownership_chains.csv`; otherwise build from [`config/equasis/ownership_seed.csv`](../config/equasis/ownership_seed.csv) via `equasis_ownership` after sanctions ingest.
+2. Optional: `sync_r2.py pull-equasis-ownership` — cache prior `ownership_chains.csv`; otherwise build from [`config/equasis/ownership_seed.csv`](https://github.com/edgesentry/indago/blob/main/config/equasis/ownership_seed.csv) via `equasis_ownership` after sanctions ingest.
 3. Regional pipeline (11-step): sanctions load → `equasis_ownership` → `vessel_registry --equasis-csv` → features (`ownership_graph`) → composite score (embeds `ownership_chain`) → regional watchlist Parquet.
 4. Run `run_public_backtest_batch.py` for all 5 regions in seed mode — custom feeds are ingested during the pipeline run.
 5. `sync_r2.py push-arktrace` — upload `score/*_watchlist.parquet` (with `ownership_chain` when graph edges exist).

--- a/docs/ref-pipeline-catalog.md
+++ b/docs/ref-pipeline-catalog.md
@@ -274,12 +274,16 @@ pipeline locally.
 ### Pipeline Steps
 
 1. Pull custom feeds from `arktrace-private-capvista` → `_inputs/custom_feeds/` (`continue-on-error`).
-2. Run `run_public_backtest_batch.py` for all 5 regions in seed mode — custom feeds are ingested at step 5 of the 11-step pipeline.
-3. `sync_r2.py push --keep 1` — zip all region artifacts, upload to `arktrace-public`, delete previous generation.
-4. `sync_r2.py push-demo` — overwrite `demo.zip` (lightweight bundle for quick developer setup).
-5. `sync_r2.py push-sanctions-db --force` — upload `public_eval.duckdb`.
-6. Lead time validation (`validate_lead_time_ofac.py`).
-7. Metrics email notification (`notify_metrics.py`).
+2. Optional: `sync_r2.py pull-equasis-ownership` — cache prior `ownership_chains.csv`; otherwise build from [`config/equasis/ownership_seed.csv`](../config/equasis/ownership_seed.csv) via `equasis_ownership` after sanctions ingest.
+3. Regional pipeline (11-step): sanctions load → `equasis_ownership` → `vessel_registry --equasis-csv` → features (`ownership_graph`) → composite score (embeds `ownership_chain`) → regional watchlist Parquet.
+4. Run `run_public_backtest_batch.py` for all 5 regions in seed mode — custom feeds are ingested during the pipeline run.
+5. `sync_r2.py push-arktrace` — upload `score/*_watchlist.parquet` (with `ownership_chain` when graph edges exist).
+6. `sync_r2.py push-equasis-ownership` (Singapore job) — publish built CSV for reuse on next run.
+7. `sync_r2.py push --keep 1` — zip all region artifacts, upload generation bundle, delete previous generation.
+8. `sync_r2.py push-demo` — overwrite `demo.zip` (lightweight bundle for quick developer setup).
+9. `sync_r2.py push-sanctions-db --force` — upload `public_eval.duckdb`.
+10. Lead time validation (`validate_lead_time_ofac.py`).
+11. Metrics snapshot + email (`push_metrics_snapshot.py`, `notify_metrics.py`) — see [ref-data-publish-metrics.md](ref-data-publish-metrics.md); do not copy P@50 into git docs.
 
 ### Expected Outputs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
   - Operations:
     - Pipeline Overview: ref-pipeline.md
     - Pipeline Catalog: ref-pipeline-catalog.md
+    - Knowledge Graph: ref-knowledge-graph.md
     - Regional Playbooks: ref-regional-playbooks.md
     - R2 Buckets: ref-r2-buckets.md
     - R2 Data Layout: ref-r2-data-layout.md


### PR DESCRIPTION
## Summary
- Remove MMSI table from `config/equasis/README.md` (use CSV + tests)
- Link equasis / knowledge graph from `docs/index.md`
- Document Equasis ownership steps in `ref-pipeline-catalog.md`
- Update `indago-inspect-watchlist` skill for `--min-chain-hops 2` workflow

## Test plan
- [ ] Docs links resolve on GitHub


Made with [Cursor](https://cursor.com)