### PR TITLE
feat(maritime-cyber): W3 port_clearance_eval + UC2 query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ Multi-domain OSINT data layer. indago ingests raw signals from maritime, corpora
 | `fixtures/` | Maritime cyber PoC fixtures (`asset_map.yaml`, SBOM, CVE — W1+) |
 | `pipelines/maritime_cyber/` | Rule pack loader; graph build (`graph.py`); eval (W3) |
 | `pipelines/maritime_cyber_graph.py` | CLI — build graph Parquet under `data/processed/maritime_cyber/` |
+| `pipelines/port_clearance_eval.py` | CLI — pass/hold eval + UC2 `affected-vessels` |
+| `pipelines/maritime_cyber/eval.py` | Rule engine, facts.json, decision_hash (W3) |
 | `config/geopolitical_events.json` | Geopolitical filter zones |
 
 ## R2 buckets

--- a/pipelines/maritime_cyber/__init__.py
+++ b/pipelines/maritime_cyber/__init__.py
@@ -8,6 +8,13 @@ from pipelines.maritime_cyber.graph import (
     to_networkx,
     write_graph_parquet,
 )
+from pipelines.maritime_cyber.eval import (
+    EvaluationResult,
+    RuleHit,
+    affected_vessels,
+    evaluate_port_clearance,
+    write_evaluation_artifacts,
+)
 from pipelines.maritime_cyber.rules import (
     KNOWN_REQUIREMENT_IDS,
     load_asset_map,
@@ -18,14 +25,19 @@ from pipelines.maritime_cyber.rules import (
 
 __all__ = [
     "KNOWN_REQUIREMENT_IDS",
+    "EvaluationResult",
     "GraphBuildResult",
+    "RuleHit",
+    "affected_vessels",
     "affected_vessels_for_cve",
     "build_maritime_cyber_graph",
+    "evaluate_port_clearance",
     "load_asset_map",
     "load_graph_from_parquet",
     "load_rule_pack",
     "to_networkx",
     "validate_asset_map",
     "validate_rule_pack",
+    "write_evaluation_artifacts",
     "write_graph_parquet",
 ]

--- a/pipelines/maritime_cyber/eval.py
+++ b/pipelines/maritime_cyber/eval.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 

--- a/pipelines/maritime_cyber/eval.py
+++ b/pipelines/maritime_cyber/eval.py
@@ -1,0 +1,380 @@
+"""Deterministic port cyber clearance evaluation (W3)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+import polars as pl
+
+from pipelines.maritime_cyber.graph import (
+    DEFAULT_CVE_SNAPSHOT,
+    DEFAULT_SBOM_DIR,
+    GraphBuildResult,
+    affected_vessels_for_cve,
+    build_maritime_cyber_graph,
+    load_sbom,
+)
+from pipelines.maritime_cyber.rules import DEFAULT_RULE_PACK, load_asset_map, load_rule_pack
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = _REPO_ROOT / "data/processed/maritime_cyber"
+
+
+@dataclass(frozen=True)
+class RuleHit:
+    rule_id: str
+    title: str
+    severity: str
+    outcome: str
+    requirements: list[str]
+    evidence: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    vessel_key: str
+    port_call_id: str
+    outcome: str
+    rules_fired: tuple[RuleHit, ...]
+    facts: dict[str, Any]
+    manifest: dict[str, Any]
+    decision_hash: str
+
+
+def _file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _canonical_hash(payload: dict[str, Any]) -> str:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def normalize_cve_node_id(cve_id: str) -> str:
+    if cve_id.startswith("cve:"):
+        return cve_id
+    if cve_id.upper().startswith("CVE-"):
+        return f"cve:{cve_id.upper()}"
+    return f"cve:{cve_id}"
+
+
+def node_properties(nodes: pl.DataFrame, node_id: str) -> dict[str, Any]:
+    rows = nodes.filter(pl.col("node_id") == node_id)
+    if len(rows) == 0:
+        return {}
+    raw = rows["properties"][0]
+    if not raw:
+        return {}
+    parsed = json.loads(raw)
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def iter_cve_asset_paths(
+    graph: nx.DiGraph,
+    nodes: pl.DataFrame,
+    vessel_key: str,
+) -> list[dict[str, Any]]:
+    """Forward walk: vessel → asset → firmware → component → CVE."""
+    vessel_id = f"vessel:{vessel_key}"
+    if vessel_id not in graph:
+        return []
+    paths: list[dict[str, Any]] = []
+    for asset_id in graph.successors(vessel_id):
+        if graph.nodes[asset_id].get("node_type") != "PhysicalAsset":
+            continue
+        asset_props = node_properties(nodes, asset_id)
+        for fw_id in graph.successors(asset_id):
+            if graph.edges.get((asset_id, fw_id), {}).get("rel_type") != "runs":
+                continue
+            for comp_id in graph.successors(fw_id):
+                if graph.edges.get((fw_id, comp_id), {}).get("rel_type") != "contains":
+                    continue
+                for cve_id in graph.successors(comp_id):
+                    if graph.edges.get((comp_id, cve_id), {}).get("rel_type") != "affectedBy":
+                        continue
+                    cve_props = node_properties(nodes, cve_id)
+                    paths.append(
+                        {
+                            "vessel_id": vessel_id,
+                            "asset_id": asset_id,
+                            "firmware_id": fw_id,
+                            "component_id": comp_id,
+                            "cve_id": cve_id,
+                            "asset": asset_props,
+                            "cve": cve_props,
+                            "component": node_properties(nodes, comp_id),
+                        }
+                    )
+    return paths
+
+
+def _match_cve_on_asset_path(path: dict[str, Any], match: dict[str, Any]) -> bool:
+    cve = path.get("cve") or {}
+    asset = path.get("asset") or {}
+    cvss = cve.get("cvss_score")
+    if cvss is None:
+        return False
+    if float(cvss) < float(match.get("cvss_gte", 0)):
+        return False
+    sf_in = match.get("safety_function_in")
+    if sf_in and asset.get("safety_function") not in sf_in:
+        return False
+    cat_in = match.get("cbs_category_in")
+    if cat_in and asset.get("cbs_category") not in cat_in:
+        return False
+    return True
+
+
+def _evaluate_rule(
+    rule: dict[str, Any],
+    *,
+    vessel_key: str,
+    graph: nx.DiGraph,
+    nodes: pl.DataFrame,
+    asset_map: dict[str, Any],
+    sbom_components: list[dict[str, Any]],
+    cve_paths: list[dict[str, Any]],
+) -> RuleHit | None:
+    rule_id = str(rule["id"])
+    cond = rule.get("condition") or {}
+    ctype = cond.get("type")
+    evidence: dict[str, Any] = {}
+
+    if ctype == "cve_on_asset_path":
+        match = cond.get("match") or {}
+        for path in cve_paths:
+            if _match_cve_on_asset_path(path, match):
+                evidence = {
+                    "path": [
+                        path["asset_id"],
+                        path["firmware_id"],
+                        path["component_id"],
+                        path["cve_id"],
+                    ],
+                    "cve_id": path["cve_id"],
+                    "cvss_score": path["cve"].get("cvss_score"),
+                    "cbs_category": path["asset"].get("cbs_category"),
+                }
+                break
+        else:
+            return None
+
+    elif ctype == "sbom_field_missing":
+        field_name = str(cond.get("field", ""))
+        missing: list[str] = []
+        for comp in sbom_components:
+            if field_name == "supplier.name":
+                supplier = comp.get("supplier") or {}
+                if not isinstance(supplier, dict) or not supplier.get("name"):
+                    missing.append(str(comp.get("purl") or comp.get("name")))
+            elif field_name == "version":
+                if not comp.get("version"):
+                    missing.append(str(comp.get("purl") or comp.get("name")))
+        if not missing:
+            return None
+        evidence = {"missing_components": missing, "field": field_name}
+
+    elif ctype == "sbom_identifier_missing":
+        require_any = cond.get("require_any") or ["purl", "cpe"]
+        missing = []
+        for comp in sbom_components:
+            if not any(comp.get(k) for k in require_any):
+                missing.append(str(comp.get("name")))
+        if not missing:
+            return None
+        evidence = {"missing_identifiers": missing}
+
+    elif ctype == "asset_map_field_missing":
+        fields = cond.get("fields") or []
+        vessels = asset_map.get("vessels") or {}
+        vessel_cfg = vessels.get(vessel_key) or {}
+        gaps: list[dict[str, str]] = []
+        for asset in vessel_cfg.get("physical_assets") or []:
+            if not isinstance(asset, dict):
+                continue
+            for fld in fields:
+                if not asset.get(fld):
+                    gaps.append({"asset_id": str(asset.get("id")), "field": fld})
+        if not gaps:
+            return None
+        evidence = {"gaps": gaps}
+
+    elif ctype == "cve_flag":
+        flag = cond.get("flag")
+        want = cond.get("value")
+        for path in cve_paths:
+            if path["cve"].get(flag) == want:
+                evidence = {"cve_id": path["cve_id"], flag: want}
+                break
+        else:
+            return None
+
+    elif ctype == "mandatory_cbs_categories":
+        required = set(cond.get("required") or [])
+        vessels = asset_map.get("vessels") or {}
+        vessel_cfg = vessels.get(vessel_key) or {}
+        present = {
+            a.get("cbs_category")
+            for a in (vessel_cfg.get("physical_assets") or [])
+            if isinstance(a, dict) and a.get("cbs_category")
+        }
+        missing_cats = sorted(required - present)
+        if not missing_cats:
+            return None
+        evidence = {"missing_categories": missing_cats}
+
+    elif ctype in ("process_log_required", "patch_age_exceeded"):
+        # PoC: no ProcessLog fixtures or CVE published_at in snapshot — never auto-fire
+        return None
+
+    else:
+        return None
+
+    return RuleHit(
+        rule_id=rule_id,
+        title=str(rule.get("title", "")),
+        severity=str(rule.get("severity", "")),
+        outcome=str(rule.get("outcome", "hold")),
+        requirements=list(rule.get("requirements") or []),
+        evidence=evidence,
+    )
+
+
+def evaluate_port_clearance(
+    vessel_key: str,
+    *,
+    port_call_id: str = "port-call-demo-sgsin",
+    graph_result: GraphBuildResult | None = None,
+    rule_pack_path: Path | None = None,
+    asset_map_path: Path | None = None,
+    cve_snapshot_path: Path | None = None,
+    sbom_dir: Path | None = None,
+) -> EvaluationResult:
+    """Evaluate clearance for one vessel; deterministic on pinned fixtures."""
+    pack = load_rule_pack(rule_pack_path)
+    asset_map = load_asset_map(asset_map_path)
+    gresult = graph_result or build_maritime_cyber_graph(
+        [vessel_key],
+        asset_map_path=asset_map_path,
+        cve_snapshot_path=cve_snapshot_path,
+        sbom_dir=sbom_dir,
+    )
+    g = gresult.nx_graph
+    nodes = gresult.nodes
+
+    sbom_path = (sbom_dir or DEFAULT_SBOM_DIR) / f"{vessel_key}.json"
+    sbom_components = load_sbom(sbom_path) if sbom_path.is_file() else []
+    cve_paths = iter_cve_asset_paths(g, nodes, vessel_key)
+
+    hits: list[RuleHit] = []
+    for rule in pack.get("rules") or []:
+        if not isinstance(rule, dict):
+            continue
+        hit = _evaluate_rule(
+            rule,
+            vessel_key=vessel_key,
+            graph=g,
+            nodes=nodes,
+            asset_map=asset_map,
+            sbom_components=sbom_components,
+            cve_paths=cve_paths,
+        )
+        if hit is not None:
+            hits.append(hit)
+
+    hold_outcomes = {h.outcome for h in hits if h.outcome == "hold"}
+    outcome = "hold" if hold_outcomes else str(pack.get("default_outcome", "pass"))
+
+    cve_path = cve_snapshot_path or DEFAULT_CVE_SNAPSHOT
+    rule_path = rule_pack_path or DEFAULT_RULE_PACK
+    manifest = {
+        "vessel_key": vessel_key,
+        "port_call_id": port_call_id,
+        "rule_pack_id": pack.get("pack_id"),
+        "rule_pack_version": pack.get("version"),
+        "rule_pack_sha256": _file_sha256(rule_path),
+        "cve_snapshot_sha256": _file_sha256(cve_path),
+        "sbom_sha256": _file_sha256(sbom_path) if sbom_path.is_file() else None,
+        "outcome": outcome,
+        "rules_fired": [h.rule_id for h in hits],
+        "graph_node_count": len(nodes),
+        "graph_edge_count": len(gresult.edges),
+    }
+    decision_hash = _canonical_hash(manifest)
+
+    paths_for_facts = [
+        {
+            "rule_ids": [h.rule_id for h in hits if h.evidence.get("cve_id") == p["cve_id"]],
+            "nodes": [p["asset_id"], p["firmware_id"], p["component_id"], p["cve_id"]],
+            "summary": (
+                f"{p['asset'].get('name')} → {p['cve'].get('osv_id', p['cve_id'])} "
+                f"(CVSS {p['cve'].get('cvss_score')})"
+            ),
+        }
+        for p in cve_paths
+    ]
+
+    facts: dict[str, Any] = {
+        "vessel_key": vessel_key,
+        "port_call_id": port_call_id,
+        "outcome": outcome,
+        "decision_hash": decision_hash,
+        "rules_fired": [
+            {
+                "id": h.rule_id,
+                "title": h.title,
+                "severity": h.severity,
+                "requirements": h.requirements,
+                "evidence": h.evidence,
+            }
+            for h in hits
+        ],
+        "paths": paths_for_facts,
+        "cve_ids": sorted({p["cve_id"] for p in cve_paths}),
+        "disclaimer": (
+            "PoC clearance from public CVE snapshot and synthetic SBOM/asset_map fixtures. "
+            "Not an official port-state or MPA berth approval."
+        ),
+    }
+
+    return EvaluationResult(
+        vessel_key=vessel_key,
+        port_call_id=port_call_id,
+        outcome=outcome,
+        rules_fired=tuple(hits),
+        facts=facts,
+        manifest=manifest,
+        decision_hash=decision_hash,
+    )
+
+
+def write_evaluation_artifacts(
+    result: EvaluationResult,
+    output_dir: Path | None = None,
+) -> dict[str, Path]:
+    """Write facts.json and evaluation manifest for audit/documaris."""
+    out = Path(output_dir or DEFAULT_OUTPUT_DIR)
+    out.mkdir(parents=True, exist_ok=True)
+    prefix = f"{result.vessel_key}_{result.port_call_id}".replace("/", "-")
+    facts_path = out / f"{prefix}_facts.json"
+    manifest_path = out / f"{prefix}_evaluation_manifest.json"
+    facts_path.write_text(json.dumps(result.facts, indent=2), encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps({**result.manifest, "decision_hash": result.decision_hash}, indent=2),
+        encoding="utf-8",
+    )
+    return {"facts": facts_path, "manifest": manifest_path}
+
+
+def affected_vessels(
+    cve_id: str,
+    graph_result: GraphBuildResult | None = None,
+) -> list[str]:
+    """UC2: list vessel keys affected by a CVE (public API for CLI)."""
+    gresult = graph_result or build_maritime_cyber_graph()
+    return affected_vessels_for_cve(gresult.nx_graph, normalize_cve_node_id(cve_id))

--- a/pipelines/port_clearance_eval.py
+++ b/pipelines/port_clearance_eval.py
@@ -1,0 +1,51 @@
+"""CLI — port cyber clearance evaluation (W3)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from pipelines.maritime_cyber.eval import (
+    DEFAULT_OUTPUT_DIR,
+    affected_vessels,
+    evaluate_port_clearance,
+    write_evaluation_artifacts,
+)
+from pipelines.maritime_cyber.graph import build_maritime_cyber_graph
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate port cyber clearance (pass/hold)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    eval_p = sub.add_parser("evaluate", help="Run clearance for one vessel")
+    eval_p.add_argument("vessel_key", help="Fixture vessel key (e.g. vessel-hold)")
+    eval_p.add_argument("--port-call-id", default="port-call-demo-sgsin")
+    eval_p.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    eval_p.add_argument("--write", action="store_true", help="Write facts.json + manifest")
+
+    uc2_p = sub.add_parser("affected-vessels", help="UC2 domino query by CVE id")
+    uc2_p.add_argument("cve_id", help="CVE-2021-44228 or cve:CVE-2021-44228")
+
+    args = parser.parse_args()
+
+    if args.command == "evaluate":
+        graph = build_maritime_cyber_graph([args.vessel_key])
+        result = evaluate_port_clearance(
+            args.vessel_key,
+            port_call_id=args.port_call_id,
+            graph_result=graph,
+        )
+        print(json.dumps({"outcome": result.outcome, "decision_hash": result.decision_hash}))
+        if args.write:
+            paths = write_evaluation_artifacts(result, args.output_dir)
+            for name, path in paths.items():
+                print(f"{name}: {path}")
+    elif args.command == "affected-vessels":
+        vessels = affected_vessels(args.cve_id)
+        print(json.dumps(vessels))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/maritime_cyber/test_eval.py
+++ b/tests/maritime_cyber/test_eval.py
@@ -1,0 +1,63 @@
+"""W3 — port clearance evaluation, facts.json, decision hash."""
+
+import json
+from pathlib import Path
+
+from pipelines.maritime_cyber.eval import (
+    affected_vessels,
+    evaluate_port_clearance,
+    write_evaluation_artifacts,
+)
+from pipelines.maritime_cyber.graph import build_maritime_cyber_graph
+
+CVE_LOG4SHELL = "CVE-2021-44228"
+
+
+def test_vessel_hold_is_hold() -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    result = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    assert result.outcome == "hold"
+    assert len(result.rules_fired) >= 1
+    rule_ids = {h.rule_id for h in result.rules_fired}
+    assert "SG-CC-001" in rule_ids or "SG-CC-007" in rule_ids
+
+
+def test_vessel_clean_is_pass() -> None:
+    graph = build_maritime_cyber_graph(["vessel-clean"])
+    result = evaluate_port_clearance("vessel-clean", graph_result=graph)
+    assert result.outcome == "pass"
+    assert result.rules_fired == ()
+
+
+def test_decision_hash_reproducible() -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    a = evaluate_port_clearance("vessel-hold", port_call_id="pc-1", graph_result=graph)
+    b = evaluate_port_clearance("vessel-hold", port_call_id="pc-1", graph_result=graph)
+    assert a.decision_hash == b.decision_hash
+    assert len(a.decision_hash) == 64
+
+
+def test_facts_json_written(tmp_path: Path) -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    result = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    paths = write_evaluation_artifacts(result, tmp_path)
+    facts = json.loads(paths["facts"].read_text(encoding="utf-8"))
+    assert facts["outcome"] == "hold"
+    assert "disclaimer" in facts
+    assert facts["decision_hash"] == result.decision_hash
+
+
+def test_uc2_affected_vessels_api() -> None:
+    assert affected_vessels(CVE_LOG4SHELL) == ["vessel-hold"]
+
+
+def test_hold_and_clean_differ() -> None:
+    hold = evaluate_port_clearance(
+        "vessel-hold",
+        graph_result=build_maritime_cyber_graph(["vessel-hold"]),
+    )
+    clean = evaluate_port_clearance(
+        "vessel-clean",
+        graph_result=build_maritime_cyber_graph(["vessel-clean"]),
+    )
+    assert hold.outcome != clean.outcome


### PR DESCRIPTION
## Achievement — W3 / #182

| #182 task | Status | Implementation |
|-----------|--------|----------------|
| pass/hold `ClearanceDecision` | Done | `evaluate_port_clearance()` in `pipelines/maritime_cyber/eval.py` |
| `facts.json` for documaris | Done | `write_evaluation_artifacts()` — paths, rules, CVE ids, disclaimer |
| UC2 `affected_vessels(cve_id)` | Done | `affected_vessels()` + CLI `port_clearance_eval.py affected-vessels` |
| `decision_hash` reproducibility | Done | SHA-256 over canonical manifest (G7); test `test_decision_hash_reproducible` |

**MVP gates:** G3 (pass/hold on fixtures), G4 (UC2 domino), G7 (stable hash).

### Demo outcomes

| Vessel | Outcome | Rules fired (sample) |
|--------|---------|----------------------|
| `vessel-hold` | **hold** | SG-CC-001, SG-CC-002, SG-CC-007 |
| `vessel-clean` | **pass** | (none) |

---

## Summary

- **`pipelines/maritime_cyber/eval.py`** — rule engine for `sg-cyber-clearance-v0.yaml` (8 condition types active; SG-CC-008/010 deferred until ProcessLog/CVE dates in fixtures)
- **`pipelines/port_clearance_eval.py`** — CLI: `evaluate`, `affected-vessels`
- **Tests:** 6 new eval tests (18 total in `tests/maritime_cyber/`)

## Related

- Refs #182 — **close on merge**
- Builds on #185 (W2 graph)
- Enables #414 area / W4 audit, W5 documaris, W6 E2E

## Test plan

- [x] `uv run pytest tests/maritime_cyber/ -v` — **18 passed**
- [x] `uv run pytest tests/ -q` — **749 passed**
- [x] `uv run python pipelines/port_clearance_eval.py evaluate vessel-hold --write`
- [x] `uv run python pipelines/port_clearance_eval.py affected-vessels CVE-2021-44228` → `["vessel-hold"]`

Made with [Cursor](https://cursor.com)