### PR TITLE
feat(maritime-cyber): W0 rule pack, ontology, and fixture schema

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,14 @@
+{
+  "MD013": false,
+  "MD033": false,
+  "MD034": false,
+  "MD035": false,
+  "MD036": false,
+  "MD041": false,
+  "MD060": false,
+  "MD025": false,
+  "MD001": false,
+  "MD024": {
+    "siblings_only": true
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@ Multi-domain OSINT data layer. indago ingests raw signals from maritime, corpora
 | `scripts/notify_metrics.py` | Data-publish summary email |
 | `scripts/fetch_publish_metrics.py` | Fetch latest metrics from public R2 (no credentials) |
 | `config/sanction_regimes.yaml` | Configurable sanction regime definitions |
+| `profiles/maritime_cyber/` | Port Cyber Clearance ontology + manifest (Cap Vista PoC) |
+| `rules/sg-cyber-clearance-v0.yaml` | Singapore clearance rule pack (E26/E27-inspired) |
+| `fixtures/` | Maritime cyber PoC fixtures (`asset_map.yaml`, SBOM, CVE — W1+) |
+| `pipelines/maritime_cyber/` | Rule pack loader; graph/eval pipelines (W2–W3) |
 | `config/geopolitical_events.json` | Geopolitical filter zones |
 
 ## R2 buckets

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,39 @@
+# Maritime cyber fixtures — Port Cyber Clearance PoC
+
+## Disclosure (portal honesty)
+
+> PoC uses **public CVE feeds** and **representative SBOM fixtures** with a documented **synthetic OT inventory map** (`asset_map.yaml`). Production deployment replaces fixtures with operator-signed manifests and optional OCEANS-X integration.
+
+This matches [maritime-cyber-governance-use-cases.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/strategy/maritime-cyber-governance-use-cases.md) §3.
+
+## Layout
+
+| Path | Layer | Status |
+|------|-------|--------|
+| `cve/snapshot-*.json` | Public (pinned OSV/NVD subset) | W1 — G1 |
+| `sbom/vessel-hold.json` | Synthetic — critical CVE on ECDIS path | W1 — G2 |
+| `sbom/vessel-clean.json` | Synthetic — no open criticals | W1 — G2 |
+| `sbom/vessel-thread.json` | Synthetic — clean + signed ProcessLog (UC3) | W1 — G2 |
+| `asset_map.yaml` | **Synthetic bridge** — OT ↔ firmware ↔ SBOM components | W0 schema · W1 data |
+| `port_calls/*.json` | Synthetic — OCEANS-X-shaped port-call events | W1 |
+| `process_logs/*.json` | Synthetic — yard patch / scan records | W1 |
+
+## Synthetic bridge (`asset_map.yaml`)
+
+`asset_map.yaml` is **not** from a live yard or class society. It models IACS UR E27-style CBS inventory fields (`ecu_zone`, `network_zone`, `cbs_category`, `safety_function`) and links physical assets to firmware images and SBOM component references.
+
+**Pilot path:** Replace this file with a customer-signed inventory manifest — graph and rule evaluation pipeline unchanged.
+
+## Demo narrative (three vessels)
+
+| Vessel key | Expected clearance | Story |
+|------------|-------------------|--------|
+| `vessel-hold` | **hold** | Stale Log4j-class component on ECDIS navigation path (pinned CVE) |
+| `vessel-clean` | **pass** | No rule triggers on current snapshot |
+| `vessel-thread` | **pass** | Clean SBOM + signed yard `ProcessLog` for UC3 timeline slide |
+
+## Profile and rules
+
+- Profile manifest: `profiles/maritime_cyber/manifest.yaml`
+- Rule pack: `rules/sg-cyber-clearance-v0.yaml`
+- Requirements matrix: `edgesentry-commercial/.../regulatory-requirements-matrix.md`

--- a/fixtures/asset_map.yaml
+++ b/fixtures/asset_map.yaml
@@ -1,0 +1,64 @@
+# Synthetic OT inventory bridge — IACS UR E27-style CBS fields (PoC)
+# NOT production yard/class data. See fixtures/README.md
+
+version: "0.1.0"
+synthetic: true
+
+vessels:
+  vessel-hold:
+    imo: "IMO9990001"
+    display_name: Demo Hold (ECDIS path)
+    physical_assets:
+      - id: ecdis-01
+        name: ECDIS Workstation
+        cbs_category: navigation
+        safety_function: essential
+        ecu_zone: bridge_nav
+        network_zone: zone_1
+        location_onboard: bridge
+        manufacturer: Demo Marine Electronics
+        firmware:
+          id: ecdis-fw-2023.4
+          version: "2023.4"
+          contains:
+            - purl: pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1
+              component_name: log4j-core
+
+  vessel-clean:
+    imo: "IMO9990002"
+    display_name: Demo Clean
+    physical_assets:
+      - id: ecdis-01
+        name: ECDIS Workstation
+        cbs_category: navigation
+        safety_function: essential
+        ecu_zone: bridge_nav
+        network_zone: zone_1
+        location_onboard: bridge
+        manufacturer: Demo Marine Electronics
+        firmware:
+          id: ecdis-fw-2024.2
+          version: "2024.2"
+          contains:
+            - purl: pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1
+              component_name: log4j-core
+
+  vessel-thread:
+    imo: "IMO9990003"
+    display_name: Demo Thread (UC3)
+    physical_assets:
+      - id: ecdis-01
+        name: ECDIS Workstation
+        cbs_category: navigation
+        safety_function: essential
+        ecu_zone: bridge_nav
+        network_zone: zone_1
+        location_onboard: bridge
+        manufacturer: Demo Marine Electronics
+        firmware:
+          id: ecdis-fw-2024.2
+          version: "2024.2"
+          contains:
+            - purl: pkg:maven/org.apache.logging.log4j/log4j-core@2.23.1
+              component_name: log4j-core
+    process_log_ref: yard-jp-42

--- a/pipelines/maritime_cyber/__init__.py
+++ b/pipelines/maritime_cyber/__init__.py
@@ -1,0 +1,15 @@
+"""Maritime cyber clearance pipelines — Port Cyber Clearance PoC."""
+
+from pipelines.maritime_cyber.rules import (
+    KNOWN_REQUIREMENT_IDS,
+    load_asset_map,
+    load_rule_pack,
+    validate_rule_pack,
+)
+
+__all__ = [
+    "KNOWN_REQUIREMENT_IDS",
+    "load_asset_map",
+    "load_rule_pack",
+    "validate_rule_pack",
+]

--- a/pipelines/maritime_cyber/rules.py
+++ b/pipelines/maritime_cyber/rules.py
@@ -1,0 +1,141 @@
+"""Load and validate maritime cyber rule packs and fixture schemas (W0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RULE_PACK = _REPO_ROOT / "rules" / "sg-cyber-clearance-v0.yaml"
+DEFAULT_ASSET_MAP = _REPO_ROOT / "fixtures" / "asset_map.yaml"
+PROFILE_MANIFEST = _REPO_ROOT / "profiles" / "maritime_cyber" / "manifest.yaml"
+
+KNOWN_REQUIREMENT_IDS = frozenset(
+    {
+        "IACS-E26-1",
+        "IACS-E27-2",
+        "IACS-E27-3",
+        "IMO-428-5",
+        "IMO-FAL3-2",
+        "IEC-62443-2-1",
+        "IEC-62443-TR2-3",
+        "NTIA-SBOM-7",
+        "OSV-1",
+    }
+)
+
+REQUIRED_ASSET_FIELDS = frozenset(
+    {
+        "id",
+        "name",
+        "cbs_category",
+        "safety_function",
+        "ecu_zone",
+        "network_zone",
+    }
+)
+
+VALID_CBS_CATEGORIES = frozenset(
+    {"navigation", "propulsion", "cargo", "communications", "other"}
+)
+
+VALID_SAFETY_FUNCTIONS = frozenset({"essential", "important", "normal"})
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        msg = f"Expected mapping at root of {path}"
+        raise ValueError(msg)
+    return data
+
+
+def load_rule_pack(path: Path | None = None) -> dict[str, Any]:
+    """Load the Singapore cyber clearance rule pack."""
+    return _load_yaml(path or DEFAULT_RULE_PACK)
+
+
+def load_asset_map(path: Path | None = None) -> dict[str, Any]:
+    """Load the synthetic OT inventory bridge."""
+    return _load_yaml(path or DEFAULT_ASSET_MAP)
+
+
+def load_profile_manifest(path: Path | None = None) -> dict[str, Any]:
+    """Load the maritime_cyber profile manifest."""
+    return _load_yaml(path or PROFILE_MANIFEST)
+
+
+def validate_rule_pack(pack: dict[str, Any]) -> list[str]:
+    """Return validation errors (empty if valid)."""
+    errors: list[str] = []
+    rules = pack.get("rules")
+    if not isinstance(rules, list) or not rules:
+        errors.append("rule pack must contain a non-empty 'rules' list")
+        return errors
+
+    if len(rules) < 5 or len(rules) > 15:
+        errors.append(f"expected 5–15 rules, got {len(rules)}")
+
+    seen_ids: set[str] = set()
+    for i, rule in enumerate(rules):
+        prefix = f"rules[{i}]"
+        if not isinstance(rule, dict):
+            errors.append(f"{prefix}: must be a mapping")
+            continue
+        rule_id = rule.get("id")
+        if not rule_id or not isinstance(rule_id, str):
+            errors.append(f"{prefix}: missing string 'id'")
+            continue
+        if rule_id in seen_ids:
+            errors.append(f"{prefix}: duplicate id {rule_id!r}")
+        seen_ids.add(rule_id)
+
+        reqs = rule.get("requirements")
+        if not isinstance(reqs, list) or not reqs:
+            errors.append(f"{prefix} ({rule_id}): missing 'requirements' list")
+        else:
+            for req in reqs:
+                if req not in KNOWN_REQUIREMENT_IDS:
+                    errors.append(f"{prefix} ({rule_id}): unknown requirement id {req!r}")
+
+        cond = rule.get("condition")
+        if not isinstance(cond, dict) or "type" not in cond:
+            errors.append(f"{prefix} ({rule_id}): condition must include 'type'")
+
+        if rule.get("outcome") not in ("hold", "pass", "investigate"):
+            errors.append(f"{prefix} ({rule_id}): invalid outcome")
+
+    return errors
+
+
+def validate_asset_map(asset_map: dict[str, Any]) -> list[str]:
+    """Validate E27-style inventory fields on all physical assets."""
+    errors: list[str] = []
+    vessels = asset_map.get("vessels")
+    if not isinstance(vessels, dict) or not vessels:
+        errors.append("asset_map must contain non-empty 'vessels'")
+        return errors
+
+    for vessel_key, vessel in vessels.items():
+        assets = vessel.get("physical_assets") if isinstance(vessel, dict) else None
+        if not isinstance(assets, list) or not assets:
+            errors.append(f"vessels.{vessel_key}: missing physical_assets")
+            continue
+        for j, asset in enumerate(assets):
+            prefix = f"vessels.{vessel_key}.physical_assets[{j}]"
+            if not isinstance(asset, dict):
+                errors.append(f"{prefix}: must be a mapping")
+                continue
+            missing = REQUIRED_ASSET_FIELDS - set(asset)
+            if missing:
+                errors.append(f"{prefix}: missing fields {sorted(missing)}")
+            cat = asset.get("cbs_category")
+            if cat and cat not in VALID_CBS_CATEGORIES:
+                errors.append(f"{prefix}: invalid cbs_category {cat!r}")
+            sf = asset.get("safety_function")
+            if sf and sf not in VALID_SAFETY_FUNCTIONS:
+                errors.append(f"{prefix}: invalid safety_function {sf!r}")
+    return errors

--- a/profiles/maritime_cyber/manifest.yaml
+++ b/profiles/maritime_cyber/manifest.yaml
@@ -1,0 +1,33 @@
+# EdgeSentry maritime cyber profile — Port Cyber Clearance PoC
+# See: edgesentry-commercial/docs/programs/20260630-capvista-products/analysis/
+
+version: "0.1.0"
+profile_id: maritime_cyber
+display_name: Maritime Cyber — Port Clearance (Singapore PoC)
+
+ontology:
+  file: ontology.yaml
+  version: "0.1.0"
+
+rule_pack:
+  file: ../../rules/sg-cyber-clearance-v0.yaml
+  version: "0.1.0"
+
+fixtures:
+  asset_map: ../../fixtures/asset_map.yaml
+  sbom_dir: ../../fixtures/sbom
+  cve_dir: ../../fixtures/cve
+  port_calls_dir: ../../fixtures/port_calls
+  process_logs_dir: ../../fixtures/process_logs
+
+pipelines:
+  graph: maritime_cyber_graph
+  evaluate: port_clearance_eval
+
+outputs:
+  parquet_dir: data/processed/maritime_cyber
+
+disclosure: >
+  PoC uses public CVE snapshots and representative SBOM fixtures with a documented
+  synthetic OT inventory map (asset_map.yaml). Production replaces fixtures with
+  operator-signed manifests.

--- a/profiles/maritime_cyber/ontology.yaml
+++ b/profiles/maritime_cyber/ontology.yaml
@@ -1,0 +1,107 @@
+# Maritime cyber ontology v0.1 — graph schema contract
+# Relational projection: nodes.parquet / edges.parquet (see technical-architecture.md)
+
+version: "0.1.0"
+
+node_classes:
+  Vessel:
+    key: vessel_id
+    properties:
+      imo: { type: string, optional: true }
+      mmsi: { type: string, optional: true }
+      name: { type: string, optional: true }
+
+  PhysicalAsset:
+    key: asset_id
+    description: Onboard CBS / OT unit (E27 inventory)
+    properties:
+      id: { type: string, required: true }
+      name: { type: string, required: true }
+      cbs_category:
+        type: enum
+        values: [navigation, propulsion, cargo, communications, other]
+        maps_to: IACS-E27-2
+      safety_function:
+        type: enum
+        values: [essential, important, normal]
+        maps_to: IACS-E27-2
+      ecu_zone: { type: string, required: true, maps_to: IACS-E27-3 }
+      network_zone: { type: string, required: true, maps_to: IACS-E27-3 }
+      location_onboard: { type: string, optional: true }
+      manufacturer: { type: string, optional: true }
+
+  Firmware:
+    key: firmware_id
+    properties:
+      id: { type: string, required: true }
+      version: { type: string, required: true }
+      image_hash: { type: string, optional: true }
+
+  SoftwareComponent:
+    key: component_ref
+    properties:
+      name: { type: string, required: true }
+      version: { type: string, required: true }
+      purl: { type: string, optional: true }
+      cpe: { type: string, optional: true }
+      supplier_name: { type: string, optional: true, maps_to: NTIA-SBOM-7 }
+
+  SBOM:
+    key: sbom_id
+    properties:
+      format: { type: string, default: CycloneDX }
+      spec_version: { type: string }
+      content_hash: { type: string }
+
+  CVE:
+    key: cve_id
+    properties:
+      osv_id: { type: string }
+      cvss_score: { type: float, optional: true }
+      severity: { type: string, optional: true }
+      in_kev: { type: boolean, default: false }
+
+  ComplianceRule:
+    key: rule_id
+    source: rules/sg-cyber-clearance-v0.yaml
+
+  ProcessLog:
+    key: log_id
+    properties:
+      event_type: { type: string }
+      signed_at: { type: datetime }
+      yard_id: { type: string, optional: true }
+
+  PortCall:
+    key: port_call_id
+    properties:
+      port_unlocode: { type: string }
+      arrival_time: { type: datetime }
+      berth_request: { type: boolean, default: true }
+
+  ClearanceDecision:
+    key: decision_id
+    properties:
+      outcome: { type: enum, values: [pass, hold, investigate] }
+      rules_fired: { type: array, items: string }
+      decision_hash: { type: string }
+
+  AuditRecord:
+    key: record_id
+    external: edgesentry-rs
+
+edge_types:
+  hasSBOM: { from: Vessel, to: SBOM }
+  lists: { from: SBOM, to: SoftwareComponent }
+  affectedBy: { from: SoftwareComponent, to: CVE }
+  hasAsset: { from: Vessel, to: PhysicalAsset }
+  runs: { from: PhysicalAsset, to: Firmware }
+  contains: { from: Firmware, to: SoftwareComponent }
+  appliesTo: { from: ProcessLog, to: Vessel }
+  for: { from: PortCall, to: Vessel }
+  evaluates: { from: ClearanceDecision, to: PortCall }
+  seals: { from: AuditRecord, to: ClearanceDecision }
+
+mandatory_cbs_categories:
+  - navigation
+  description: Minimum inventory categories per SG-CC-009 (PoC demo fleet)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pandas>=2.0",
     "pandera[polars]>=0.21",
     "boto3>=1.34",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,11 @@
+# Compliance rule packs (indago)
+
+Machine-readable rule packs for domain profiles. Each pack maps public regulatory summaries to deterministic `condition` types consumed by evaluation pipelines.
+
+| Pack | Profile | Status |
+|------|---------|--------|
+| [sg-cyber-clearance-v0.yaml](sg-cyber-clearance-v0.yaml) | `maritime_cyber` | PoC — Cap Vista 6/30 |
+
+**Traceability matrix:** [regulatory-requirements-matrix.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/regulatory-requirements-matrix.md)
+
+**Loader:** `pipelines/maritime_cyber/rules.py`

--- a/rules/sg-cyber-clearance-v0.yaml
+++ b/rules/sg-cyber-clearance-v0.yaml
@@ -1,0 +1,123 @@
+# Singapore Port Cyber Clearance — rule pack v0.1 (PoC)
+# Traceability: edgesentry-commercial/.../regulatory-requirements-matrix.md
+# Evaluator: pipelines/maritime_cyber/port_clearance_eval.py (W3)
+
+version: "0.1.0"
+pack_id: sg-cyber-clearance-v0
+jurisdiction: SG
+description: >
+  Deterministic clearance rules derived from public summaries of IACS UR E26/E27,
+  IMO MSC.428(98), IEC 62443, and NTIA SBOM minimum elements. Not legal advice.
+
+default_outcome: pass
+aggregate: any_hold_rule_fired_implies_hold
+
+parameters:
+  critical_cvss_threshold: 9.0
+  high_cvss_threshold: 7.0
+  safety_patch_sla_days: 30
+  process_log_window_days: 90
+
+rules:
+  - id: SG-CC-001
+    title: Critical CVE on safety-related CBS
+    severity: critical
+    outcome: hold
+    requirements: [IACS-E26-1, IACS-E27-2, IMO-428-5]
+    condition:
+      type: cve_on_asset_path
+      match:
+        cvss_gte: 9.0
+        safety_function_in: [essential, important]
+        path: [PhysicalAsset, Firmware, SoftwareComponent, CVE]
+
+  - id: SG-CC-002
+    title: High CVE on navigation or ECDIS software path
+    severity: high
+    outcome: hold
+    requirements: [IACS-E26-1, IACS-E27-2, IMO-428-5]
+    condition:
+      type: cve_on_asset_path
+      match:
+        cvss_gte: 7.0
+        cbs_category_in: [navigation]
+        path: [PhysicalAsset, Firmware, SoftwareComponent, CVE]
+
+  - id: SG-CC-003
+    title: SBOM component missing supplier name (NTIA minimum)
+    severity: medium
+    outcome: hold
+    requirements: [NTIA-SBOM-7, IMO-428-5]
+    condition:
+      type: sbom_field_missing
+      field: supplier.name
+
+  - id: SG-CC-004
+    title: SBOM component missing version
+    severity: medium
+    outcome: hold
+    requirements: [NTIA-SBOM-7, IMO-428-5]
+    condition:
+      type: sbom_field_missing
+      field: version
+
+  - id: SG-CC-005
+    title: SBOM component missing package identifier (PURL or CPE)
+    severity: medium
+    outcome: hold
+    requirements: [NTIA-SBOM-7]
+    condition:
+      type: sbom_identifier_missing
+      require_any: [purl, cpe]
+
+  - id: SG-CC-006
+    title: CBS inventory missing network zone (E27)
+    severity: high
+    outcome: hold
+    requirements: [IACS-E27-2, IACS-E27-3]
+    condition:
+      type: asset_map_field_missing
+      fields: [ecu_zone, network_zone]
+
+  - id: SG-CC-007
+    title: Known exploited vulnerability present on vessel SBOM path
+    severity: critical
+    outcome: hold
+    requirements: [IMO-428-5, OSV-1]
+    condition:
+      type: cve_flag
+      flag: in_kev
+      value: true
+
+  - id: SG-CC-008
+    title: Critical patch applied without signed ProcessLog in window
+    severity: medium
+    outcome: hold
+    requirements: [IEC-62443-2-1, IMO-428-5]
+    condition:
+      type: process_log_required
+      when:
+        critical_cve_open: true
+      within_days: 90
+      require_signed: true
+
+  - id: SG-CC-009
+    title: Mandatory CBS categories not inventoried for vessel
+    severity: medium
+    outcome: hold
+    requirements: [IACS-E27-2, IMO-428-5]
+    condition:
+      type: mandatory_cbs_categories
+      required: [navigation]
+
+  - id: SG-CC-010
+    title: Critical CVE open beyond patch SLA on safety zone asset
+    severity: high
+    outcome: hold
+    requirements: [IEC-62443-TR2-3, IACS-E26-1]
+    condition:
+      type: patch_age_exceeded
+      match:
+        cvss_gte: 9.0
+        safety_function_in: [essential]
+        max_age_days: 30

--- a/tests/maritime_cyber/test_rule_pack.py
+++ b/tests/maritime_cyber/test_rule_pack.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 
-import pytest
-
 from pipelines.maritime_cyber.rules import (
     KNOWN_REQUIREMENT_IDS,
     load_asset_map,

--- a/tests/maritime_cyber/test_rule_pack.py
+++ b/tests/maritime_cyber/test_rule_pack.py
@@ -1,0 +1,57 @@
+"""W0 — rule pack and asset_map schema validation."""
+
+from pathlib import Path
+
+import pytest
+
+from pipelines.maritime_cyber.rules import (
+    KNOWN_REQUIREMENT_IDS,
+    load_asset_map,
+    load_profile_manifest,
+    load_rule_pack,
+    validate_asset_map,
+    validate_rule_pack,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_rule_pack_loads_and_validates() -> None:
+    pack = load_rule_pack()
+    assert pack["pack_id"] == "sg-cyber-clearance-v0"
+    errors = validate_rule_pack(pack)
+    assert errors == [], errors
+    rule_ids = {r["id"] for r in pack["rules"]}
+    assert "SG-CC-001" in rule_ids
+    assert len(pack["rules"]) >= 5
+
+
+def test_every_rule_cites_known_requirement() -> None:
+    pack = load_rule_pack()
+    for rule in pack["rules"]:
+        for req in rule["requirements"]:
+            assert req in KNOWN_REQUIREMENT_IDS, f"{rule['id']}: {req}"
+
+
+def test_asset_map_e27_fields() -> None:
+    asset_map = load_asset_map()
+    assert asset_map.get("synthetic") is True
+    errors = validate_asset_map(asset_map)
+    assert errors == [], errors
+    assert set(asset_map["vessels"]) >= {"vessel-hold", "vessel-clean", "vessel-thread"}
+
+
+def test_profile_manifest_points_at_rule_pack() -> None:
+    manifest = load_profile_manifest()
+    assert manifest["profile_id"] == "maritime_cyber"
+    rule_path = REPO_ROOT / "rules" / "sg-cyber-clearance-v0.yaml"
+    assert rule_path.is_file()
+
+
+def test_regulatory_matrix_ids_align_with_rule_pack() -> None:
+    """Requirement IDs in rules must be subset of W0 matrix (code-defined set)."""
+    pack = load_rule_pack()
+    cited: set[str] = set()
+    for rule in pack["rules"]:
+        cited.update(rule["requirements"])
+    assert cited <= KNOWN_REQUIREMENT_IDS

--- a/uv.lock
+++ b/uv.lock
@@ -386,6 +386,7 @@ dependencies = [
     { name = "pylance" },
     { name = "python-dotenv" },
     { name = "pytz" },
+    { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "websockets" },
 ]
@@ -413,6 +414,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pytz", specifier = ">=2026.1.post1" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "scikit-learn", specifier = ">=1.5" },
     { name = "websockets", specifier = ">=12.0" },
 ]


### PR DESCRIPTION
## Summary
- **`rules/sg-cyber-clearance-v0.yaml`** — 10 deterministic clearance rules; each cites ≥1 public requirement ID
- **`profiles/maritime_cyber/`** — manifest + ontology (E27-style `PhysicalAsset` fields)
- **`fixtures/asset_map.yaml`** + README — synthetic bridge disclosure; 3-vessel template
- **`pipelines/maritime_cyber/rules.py`** — load/validate rule pack and asset map
- **`tests/maritime_cyber/`** — 5 validation tests

## Related
- edgesentry-commercial: regulatory traceability matrix (companion PR)
- Cap Vista W0 — enables W1 (#180) fixtures and W3 eval

## Test plan
- [x] `uv sync --extra test && uv run pytest tests/maritime_cyber/ -q` (5 passed)
- [ ] After merge: W1 adds CVE snapshot + CycloneDX SBOM fixtures

Made with [Cursor](https://cursor.com)