### PR TITLE
fix(pipeline): rebuild equasis CSV when seed is newer than cached version

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -275,7 +275,12 @@ def _ensure_equasis_ownership_csv(db_path: str) -> Path | None:
     explicit = os.getenv("EQUASIS_OWNERSHIP_CSV")
     if explicit and Path(explicit).is_file():
         return Path(explicit)
-    if _EQUASIS_CSV.is_file() and _EQUASIS_CSV.stat().st_size > 0:
+    seed_newer = (
+        _EQUASIS_SEED.is_file()
+        and _EQUASIS_CSV.is_file()
+        and _EQUASIS_SEED.stat().st_mtime > _EQUASIS_CSV.stat().st_mtime
+    )
+    if _EQUASIS_CSV.is_file() and _EQUASIS_CSV.stat().st_size > 0 and not seed_newer:
         return _EQUASIS_CSV
     if not _EQUASIS_SEED.is_file():
         logger.warning("  ⚠ equasis: no seed at %s — skipping ownership edges", _EQUASIS_SEED)


### PR DESCRIPTION
## Summary

- `_ensure_equasis_ownership_csv` was short-circuiting on the R2-pulled `ownership_chains.csv` even when `ownership_seed.csv` had been updated in the repo
- Added a seed-vs-CSV mtime check: if the seed is newer, the CSV is rebuilt from scratch against the current DB
- This is the root cause of why PR #176 (ANHONA/DOBRYNYA seed fix) didn't take effect in the first data-publish run after merge

## Why this matters

In CI, `pull-equasis-ownership` downloads the previous `ownership_chains.csv` from R2. Before this fix, that cached file was always reused — seed changes had no effect until someone manually deleted the R2 object. Now any commit to `ownership_seed.csv` automatically triggers a rebuild on the next CI run.

## Test plan

- [x] 723 passed, 9 skipped — full suite green

## After merge

Re-trigger data-publish to get ANHONA and DOBRYNYA to `chain_hops >= 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)