### PR TITLE
fix(pipeline): use seed content-hash to detect equasis CSV staleness

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -12,6 +12,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import logging
 import os
 import subprocess
@@ -47,6 +48,7 @@ _EQUASIS_CSV = Path(
     os.getenv("EQUASIS_OWNERSHIP_CSV", str(_MARIDB_DATA / "equasis" / "ownership_chains.csv"))
 )
 _EQUASIS_SEED = _REPO_ROOT / "config" / "equasis" / "ownership_seed.csv"
+_EQUASIS_SEED_HASH = _EQUASIS_CSV.parent / "ownership_chains.seed_hash"
 
 
 def _db(stem: str) -> str:
@@ -275,13 +277,15 @@ def _ensure_equasis_ownership_csv(db_path: str) -> Path | None:
     explicit = os.getenv("EQUASIS_OWNERSHIP_CSV")
     if explicit and Path(explicit).is_file():
         return Path(explicit)
-    seed_newer = (
-        _EQUASIS_SEED.is_file()
-        and _EQUASIS_CSV.is_file()
-        and _EQUASIS_SEED.stat().st_mtime > _EQUASIS_CSV.stat().st_mtime
-    )
-    if _EQUASIS_CSV.is_file() and _EQUASIS_CSV.stat().st_size > 0 and not seed_newer:
-        return _EQUASIS_CSV
+    if _EQUASIS_CSV.is_file() and _EQUASIS_CSV.stat().st_size > 0:
+        if _EQUASIS_SEED.is_file():
+            current_hash = hashlib.sha256(_EQUASIS_SEED.read_bytes()).hexdigest()
+            cached_hash = _EQUASIS_SEED_HASH.read_text().strip() if _EQUASIS_SEED_HASH.is_file() else ""
+            if current_hash == cached_hash:
+                return _EQUASIS_CSV
+            logger.info("  ↻ equasis: seed changed — rebuilding ownership CSV")
+        else:
+            return _EQUASIS_CSV
     if not _EQUASIS_SEED.is_file():
         logger.warning("  ⚠ equasis: no seed at %s — skipping ownership edges", _EQUASIS_SEED)
         return None
@@ -295,6 +299,7 @@ def _ensure_equasis_ownership_csv(db_path: str) -> Path | None:
     if n <= 0:
         logger.warning("  ⚠ equasis: 0 ownership rows resolved from seed")
         return None
+    _EQUASIS_SEED_HASH.write_text(hashlib.sha256(_EQUASIS_SEED.read_bytes()).hexdigest())
     logger.info("  ✓ equasis: %d ownership rows → %s", n, _EQUASIS_CSV.name)
     return _EQUASIS_CSV
 

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -1021,8 +1021,11 @@ def cmd_pull_equasis_ownership(args: argparse.Namespace) -> int:
         hash_infos = fs.get_file_info([hash_r2])
         if hash_infos[0].type != pafs.FileType.NotFound:
             _download_file(fs, hash_r2, dest.parent / "ownership_chains.seed_hash")
-    except Exception:
-        pass
+    except Exception as exc:
+        print(
+            f"Warning: failed to download optional seed hash ({hash_r2}): {exc}",
+            file=sys.stderr,
+        )
     print(f"Done. {dest.stat().st_size} B")
     return 0
 

--- a/scripts/sync_r2.py
+++ b/scripts/sync_r2.py
@@ -157,6 +157,7 @@ _GDELT_R2_KEY = "gdelt.lance.zip"  # single zip for gdelt
 _SANCTIONS_DB_R2_KEY = "public_eval.duckdb"  # OpenSanctions DB; separate from rotation zip
 _WATCHLISTS_R2_KEY = "watchlists.zip"  # lightweight bundle of *_watchlist.parquet files
 _EQUASIS_OWNERSHIP_R2_KEY = "equasis/ownership_chains.csv"  # global ownership seed output (indago#169)
+_EQUASIS_SEED_HASH_R2_KEY = "equasis/ownership_chains.seed_hash"
 _DEMO_R2_KEY = "demo.zip"  # fixed-key public demo bundle; overwritten on every push-demo
 _GFW_EO_R2_PREFIX = "gfw-eo/"  # SAR + Sentinel-2 parquets; one file per region
 _GFW_EO_REGIONS = ["singapore", "japan", "europe", "blacksea", "middleeast"]
@@ -985,6 +986,9 @@ def cmd_push_equasis_ownership(args: argparse.Namespace) -> int:
     r2_path = f"{bucket}/{_EQUASIS_OWNERSHIP_R2_KEY}"
     print(f"Uploading {local.name} ({local.stat().st_size} B) → {r2_path} ...")
     _upload_file(fs, local, r2_path)
+    hash_local = local.parent / "ownership_chains.seed_hash"
+    if hash_local.is_file():
+        _upload_file(fs, hash_local, f"{bucket}/{_EQUASIS_SEED_HASH_R2_KEY}")
     print(f"Done. Public: {_PUBLIC_BASE_URL}/{_EQUASIS_OWNERSHIP_R2_KEY}")
     return 0
 
@@ -1012,6 +1016,13 @@ def cmd_pull_equasis_ownership(args: argparse.Namespace) -> int:
     dest.parent.mkdir(parents=True, exist_ok=True)
     print(f"Downloading {_EQUASIS_OWNERSHIP_R2_KEY} → {dest} ...")
     _download_file(fs, r2_path, dest)
+    hash_r2 = f"{bucket}/{_EQUASIS_SEED_HASH_R2_KEY}"
+    try:
+        hash_infos = fs.get_file_info([hash_r2])
+        if hash_infos[0].type != pafs.FileType.NotFound:
+            _download_file(fs, hash_r2, dest.parent / "ownership_chains.seed_hash")
+    except Exception:
+        pass
     print(f"Done. {dest.stat().st_size} B")
     return 0
 

--- a/tests/test_equasis_seed_hash.py
+++ b/tests/test_equasis_seed_hash.py
@@ -1,0 +1,147 @@
+"""Tests for the seed content-hash cache invalidation in _ensure_equasis_ownership_csv."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import scripts.run_pipeline as rp
+
+
+def _write_seed(path: Path, content: str = "mmsi,manager_name\n312171000,Harry Victor\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def _seed_hash(seed_path: Path) -> str:
+    return hashlib.sha256(seed_path.read_bytes()).hexdigest()
+
+
+def _patch_paths(monkeypatch, tmp_path: Path):
+    csv_path = tmp_path / "equasis" / "ownership_chains.csv"
+    seed_path = tmp_path / "seed" / "ownership_seed.csv"
+    hash_path = tmp_path / "equasis" / "ownership_chains.seed_hash"
+    monkeypatch.setattr(rp, "_EQUASIS_CSV", csv_path)
+    monkeypatch.setattr(rp, "_EQUASIS_SEED", seed_path)
+    monkeypatch.setattr(rp, "_EQUASIS_SEED_HASH", hash_path)
+    return csv_path, seed_path, hash_path
+
+
+def test_cache_hit_returns_existing_csv(monkeypatch, tmp_path):
+    """CSV exists and hash matches → return without rebuilding."""
+    csv_path, seed_path, hash_path = _patch_paths(monkeypatch, tmp_path)
+    _write_seed(seed_path)
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    csv_path.write_text("mmsi,manager_id\n312171000,co-harry\n")
+    hash_path.write_text(_seed_hash(seed_path))
+
+    with patch("pipelines.ingest.equasis_ownership.build_ownership_csv") as mock_build:
+        result = rp._ensure_equasis_ownership_csv("unused.duckdb")
+
+    assert result == csv_path
+    mock_build.assert_not_called()
+
+
+def test_stale_cache_no_hash_file_triggers_rebuild(monkeypatch, tmp_path, tmp_db):
+    """CSV exists but no hash file → rebuild (e.g. after pulling old CSV from R2)."""
+    csv_path, seed_path, hash_path = _patch_paths(monkeypatch, tmp_path)
+    _write_seed(seed_path)
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    csv_path.write_text("mmsi,manager_id\n312171000,stale\n")
+    # hash_path intentionally absent
+
+    with patch("pipelines.ingest.equasis_ownership.build_ownership_csv", return_value=1) as mock_build:
+        result = rp._ensure_equasis_ownership_csv(tmp_db)
+
+    mock_build.assert_called_once()
+    assert result == csv_path
+
+
+def test_seed_changed_triggers_rebuild(monkeypatch, tmp_path, tmp_db):
+    """CSV exists, hash file present but mismatches current seed → rebuild."""
+    csv_path, seed_path, hash_path = _patch_paths(monkeypatch, tmp_path)
+    _write_seed(seed_path)
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    csv_path.write_text("mmsi,manager_id\n312171000,old\n")
+    hash_path.write_text("0" * 64)  # wrong hash
+
+    with patch("pipelines.ingest.equasis_ownership.build_ownership_csv", return_value=1) as mock_build:
+        result = rp._ensure_equasis_ownership_csv(tmp_db)
+
+    mock_build.assert_called_once()
+    assert result == csv_path
+
+
+def test_successful_build_writes_hash_file(monkeypatch, tmp_path, tmp_db):
+    """After a successful build, the seed hash is persisted alongside the CSV."""
+    csv_path, seed_path, hash_path = _patch_paths(monkeypatch, tmp_path)
+    _write_seed(seed_path)
+    # No CSV yet — forces build path
+
+    def fake_build(*args, **kwargs):
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        csv_path.write_text("mmsi,manager_id\n312171000,co-harry\n")
+        return 1
+
+    with patch("pipelines.ingest.equasis_ownership.build_ownership_csv", side_effect=fake_build):
+        rp._ensure_equasis_ownership_csv(tmp_db)
+
+    assert hash_path.is_file()
+    assert hash_path.read_text().strip() == _seed_hash(seed_path)
+
+
+def test_no_seed_returns_none(monkeypatch, tmp_path, tmp_db):
+    """No seed file and no CSV → return None (skip ownership edges)."""
+    csv_path, seed_path, hash_path = _patch_paths(monkeypatch, tmp_path)
+    # Neither CSV nor seed exists
+
+    result = rp._ensure_equasis_ownership_csv(tmp_db)
+
+    assert result is None
+
+
+def test_build_failure_returns_none(monkeypatch, tmp_path, tmp_db):
+    """build_ownership_csv raises → return None gracefully."""
+    csv_path, seed_path, hash_path = _patch_paths(monkeypatch, tmp_path)
+    _write_seed(seed_path)
+
+    with patch(
+        "pipelines.ingest.equasis_ownership.build_ownership_csv",
+        side_effect=RuntimeError("DB error"),
+    ):
+        result = rp._ensure_equasis_ownership_csv(tmp_db)
+
+    assert result is None
+    assert not hash_path.exists()
+
+
+def test_build_zero_rows_returns_none(monkeypatch, tmp_path, tmp_db):
+    """build_ownership_csv returns 0 rows → return None, no hash written."""
+    csv_path, seed_path, hash_path = _patch_paths(monkeypatch, tmp_path)
+    _write_seed(seed_path)
+
+    with patch("pipelines.ingest.equasis_ownership.build_ownership_csv", return_value=0):
+        result = rp._ensure_equasis_ownership_csv(tmp_db)
+
+    assert result is None
+    assert not hash_path.exists()
+
+
+def test_env_override_bypasses_hash_logic(monkeypatch, tmp_path):
+    """EQUASIS_OWNERSHIP_CSV env var always wins — hash logic not consulted."""
+    csv_path, seed_path, hash_path = _patch_paths(monkeypatch, tmp_path)
+    override = tmp_path / "override.csv"
+    override.write_text("mmsi,manager_id\n")
+    monkeypatch.setenv("EQUASIS_OWNERSHIP_CSV", str(override))
+
+    with patch("pipelines.ingest.equasis_ownership.build_ownership_csv") as mock_build:
+        result = rp._ensure_equasis_ownership_csv("unused.duckdb")
+
+    assert result == override
+    mock_build.assert_not_called()
+    monkeypatch.delenv("EQUASIS_OWNERSHIP_CSV")


### PR DESCRIPTION
## Summary

PR #177 (mtime approach) didn't work: `pull-equasis-ownership` runs *after* git checkout, so the downloaded CSV always gets a newer mtime than the checked-out seed — the cache check always returned false, and the old CSV was always reused.

This replaces mtime with a sha256 content-hash:

- After a successful build, `sha256(ownership_seed.csv)` is written to `data/processed/equasis/ownership_chains.seed_hash`
- On the next run: if the current seed hash matches the stored hash → use cache; otherwise → rebuild
- `push/pull-equasis-ownership` now includes the `.seed_hash` sidecar so the hash persists across CI runs

**Effect in CI:**
1. This run: no hash file on R2 → `cached_hash = ""` ≠ `current_hash` → rebuild from new seed → ANHONA and DOBRYNYA get `chain_hops >= 2`
2. Subsequent runs with unchanged seed: hash matches → cache hit, no rebuild

## Test plan

- [x] 723 passed, 9 skipped — full suite green

## After merge

Trigger data-publish; verify with `inspect_watchlist --mmsi 312171000 273449240` expecting `chain_hops >= 2` for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)