### PR TITLE
feat(agents): add hold-to-pass D1 demo scenario

### DIFF
--- a/agents/port_clearance/README.md
+++ b/agents/port_clearance/README.md
@@ -25,6 +25,9 @@ uv run python -m agents.port_clearance.run_clearance vessel-hold
 # Pass vessel
 uv run python -m agents.port_clearance.run_clearance vessel-clean
 
+# D1 scenario: hold -> remediation -> pass (one command)
+uv run python -m agents.port_clearance.run_clearance vessel-hold --scenario hold-to-pass
+
 # Eval + artefacts only (no eds)
 uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-render --skip-seal
 

--- a/agents/port_clearance/run_clearance.py
+++ b/agents/port_clearance/run_clearance.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -40,6 +41,8 @@ class ClearanceRunResult:
     port_call_id: str
     outcome: str
     decision_hash: str
+    bom_baseline_ref: dict[str, Any]
+    cve_snapshot_ref: dict[str, Any]
     output_dir: Path
     facts_path: Path
     manifest_path: Path
@@ -58,6 +61,18 @@ def load_profile_manifest(path: Path | None = None) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"invalid manifest YAML: {manifest_path}")
     return data
+
+
+def _file_sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    import hashlib
+
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
 
 
 def find_eds_binary(explicit: str | None = None) -> Path:
@@ -108,6 +123,9 @@ def run_clearance(
     profile_manifest: Path | None = None,
     graph_output_dir: Path | None = None,
     write_graph: bool = True,
+    asset_map_path: Path | None = None,
+    cve_snapshot_path: Path | None = None,
+    sbom_dir: Path | None = None,
     eds_bin: str | Path | None = None,
     verify_url: str | None = None,
     private_key_hex: str = _DEMO_PRIV_KEY,
@@ -121,7 +139,12 @@ def run_clearance(
     out.mkdir(parents=True, exist_ok=True)
 
     graph_dir = Path(graph_output_dir or DEFAULT_OUTPUT_DIR)
-    graph_result = build_maritime_cyber_graph([vessel_key])
+    graph_result = build_maritime_cyber_graph(
+        [vessel_key],
+        asset_map_path=asset_map_path,
+        cve_snapshot_path=cve_snapshot_path,
+        sbom_dir=sbom_dir,
+    )
     if write_graph:
         write_graph_parquet(graph_result, graph_dir)
 
@@ -129,6 +152,9 @@ def run_clearance(
         vessel_key,
         port_call_id=port_call_id,
         graph_result=graph_result,
+        asset_map_path=asset_map_path,
+        cve_snapshot_path=cve_snapshot_path,
+        sbom_dir=sbom_dir,
     )
     artifact_paths = write_evaluation_artifacts(eval_result, out)
     facts_path = artifact_paths["facts"]
@@ -184,12 +210,31 @@ def run_clearance(
         if sign.returncode != 0:
             raise RuntimeError(f"eds audit sign-clearance failed:\n{sign.stderr}")
 
+    # Audit-time references (PoC shape): frozen BOM baseline + CVE snapshot refs
+    resolved_asset_map = Path(asset_map_path) if asset_map_path else (_REPO_ROOT / "fixtures" / "asset_map.yaml")
+    resolved_cve_snapshot = Path(cve_snapshot_path) if cve_snapshot_path else (_REPO_ROOT / "fixtures" / "cve" / "snapshot-2026-05-26.json")
+    resolved_sbom_dir = Path(sbom_dir) if sbom_dir else (_REPO_ROOT / "fixtures" / "sbom")
+    resolved_sbom_path = resolved_sbom_dir / f"{vessel_key}.json"
+
+    bom_baseline_ref = {
+        "asset_map_path": str(resolved_asset_map),
+        "asset_map_sha256": _file_sha256(resolved_asset_map),
+        "sbom_path": str(resolved_sbom_path),
+        "sbom_sha256": _file_sha256(resolved_sbom_path),
+    }
+    cve_snapshot_ref = {
+        "cve_snapshot_path": str(resolved_cve_snapshot),
+        "cve_snapshot_sha256": _file_sha256(resolved_cve_snapshot),
+    }
+
     # Persist run summary for W7 / demo tooling
     summary = {
         "vessel_key": vessel_key,
         "port_call_id": port_call_id,
         "outcome": eval_result.outcome,
         "decision_hash": eval_result.decision_hash,
+        "bom_baseline_ref": bom_baseline_ref,
+        "cve_snapshot_ref": cve_snapshot_ref,
         "profile_id": profile.get("profile_id"),
         "profile_version": profile.get("version"),
         "facts": str(facts_path),
@@ -208,6 +253,8 @@ def run_clearance(
         port_call_id=port_call_id,
         outcome=eval_result.outcome,
         decision_hash=eval_result.decision_hash,
+        bom_baseline_ref=bom_baseline_ref,
+        cve_snapshot_ref=cve_snapshot_ref,
         output_dir=out,
         facts_path=facts_path,
         manifest_path=manifest_path,
@@ -217,11 +264,124 @@ def run_clearance(
     )
 
 
+def _write_patched_sbom_for_log4j_hold(
+    *,
+    vessel_key: str,
+    src_sbom_path: Path,
+    dst_sbom_path: Path,
+    fixed_version: str = "2.15.0",
+) -> None:
+    """PoC remediation step: patch Log4j on hold vessel to fixed version."""
+    data = json.loads(src_sbom_path.read_text(encoding="utf-8"))
+    comps = data.get("components") or []
+    if not isinstance(comps, list):
+        raise ValueError("invalid CycloneDX: components missing")
+
+    patched = False
+    for c in comps:
+        if not isinstance(c, dict):
+            continue
+        if c.get("purl") == "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1":
+            c["version"] = fixed_version
+            c["purl"] = f"pkg:maven/org.apache.logging.log4j/log4j-core@{fixed_version}"
+            patched = True
+
+    if not patched:
+        raise ValueError(f"expected log4j-core component not found in {vessel_key} SBOM")
+
+    dst_sbom_path.parent.mkdir(parents=True, exist_ok=True)
+    dst_sbom_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def run_hold_to_pass_scenario(
+    vessel_key: str = "vessel-hold",
+    *,
+    port_call_id: str = "port-call-demo-sgsin",
+    output_dir: Path | None = None,
+    profile_manifest: Path | None = None,
+    eds_bin: str | Path | None = None,
+    verify_url: str | None = None,
+    private_key_hex: str = _DEMO_PRIV_KEY,
+    device_id: str = "port-clearance-poc",
+    skip_render: bool = False,
+    skip_seal: bool = False,
+) -> dict[str, ClearanceRunResult]:
+    """D1: one command demo — hold -> remediation -> pass."""
+    if vessel_key != "vessel-hold":
+        raise ValueError("hold-to-pass scenario currently supports vessel-hold only (Log4j PoC)")
+
+    base_out = Path(output_dir or DEFAULT_OUTPUT_DIR / "clearance_runs" / "scenario_hold_to_pass")
+    scenario_id = time.strftime("%Y%m%d-%H%M%S")
+    run_root = base_out / scenario_id
+    baseline_out = run_root / "baseline"
+    remediated_out = run_root / "remediated"
+
+    baseline = run_clearance(
+        vessel_key,
+        port_call_id=port_call_id,
+        output_dir=baseline_out,
+        profile_manifest=profile_manifest,
+        write_graph=False,
+        eds_bin=eds_bin,
+        verify_url=verify_url,
+        private_key_hex=private_key_hex,
+        device_id=device_id,
+        skip_render=skip_render,
+        skip_seal=skip_seal,
+    )
+
+    # Remediation: patch SBOM only (asset_map and CVE snapshot remain pinned)
+    patched_sbom_dir = remediated_out / "sbom"
+    src_sbom = _REPO_ROOT / "fixtures" / "sbom" / f"{vessel_key}.json"
+    dst_sbom = patched_sbom_dir / f"{vessel_key}.json"
+    _write_patched_sbom_for_log4j_hold(vessel_key=vessel_key, src_sbom_path=src_sbom, dst_sbom_path=dst_sbom)
+
+    remediated = run_clearance(
+        vessel_key,
+        port_call_id=port_call_id,
+        output_dir=remediated_out,
+        profile_manifest=profile_manifest,
+        write_graph=False,
+        sbom_dir=patched_sbom_dir,
+        eds_bin=eds_bin,
+        verify_url=verify_url,
+        private_key_hex=private_key_hex,
+        device_id=device_id,
+        skip_render=skip_render,
+        skip_seal=skip_seal,
+    )
+
+    # Persist top-level scenario summary
+    scenario_summary = {
+        "scenario": "hold-to-pass",
+        "vessel_key": vessel_key,
+        "port_call_id": port_call_id,
+        "baseline": {
+            "outcome": baseline.outcome,
+            "decision_hash": baseline.decision_hash,
+            "run_dir": str(baseline.output_dir),
+        },
+        "remediated": {
+            "outcome": remediated.outcome,
+            "decision_hash": remediated.decision_hash,
+            "run_dir": str(remediated.output_dir),
+        },
+    }
+    (run_root / "scenario_summary.json").write_text(
+        json.dumps(scenario_summary, indent=2),
+        encoding="utf-8",
+    )
+
+    return {"baseline": baseline, "remediated": remediated}
+
+
 def print_verify_instructions(result: ClearanceRunResult, eds: Path | None = None) -> None:
     """Print third-party verify commands (G6/G7 demo script)."""
     print("\n=== Port Cyber Clearance — verify (third party) ===\n")
     print(f"  outcome:        {result.outcome.upper()}")
     print(f"  decision_hash:  {result.decision_hash}")
+    print(f"  bom_baseline:   {result.bom_baseline_ref.get('sbom_sha256')}")
+    print(f"  cve_snapshot:   {result.cve_snapshot_ref.get('cve_snapshot_sha256')}")
     print(f"  verify_url:     {result.verify_url}\n")
 
     if result.html_path:
@@ -246,6 +406,11 @@ def main(argv: list[str] | None = None) -> int:
         description="E2E port cyber clearance (graph → eval → HTML → audit seal)",
     )
     parser.add_argument("vessel_key", help="Fixture vessel key (e.g. vessel-hold)")
+    parser.add_argument(
+        "--scenario",
+        choices=["hold-to-pass"],
+        help="Run a scripted scenario (D1 demo). When set, vessel_key is used as baseline input.",
+    )
     parser.add_argument(
         "--port-call-id",
         default="port-call-demo-sgsin",
@@ -291,6 +456,44 @@ def main(argv: list[str] | None = None) -> int:
         f"({args.profile_manifest})",
         file=sys.stderr,
     )
+
+    if args.scenario == "hold-to-pass":
+        try:
+            results = run_hold_to_pass_scenario(
+                args.vessel_key,
+                port_call_id=args.port_call_id,
+                output_dir=args.output_dir,
+                profile_manifest=args.profile_manifest,
+                eds_bin=args.eds_bin,
+                verify_url=args.verify_url,
+                private_key_hex=args.key,
+                device_id=args.device_id,
+                skip_render=args.skip_render,
+                skip_seal=args.skip_seal,
+            )
+        except (FileNotFoundError, RuntimeError, ValueError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+
+        baseline = results["baseline"]
+        remediated = results["remediated"]
+
+        print("\nscenario: hold-to-pass\n")
+        print(f"baseline.outcome: {baseline.outcome}")
+        print(f"baseline.decision_hash: {baseline.decision_hash}")
+        print(f"remediated.outcome: {remediated.outcome}")
+        print(f"remediated.decision_hash: {remediated.decision_hash}")
+
+        try:
+            eds = None if args.skip_seal else find_eds_binary(args.eds_bin)
+        except FileNotFoundError:
+            eds = None
+
+        print("\n--- baseline verify ---")
+        print_verify_instructions(baseline, eds=eds)
+        print("\n--- remediated verify ---")
+        print_verify_instructions(remediated, eds=eds)
+        return 0
 
     try:
         result = run_clearance(

--- a/tests/maritime_cyber/test_run_clearance.py
+++ b/tests/maritime_cyber/test_run_clearance.py
@@ -12,6 +12,7 @@ import pytest
 from agents.port_clearance.run_clearance import (
     load_profile_manifest,
     run_clearance,
+    run_hold_to_pass_scenario,
 )
 
 
@@ -47,6 +48,19 @@ def test_run_clearance_eval_only(tmp_path: Path, vessel_key: str, expected_outco
 
     summary_path = tmp_path / vessel_key / f"{vessel_key}_port-call-demo-sgsin_run_summary.json"
     assert summary_path.is_file()
+
+
+def test_hold_to_pass_scenario_eval_only(tmp_path: Path) -> None:
+    """D1: hold -> remediation -> pass without eds (CI-safe)."""
+    results = run_hold_to_pass_scenario(
+        "vessel-hold",
+        output_dir=tmp_path / "scenario",
+        skip_render=True,
+        skip_seal=True,
+    )
+    assert results["baseline"].outcome == "hold"
+    assert results["remediated"].outcome == "pass"
+    assert results["baseline"].decision_hash != results["remediated"].decision_hash
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- add `--scenario hold-to-pass` to `run_clearance` to orchestrate baseline hold, remediation, and re-evaluation pass in one command
- persist audit evidence references (`bom_baseline_ref`, `cve_snapshot_ref`) in run summaries and show before/after verify output details
- add a CI-safe test for hold→pass scenario and document the command in the port clearance README

## Test plan
- [x] `uv run pytest tests/maritime_cyber/test_run_clearance.py -k \"hold_to_pass_scenario_eval_only or run_clearance_eval_only\"`
- [x] `uv run python -m agents.port_clearance.run_clearance vessel-hold --scenario hold-to-pass --skip-render --skip-seal`

## Linked issue
- Closes #156

Made with [Cursor](https://cursor.com)