### PR TITLE
feat(maritime-cyber): G11/G12 audit refs and drift detection (#157)

### DIFF
--- a/agents/port_clearance/run_clearance.py
+++ b/agents/port_clearance/run_clearance.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import yaml
 
+from pipelines.maritime_cyber.audit_refs import build_bom_baseline_ref, build_cve_snapshot_ref
 from pipelines.maritime_cyber.eval import (
     affected_vessels,
     evaluate_port_clearance,
@@ -64,18 +65,6 @@ def load_profile_manifest(path: Path | None = None) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"invalid manifest YAML: {manifest_path}")
     return data
-
-
-def _file_sha256(path: Path) -> str | None:
-    if not path.is_file():
-        return None
-    import hashlib
-
-    h = hashlib.sha256()
-    with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
 
 
 def _eds_supports_clearance_audit(eds: Path) -> bool:
@@ -267,22 +256,12 @@ def run_clearance(
             eds=eds,
         )
 
-    # Audit-time references (PoC shape): frozen BOM baseline + CVE snapshot refs
-    resolved_asset_map = Path(asset_map_path) if asset_map_path else (_REPO_ROOT / "fixtures" / "asset_map.yaml")
-    resolved_cve_snapshot = Path(cve_snapshot_path) if cve_snapshot_path else (_REPO_ROOT / "fixtures" / "cve" / "snapshot-2026-05-26.json")
-    resolved_sbom_dir = Path(sbom_dir) if sbom_dir else (_REPO_ROOT / "fixtures" / "sbom")
-    resolved_sbom_path = resolved_sbom_dir / f"{vessel_key}.json"
-
-    bom_baseline_ref = {
-        "asset_map_path": str(resolved_asset_map),
-        "asset_map_sha256": _file_sha256(resolved_asset_map),
-        "sbom_path": str(resolved_sbom_path),
-        "sbom_sha256": _file_sha256(resolved_sbom_path),
-    }
-    cve_snapshot_ref = {
-        "cve_snapshot_path": str(resolved_cve_snapshot),
-        "cve_snapshot_sha256": _file_sha256(resolved_cve_snapshot),
-    }
+    bom_baseline_ref = build_bom_baseline_ref(
+        vessel_key,
+        asset_map_path=asset_map_path,
+        sbom_dir=sbom_dir,
+    )
+    cve_snapshot_ref = build_cve_snapshot_ref(cve_snapshot_path=cve_snapshot_path)
 
     # Persist run summary for W7 / demo tooling
     summary: dict[str, Any] = {

--- a/pipelines/maritime_cyber/audit_refs.py
+++ b/pipelines/maritime_cyber/audit_refs.py
@@ -1,0 +1,101 @@
+"""G11/G12 audit evidence references — frozen BOM baseline + CVE snapshot (Cap Vista D2)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ASSET_MAP = _REPO_ROOT / "fixtures" / "asset_map.yaml"
+DEFAULT_CVE_SNAPSHOT = _REPO_ROOT / "fixtures" / "cve" / "snapshot-2026-05-26.json"
+DEFAULT_SBOM_DIR = _REPO_ROOT / "fixtures" / "sbom"
+
+
+class ManifestDriftError(ValueError):
+    """Pinned inputs no longer match manifest audit references."""
+
+
+def file_sha256(path: Path) -> str:
+    if not path.is_file():
+        raise FileNotFoundError(f"missing file for audit ref: {path}")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def build_bom_baseline_ref(
+    vessel_key: str,
+    *,
+    asset_map_path: Path | None = None,
+    sbom_dir: Path | None = None,
+) -> dict[str, Any]:
+    asset_map = Path(asset_map_path or DEFAULT_ASSET_MAP)
+    sbom_dir_path = Path(sbom_dir or DEFAULT_SBOM_DIR)
+    sbom_path = sbom_dir_path / f"{vessel_key}.json"
+    return {
+        "asset_map_path": str(asset_map.resolve()),
+        "asset_map_sha256": file_sha256(asset_map),
+        "sbom_path": str(sbom_path.resolve()),
+        "sbom_sha256": file_sha256(sbom_path),
+    }
+
+
+def build_cve_snapshot_ref(*, cve_snapshot_path: Path | None = None) -> dict[str, Any]:
+    cve_path = Path(cve_snapshot_path or DEFAULT_CVE_SNAPSHOT)
+    return {
+        "cve_snapshot_path": str(cve_path.resolve()),
+        "cve_snapshot_sha256": file_sha256(cve_path),
+    }
+
+
+def assert_manifest_audit_refs(
+    manifest: dict[str, Any],
+    vessel_key: str,
+    *,
+    asset_map_path: Path | None = None,
+    cve_snapshot_path: Path | None = None,
+    sbom_dir: Path | None = None,
+) -> None:
+    """Re-read pinned files; fail if SHA-256 drifted from manifest refs (G11 tamper detection)."""
+    expected_bom = build_bom_baseline_ref(
+        vessel_key,
+        asset_map_path=asset_map_path,
+        sbom_dir=sbom_dir,
+    )
+    expected_cve = build_cve_snapshot_ref(cve_snapshot_path=cve_snapshot_path)
+
+    for key, expected in (
+        ("bom_baseline_ref", expected_bom),
+        ("cve_snapshot_ref", expected_cve),
+    ):
+        actual = manifest.get(key)
+        if actual != expected:
+            raise ManifestDriftError(
+                f"{key} drift: manifest refs do not match current pinned inputs\n"
+                f"  manifest: {json.dumps(actual, sort_keys=True)}\n"
+                f"  expected: {json.dumps(expected, sort_keys=True)}"
+            )
+
+    # Legacy flat fields must stay aligned with structured refs
+    bom = manifest.get("bom_baseline_ref") or expected_bom
+    cve = manifest.get("cve_snapshot_ref") or expected_cve
+    if manifest.get("sbom_sha256") and manifest["sbom_sha256"] != bom.get("sbom_sha256"):
+        raise ManifestDriftError("sbom_sha256 flat field drift vs bom_baseline_ref")
+    if manifest.get("cve_snapshot_sha256") and manifest["cve_snapshot_sha256"] != cve.get(
+        "cve_snapshot_sha256"
+    ):
+        raise ManifestDriftError("cve_snapshot_sha256 flat field drift vs cve_snapshot_ref")
+
+
+def integrated_snapshot_fingerprint(manifest: dict[str, Any]) -> str:
+    """Tamper-evident fingerprint over BOM×CVE refs + evaluation outcome (G11)."""
+    body = {
+        "bom_baseline_ref": manifest.get("bom_baseline_ref"),
+        "cve_snapshot_ref": manifest.get("cve_snapshot_ref"),
+        "vessel_key": manifest.get("vessel_key"),
+        "port_call_id": manifest.get("port_call_id"),
+        "outcome": manifest.get("outcome"),
+        "rules_fired": manifest.get("rules_fired"),
+    }
+    canonical = json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/pipelines/maritime_cyber/eval.py
+++ b/pipelines/maritime_cyber/eval.py
@@ -19,6 +19,11 @@ from pipelines.maritime_cyber.graph import (
     build_maritime_cyber_graph,
     load_sbom,
 )
+from pipelines.maritime_cyber.audit_refs import (
+    build_bom_baseline_ref,
+    build_cve_snapshot_ref,
+    integrated_snapshot_fingerprint,
+)
 from pipelines.maritime_cyber.rules import DEFAULT_RULE_PACK, load_asset_map, load_rule_pack
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -111,6 +116,36 @@ def iter_cve_asset_paths(
                         }
                     )
     return paths
+
+
+def format_impacted_paths(cve_paths: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """G12: structured paths for auditors (component → CVE → asset → vessel)."""
+    formatted: list[dict[str, Any]] = []
+    for p in cve_paths:
+        asset = p.get("asset") or {}
+        component = p.get("component") or {}
+        cve = p.get("cve") or {}
+        formatted.append(
+            {
+                "vessel_id": p.get("vessel_id"),
+                "asset_id": p.get("asset_id"),
+                "asset_name": asset.get("name"),
+                "firmware_id": p.get("firmware_id"),
+                "component_id": p.get("component_id"),
+                "component_name": component.get("name"),
+                "component_purl": component.get("purl"),
+                "cve_id": p.get("cve_id"),
+                "cve_osv_id": cve.get("osv_id"),
+                "cvss_score": cve.get("cvss_score"),
+                "path_nodes": [
+                    p.get("asset_id"),
+                    p.get("firmware_id"),
+                    p.get("component_id"),
+                    p.get("cve_id"),
+                ],
+            }
+        )
+    return formatted
 
 
 def _match_cve_on_asset_path(path: dict[str, Any], match: dict[str, Any]) -> bool:
@@ -290,21 +325,33 @@ def evaluate_port_clearance(
     hold_outcomes = {h.outcome for h in hits if h.outcome == "hold"}
     outcome = "hold" if hold_outcomes else str(pack.get("default_outcome", "pass"))
 
-    cve_path = cve_snapshot_path or DEFAULT_CVE_SNAPSHOT
+    cve_path = Path(cve_snapshot_path or DEFAULT_CVE_SNAPSHOT)
     rule_path = rule_pack_path or DEFAULT_RULE_PACK
+    bom_baseline_ref = build_bom_baseline_ref(
+        vessel_key,
+        asset_map_path=asset_map_path,
+        sbom_dir=sbom_dir,
+    )
+    cve_snapshot_ref = build_cve_snapshot_ref(cve_snapshot_path=cve_path)
+    impacted_paths = format_impacted_paths(cve_paths)
+
     manifest = {
         "vessel_key": vessel_key,
         "port_call_id": port_call_id,
         "rule_pack_id": pack.get("pack_id"),
         "rule_pack_version": pack.get("version"),
         "rule_pack_sha256": _file_sha256(rule_path),
-        "cve_snapshot_sha256": _file_sha256(cve_path),
-        "sbom_sha256": _file_sha256(sbom_path) if sbom_path.is_file() else None,
+        "bom_baseline_ref": bom_baseline_ref,
+        "cve_snapshot_ref": cve_snapshot_ref,
+        "cve_snapshot_sha256": cve_snapshot_ref["cve_snapshot_sha256"],
+        "sbom_sha256": bom_baseline_ref["sbom_sha256"],
         "outcome": outcome,
         "rules_fired": [h.rule_id for h in hits],
         "graph_node_count": len(nodes),
         "graph_edge_count": len(gresult.edges),
+        "impacted_path_count": len(impacted_paths),
     }
+    manifest["integrated_snapshot_fingerprint"] = integrated_snapshot_fingerprint(manifest)
     decision_hash = _canonical_hash(manifest)
 
     paths_for_facts = [
@@ -324,6 +371,10 @@ def evaluate_port_clearance(
         "port_call_id": port_call_id,
         "outcome": outcome,
         "decision_hash": decision_hash,
+        "bom_baseline_ref": bom_baseline_ref,
+        "cve_snapshot_ref": cve_snapshot_ref,
+        "integrated_snapshot_fingerprint": manifest["integrated_snapshot_fingerprint"],
+        "impacted_paths": impacted_paths,
         "rules_fired": [
             {
                 "id": h.rule_id,
@@ -364,11 +415,23 @@ def write_evaluation_artifacts(
     facts_path = out / f"{prefix}_facts.json"
     manifest_path = out / f"{prefix}_evaluation_manifest.json"
     facts_path.write_text(json.dumps(result.facts, indent=2), encoding="utf-8")
-    manifest_path.write_text(
-        json.dumps({**result.manifest, "decision_hash": result.decision_hash}, indent=2),
-        encoding="utf-8",
-    )
-    return {"facts": facts_path, "manifest": manifest_path}
+    manifest_on_disk = {**result.manifest, "decision_hash": result.decision_hash}
+    manifest_path.write_text(json.dumps(manifest_on_disk, indent=2), encoding="utf-8")
+
+    snapshot_path = out / f"{prefix}_integrated_snapshot.json"
+    snapshot_body = {
+        "vessel_key": result.vessel_key,
+        "port_call_id": result.port_call_id,
+        "outcome": result.outcome,
+        "decision_hash": result.decision_hash,
+        "bom_baseline_ref": result.manifest.get("bom_baseline_ref"),
+        "cve_snapshot_ref": result.manifest.get("cve_snapshot_ref"),
+        "integrated_snapshot_fingerprint": result.manifest.get("integrated_snapshot_fingerprint"),
+        "impacted_paths": result.facts.get("impacted_paths"),
+    }
+    snapshot_path.write_text(json.dumps(snapshot_body, indent=2), encoding="utf-8")
+
+    return {"facts": facts_path, "manifest": manifest_path, "integrated_snapshot": snapshot_path}
 
 
 def affected_vessels(

--- a/tests/maritime_cyber/test_audit_refs.py
+++ b/tests/maritime_cyber/test_audit_refs.py
@@ -1,0 +1,96 @@
+"""G11/G12 — audit refs, drift detection, integrated snapshot fingerprint."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pipelines.maritime_cyber.audit_refs import (
+    ManifestDriftError,
+    assert_manifest_audit_refs,
+    build_bom_baseline_ref,
+    integrated_snapshot_fingerprint,
+)
+from pipelines.maritime_cyber.eval import evaluate_port_clearance, write_evaluation_artifacts
+from pipelines.maritime_cyber.graph import build_maritime_cyber_graph
+
+
+def test_manifest_includes_audit_refs_and_fingerprint() -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    result = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    assert "bom_baseline_ref" in result.manifest
+    assert "cve_snapshot_ref" in result.manifest
+    assert result.manifest["bom_baseline_ref"]["sbom_sha256"] == result.manifest["sbom_sha256"]
+    assert (
+        result.manifest["cve_snapshot_ref"]["cve_snapshot_sha256"]
+        == result.manifest["cve_snapshot_sha256"]
+    )
+    assert len(result.manifest["integrated_snapshot_fingerprint"]) == 64
+    assert result.facts["impacted_paths"]
+    assert result.facts["bom_baseline_ref"] == result.manifest["bom_baseline_ref"]
+
+
+def test_integrated_snapshot_written(tmp_path: Path) -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    result = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    paths = write_evaluation_artifacts(result, tmp_path)
+    snap = paths["integrated_snapshot"]
+    assert snap.is_file()
+    body = json.loads(snap.read_text(encoding="utf-8"))
+    assert body["integrated_snapshot_fingerprint"] == result.manifest["integrated_snapshot_fingerprint"]
+    assert body["impacted_paths"]
+
+
+def test_manifest_audit_refs_stable_across_reruns() -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    a = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    b = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    assert a.decision_hash == b.decision_hash
+    assert_manifest_audit_refs(a.manifest, "vessel-hold")
+    assert_manifest_audit_refs(b.manifest, "vessel-hold")
+
+
+def test_manifest_drift_detects_tampered_sbom(tmp_path: Path) -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    sbom_dir = tmp_path / "sbom"
+    sbom_dir.mkdir()
+    src = Path(__file__).resolve().parents[2] / "fixtures" / "sbom" / "vessel-hold.json"
+    dst = sbom_dir / "vessel-hold.json"
+    dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+    result = evaluate_port_clearance(
+        "vessel-hold",
+        graph_result=build_maritime_cyber_graph(["vessel-hold"], sbom_dir=sbom_dir),
+        sbom_dir=sbom_dir,
+    )
+    assert_manifest_audit_refs(result.manifest, "vessel-hold", sbom_dir=sbom_dir)
+
+    data = json.loads(dst.read_text(encoding="utf-8"))
+    data["metadata"] = {"tampered": True}
+    dst.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ManifestDriftError, match="bom_baseline_ref drift"):
+        assert_manifest_audit_refs(result.manifest, "vessel-hold", sbom_dir=sbom_dir)
+
+
+def test_integrated_snapshot_fingerprint_changes_on_outcome_change() -> None:
+    hold = evaluate_port_clearance(
+        "vessel-hold",
+        graph_result=build_maritime_cyber_graph(["vessel-hold"]),
+    )
+    clean = evaluate_port_clearance(
+        "vessel-clean",
+        graph_result=build_maritime_cyber_graph(["vessel-clean"]),
+    )
+    assert integrated_snapshot_fingerprint(hold.manifest) != integrated_snapshot_fingerprint(
+        clean.manifest
+    )
+
+
+def test_build_bom_baseline_ref_paths_exist() -> None:
+    ref = build_bom_baseline_ref("vessel-hold")
+    assert Path(ref["sbom_path"]).is_file()
+    assert Path(ref["asset_map_path"]).is_file()
+    assert len(ref["sbom_sha256"]) == 64

--- a/tests/maritime_cyber/test_audit_refs.py
+++ b/tests/maritime_cyber/test_audit_refs.py
@@ -53,7 +53,6 @@ def test_manifest_audit_refs_stable_across_reruns() -> None:
 
 
 def test_manifest_drift_detects_tampered_sbom(tmp_path: Path) -> None:
-    graph = build_maritime_cyber_graph(["vessel-hold"])
     sbom_dir = tmp_path / "sbom"
     sbom_dir.mkdir()
     src = Path(__file__).resolve().parents[2] / "fixtures" / "sbom" / "vessel-hold.json"

--- a/tests/maritime_cyber/test_eval.py
+++ b/tests/maritime_cyber/test_eval.py
@@ -45,6 +45,11 @@ def test_facts_json_written(tmp_path: Path) -> None:
     assert facts["outcome"] == "hold"
     assert "disclaimer" in facts
     assert facts["decision_hash"] == result.decision_hash
+    assert facts["bom_baseline_ref"]["sbom_sha256"]
+    assert facts["cve_snapshot_ref"]["cve_snapshot_sha256"]
+    assert facts["impacted_paths"]
+    manifest = json.loads(paths["manifest"].read_text(encoding="utf-8"))
+    assert manifest["bom_baseline_ref"] == facts["bom_baseline_ref"]
 
 
 def test_uc2_affected_vessels_api() -> None:


### PR DESCRIPTION
## Summary
- Add `bom_baseline_ref` / `cve_snapshot_ref` to evaluation manifests and facts (G12)
- Emit `*_integrated_snapshot.json` with fingerprint + impacted paths (G11)
- `assert_manifest_audit_refs()` + CI drift tests (tampered SBOM detection)
- Deduplicate ref builders used by `run_clearance`

## Acceptance criteria
- [x] AC1 Manifest schema
- [x] AC2 Drift / tamper detection
- [x] AC3 Facts include impacted_paths
- [x] AC5 Shared ref builders with run_clearance

## Test plan
- [x] `uv run pytest tests/maritime_cyber/ -q` (30 passed)

## Linked issues
- Closes https://github.com/edgesentry/edgesentry-commercial/issues/157 (engineering)
- Overlaps https://github.com/edgesentry/indago/issues/190 (drift CI)

Pair with edgesentry-rs PR for HTML audit section (AC3 report).

Made with [Cursor](https://cursor.com)