### PR TITLE
feat(agents): mock WORM retention for G11 (#158)

### DIFF
--- a/agents/port_clearance/README.md
+++ b/agents/port_clearance/README.md
@@ -7,7 +7,8 @@ One command runs the Cap Vista UC1 demo path:
 3. Evaluate pass/hold → `*_facts.json` + `*_evaluation_manifest.json`
 4. Render certificate HTML (`eds document render-clearance`)
 5. Seal audit chain (`eds audit sign-clearance`)
-6. Print third-party verify instructions
+6. Publish artefacts to **mock WORM** store (G11 — append-only, content-addressed)
+7. Print third-party verify instructions
 
 ## Prerequisites
 
@@ -39,11 +40,38 @@ When `eds` is available, each sealed run auto-runs `eds audit verify-clearance` 
 # Eval + artefacts only (no eds)
 uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-render --skip-seal
 
+# Skip immutable publish (G11 demo off)
+uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-worm
+
 # Machine-readable summary
 uv run python -m agents.port_clearance.run_clearance vessel-hold --json
 ```
 
 Outputs default to `data/processed/maritime_cyber/clearance_runs/<vessel_key>/`.
+
+## Immutable retention (G11 / D3)
+
+After each run, artefacts are copied to a **mock WORM** directory (append-only; `chmod 444` on objects):
+
+- `*_integrated_snapshot.json`
+- `*_evaluation_manifest.json`
+- `*_clearance_chain.json` (when sealed)
+
+Publish record: `*_worm_publish.json` (object keys + SHA-256 + `published_at`).
+
+Default store: `data/processed/maritime_cyber/worm_store/clearance/`  
+Override: `export CLEARANCE_WORM_ROOT=/path/to/worm`
+
+### Third-party retention verify
+
+```bash
+uv run python -m agents.port_clearance.verify_retention \
+  data/processed/maritime_cyber/clearance_runs/vessel-hold/vessel-hold_port-call-demo-sgsin_worm_publish.json
+```
+
+Steps performed: fetch each WORM object → verify SHA-256 → `assert_manifest_audit_refs` on stored manifest.
+
+Production pilots may set `CLEARANCE_WORM_URI` (future); **Cap Vista PoC does not require R2 upload**.
 
 ## Related
 

--- a/agents/port_clearance/run_clearance.py
+++ b/agents/port_clearance/run_clearance.py
@@ -32,6 +32,8 @@ from pipelines.maritime_cyber.graph import (
     write_graph_parquet,
 )
 
+from agents.port_clearance.worm_store import publish_clearance_run  # noqa: E402
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PROFILE_MANIFEST = _REPO_ROOT / "profiles" / "maritime_cyber" / "manifest.yaml"
 _DEFAULT_EDS_REL = _REPO_ROOT.parent / "edgesentry-rs" / "target" / "debug" / "eds"
@@ -53,6 +55,7 @@ class ClearanceRunResult:
     html_path: Path | None
     chain_path: Path | None
     verify_url: str
+    worm_publish_path: Path | None
 
 
 def load_profile_manifest(path: Path | None = None) -> dict[str, Any]:
@@ -170,6 +173,8 @@ def run_clearance(
     device_id: str = "port-clearance-poc",
     skip_render: bool = False,
     skip_seal: bool = False,
+    skip_worm: bool = False,
+    worm_root: Path | None = None,
     prior_decision_hash: str | None = None,
     lifecycle_event: str | None = None,
 ) -> ClearanceRunResult:
@@ -200,6 +205,7 @@ def run_clearance(
     artifact_paths = write_evaluation_artifacts(eval_result, out)
     facts_path = artifact_paths["facts"]
     manifest_path = artifact_paths["manifest"]
+    integrated_snapshot_path = artifact_paths.get("integrated_snapshot")
 
     url = verify_url or _default_verify_url(eval_result.decision_hash)
     prefix = f"{vessel_key}_{port_call_id}".replace("/", "-")
@@ -285,6 +291,20 @@ def run_clearance(
         summary["lifecycle_event"] = lifecycle_event
     if prior_decision_hash:
         summary["prior_decision_hash"] = prior_decision_hash
+
+    worm_publish_path: Path | None = None
+    if not skip_worm:
+        worm_record = publish_clearance_run(
+            out,
+            prefix=prefix,
+            manifest_path=manifest_path,
+            integrated_snapshot_path=integrated_snapshot_path,
+            chain_path=chain_path,
+            worm_root=worm_root,
+        )
+        worm_publish_path = Path(worm_record["publish_record_path"])
+        summary["worm_publish"] = worm_record
+
     (out / f"{prefix}_run_summary.json").write_text(
         json.dumps(summary, indent=2),
         encoding="utf-8",
@@ -303,6 +323,7 @@ def run_clearance(
         html_path=html_path,
         chain_path=chain_path,
         verify_url=url,
+        worm_publish_path=worm_publish_path,
     )
 
 
@@ -347,6 +368,8 @@ def run_hold_to_pass_scenario(
     device_id: str = "port-clearance-poc",
     skip_render: bool = False,
     skip_seal: bool = False,
+    skip_worm: bool = False,
+    worm_root: Path | None = None,
 ) -> dict[str, Any]:
     """D1: E7 -> E9 -> E10 -> re-E7 — hold, domino query, remediation, pass."""
     if vessel_key != "vessel-hold":
@@ -372,6 +395,8 @@ def run_hold_to_pass_scenario(
         device_id=device_id,
         skip_render=skip_render,
         skip_seal=skip_seal,
+        skip_worm=skip_worm,
+        worm_root=worm_root,
         lifecycle_event="E7",
     )
 
@@ -418,6 +443,8 @@ def run_hold_to_pass_scenario(
         device_id=device_id,
         skip_render=skip_render,
         skip_seal=skip_seal,
+        skip_worm=skip_worm,
+        worm_root=worm_root,
         prior_decision_hash=baseline.decision_hash,
         lifecycle_event="E7",
     )
@@ -533,6 +560,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--device-id", default="port-clearance-poc")
     parser.add_argument("--skip-render", action="store_true", help="Skip HTML certificate")
     parser.add_argument("--skip-seal", action="store_true", help="Skip audit sign-clearance")
+    parser.add_argument(
+        "--skip-worm",
+        action="store_true",
+        help="Skip mock WORM publish (G11 immutable retention demo)",
+    )
+    parser.add_argument(
+        "--worm-root",
+        type=Path,
+        help="Mock WORM store root (default: CLEARANCE_WORM_ROOT or data/processed/.../worm_store/clearance)",
+    )
     parser.add_argument("--json", action="store_true", help="Print run summary JSON to stdout")
     args = parser.parse_args(argv)
 
@@ -561,6 +598,8 @@ def main(argv: list[str] | None = None) -> int:
                 device_id=args.device_id,
                 skip_render=args.skip_render,
                 skip_seal=args.skip_seal,
+                skip_worm=args.skip_worm,
+                worm_root=args.worm_root,
             )
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -578,6 +617,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"re-E7 remediated.outcome: {remediated.outcome}")
         print(f"re-E7 remediated.decision_hash: {remediated.decision_hash}")
         print(f"scenario_summary: {results['scenario_summary_path']}")
+        if baseline.worm_publish_path:
+            print(f"baseline.worm_publish: {baseline.worm_publish_path}")
+        if remediated.worm_publish_path:
+            print(f"remediated.worm_publish: {remediated.worm_publish_path}")
 
         try:
             eds = None if args.skip_seal else find_eds_binary(args.eds_bin)
@@ -603,6 +646,8 @@ def main(argv: list[str] | None = None) -> int:
             device_id=args.device_id,
             skip_render=args.skip_render,
             skip_seal=args.skip_seal,
+            skip_worm=args.skip_worm,
+            worm_root=args.worm_root,
         )
     except (FileNotFoundError, RuntimeError) as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -631,6 +676,8 @@ def main(argv: list[str] | None = None) -> int:
             print(f"html: {result.html_path}")
         if result.chain_path:
             print(f"chain: {result.chain_path}")
+        if result.worm_publish_path:
+            print(f"worm_publish: {result.worm_publish_path}")
 
     try:
         eds = None if args.skip_seal else find_eds_binary(args.eds_bin)

--- a/agents/port_clearance/verify_retention.py
+++ b/agents/port_clearance/verify_retention.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""CLI — verify immutable WORM retention for a clearance run (D3-2)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from agents.port_clearance.worm_store import verify_retention
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify clearance artefacts in mock WORM store (fetch + SHA-256)",
+    )
+    parser.add_argument(
+        "publish_record",
+        type=Path,
+        help="Path to *_worm_publish.json from run_clearance",
+    )
+    parser.add_argument(
+        "--worm-root",
+        type=Path,
+        help="Override WORM root (default: record or CLEARANCE_WORM_ROOT)",
+    )
+    parser.add_argument(
+        "--skip-manifest-refs",
+        action="store_true",
+        help="Skip assert_manifest_audit_refs on stored manifest",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON result")
+    args = parser.parse_args(argv)
+
+    if not args.publish_record.is_file():
+        print(f"error: publish record not found: {args.publish_record}", file=sys.stderr)
+        return 2
+
+    try:
+        result = verify_retention(
+            args.publish_record,
+            worm_root=args.worm_root,
+            check_manifest_refs=not args.skip_manifest_refs,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print("RETENTION_VERIFIED")
+        print(f"  worm_root: {result['worm_root']}")
+        print(f"  objects:   {len(result['objects_verified'])}")
+        print(f"  manifest_audit_refs: {result['manifest_audit_refs']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/port_clearance/worm_store.py
+++ b/agents/port_clearance/worm_store.py
@@ -13,7 +13,6 @@ from typing import Any
 from pipelines.maritime_cyber.audit_refs import assert_manifest_audit_refs, file_sha256
 from pipelines.maritime_cyber.graph import DEFAULT_OUTPUT_DIR
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_WORM_ROOT = DEFAULT_OUTPUT_DIR / "worm_store" / "clearance"
 
 

--- a/agents/port_clearance/worm_store.py
+++ b/agents/port_clearance/worm_store.py
@@ -1,0 +1,225 @@
+"""G11 — mock WORM / append-only storage for clearance artefacts (Cap Vista D3)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pipelines.maritime_cyber.audit_refs import assert_manifest_audit_refs, file_sha256
+from pipelines.maritime_cyber.graph import DEFAULT_OUTPUT_DIR
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WORM_ROOT = DEFAULT_OUTPUT_DIR / "worm_store" / "clearance"
+
+
+class WormTamperError(ValueError):
+    """Stored object was modified or replaced (object-lock violation)."""
+
+
+class WormRetentionError(ValueError):
+    """Retention verification failed."""
+
+
+@dataclass(frozen=True)
+class WormObjectRecord:
+    object_key: str
+    source_path: str
+    storage_path: str
+    sha256: str
+    size_bytes: int
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def resolve_worm_root(explicit: Path | str | None = None) -> Path:
+    if explicit is not None:
+        return Path(explicit).expanduser().resolve()
+    env = os.environ.get("CLEARANCE_WORM_ROOT")
+    if env:
+        return Path(env).expanduser().resolve()
+    return DEFAULT_WORM_ROOT.resolve()
+
+
+def _storage_target_label(worm_root: Path) -> str:
+    if os.environ.get("CLEARANCE_WORM_URI"):
+        return "configured"
+    return "mock"
+
+
+def publish_artifact(
+    *,
+    worm_root: Path,
+    publish_namespace: str,
+    object_key: str,
+    source: Path,
+) -> WormObjectRecord:
+    """Copy artefact into append-only store; refuse to replace differing content."""
+    if not source.is_file():
+        raise FileNotFoundError(f"artefact missing for WORM publish: {source}")
+
+    digest = file_sha256(source)
+    rel = Path("objects") / publish_namespace / object_key
+    dest = worm_root / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    if dest.exists():
+        existing = file_sha256(dest)
+        if existing != digest:
+            raise WormTamperError(
+                f"object-lock violation: {dest} exists with different content "
+                f"(existing={existing}, new={digest})"
+            )
+        size = dest.stat().st_size
+    else:
+        shutil.copy2(source, dest)
+        dest.chmod(0o444)
+        size = dest.stat().st_size
+
+    return WormObjectRecord(
+        object_key=object_key,
+        source_path=str(source.resolve()),
+        storage_path=str(rel.as_posix()),
+        sha256=digest,
+        size_bytes=size,
+    )
+
+
+def publish_clearance_run(
+    run_dir: Path,
+    *,
+    prefix: str,
+    manifest_path: Path,
+    integrated_snapshot_path: Path | None = None,
+    chain_path: Path | None = None,
+    worm_root: Path | None = None,
+) -> dict[str, Any]:
+    """Publish clearance artefacts to mock WORM; write `*_worm_publish.json` in run_dir."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    root = resolve_worm_root(worm_root)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    decision_hash = manifest.get("decision_hash")
+    if not isinstance(decision_hash, str) or len(decision_hash) < 16:
+        raise WormRetentionError("manifest missing decision_hash for WORM namespace")
+    namespace = f"{prefix.replace('/', '-')}/{decision_hash[:16]}"
+    published_at = _utc_now_iso()
+
+    objects: list[WormObjectRecord] = []
+    artefacts: list[tuple[str, Path]] = [
+        ("evaluation_manifest.json", manifest_path),
+    ]
+    if integrated_snapshot_path and integrated_snapshot_path.is_file():
+        artefacts.append(("integrated_snapshot.json", integrated_snapshot_path))
+    if chain_path and chain_path.is_file():
+        artefacts.append(("clearance_chain.json", chain_path))
+
+    for name, path in artefacts:
+        objects.append(
+            publish_artifact(
+                worm_root=root,
+                publish_namespace=namespace,
+                object_key=name,
+                source=path,
+            )
+        )
+
+    record = {
+        "storage_target": _storage_target_label(root),
+        "worm_root": str(root),
+        "publish_namespace": namespace,
+        "published_at": published_at,
+        "objects": [
+            {
+                "object_key": o.object_key,
+                "source_path": o.source_path,
+                "storage_path": o.storage_path,
+                "sha256": o.sha256,
+                "size_bytes": o.size_bytes,
+            }
+            for o in objects
+        ],
+    }
+    publish_path = run_dir / f"{prefix}_worm_publish.json"
+    publish_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+    record["publish_record_path"] = str(publish_path)
+    return record
+
+
+def verify_retention(
+    publish_record_path: Path,
+    *,
+    worm_root: Path | None = None,
+    check_manifest_refs: bool = True,
+) -> dict[str, Any]:
+    """Fetch WORM copies and verify SHA-256; optional manifest drift check."""
+    record = json.loads(publish_record_path.read_text(encoding="utf-8"))
+    root = resolve_worm_root(worm_root or Path(record["worm_root"]))
+
+    verified: list[dict[str, Any]] = []
+    for obj in record.get("objects") or []:
+        storage_rel = obj.get("storage_path")
+        expected_sha = obj.get("sha256")
+        if not storage_rel or not expected_sha:
+            raise WormRetentionError(f"invalid publish record object entry: {obj}")
+
+        stored = root / storage_rel
+        if not stored.is_file():
+            raise WormRetentionError(f"WORM object missing: {stored}")
+
+        actual_sha = file_sha256(stored)
+        if actual_sha != expected_sha:
+            raise WormTamperError(
+                f"hash mismatch for {obj.get('object_key')}: "
+                f"expected {expected_sha}, got {actual_sha}"
+            )
+        verified.append(
+            {
+                "object_key": obj.get("object_key"),
+                "storage_path": str(stored),
+                "sha256": actual_sha,
+                "status": "ok",
+            }
+        )
+
+    manifest_path: Path | None = None
+    for obj in record.get("objects") or []:
+        if obj.get("object_key") == "evaluation_manifest.json":
+            manifest_path = root / obj["storage_path"]
+            break
+
+    manifest_refs_status = "skipped"
+    if check_manifest_refs and manifest_path and manifest_path.is_file():
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        vessel_key = manifest.get("vessel_key")
+        if not vessel_key:
+            raise WormRetentionError("manifest missing vessel_key")
+        assert_manifest_audit_refs(manifest, vessel_key)
+        manifest_refs_status = "ok"
+
+    return {
+        "status": "verified",
+        "storage_target": record.get("storage_target"),
+        "worm_root": str(root),
+        "publish_record": str(publish_record_path.resolve()),
+        "objects_verified": verified,
+        "manifest_audit_refs": manifest_refs_status,
+    }
+
+
+def tamper_worm_object(publish_record_path: Path, object_key: str, *, worm_root: Path | None = None) -> Path:
+    """PoC demo helper: mutate stored bytes to simulate integrity violation."""
+    record = json.loads(publish_record_path.read_text(encoding="utf-8"))
+    root = resolve_worm_root(worm_root or Path(record["worm_root"]))
+    for obj in record.get("objects") or []:
+        if obj.get("object_key") == object_key:
+            path = root / obj["storage_path"]
+            path.chmod(0o644)
+            path.write_bytes(path.read_bytes() + b"\n# tampered\n")
+            return path
+    raise KeyError(f"object_key not in publish record: {object_key}")

--- a/tests/maritime_cyber/test_run_clearance.py
+++ b/tests/maritime_cyber/test_run_clearance.py
@@ -81,6 +81,7 @@ def test_hold_to_pass_scenario_eval_only(tmp_path: Path) -> None:
         output_dir=tmp_path / "scenario",
         skip_render=True,
         skip_seal=True,
+        worm_root=tmp_path / "worm",
     )
     assert results["baseline"].outcome == "hold"
     assert results["remediated"].outcome == "pass"
@@ -115,6 +116,7 @@ def test_hold_to_pass_scenario_verify_clearance_both_runs(tmp_path: Path) -> Non
         skip_render=True,
         skip_seal=False,
         eds_bin=eds,
+        worm_root=tmp_path / "worm",
     )
     eds_path = Path(eds)
     for label in ("baseline", "remediated"):

--- a/tests/maritime_cyber/test_worm_store.py
+++ b/tests/maritime_cyber/test_worm_store.py
@@ -1,0 +1,102 @@
+"""D3 — mock WORM publish and retention verification (G11)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agents.port_clearance.run_clearance import run_clearance
+from agents.port_clearance.worm_store import (
+    WormTamperError,
+    publish_clearance_run,
+    tamper_worm_object,
+    verify_retention,
+)
+
+
+def test_run_clearance_publishes_worm_record(tmp_path: Path) -> None:
+    worm_root = tmp_path / "worm"
+    result = run_clearance(
+        "vessel-hold",
+        output_dir=tmp_path / "hold",
+        write_graph=False,
+        skip_render=True,
+        skip_seal=True,
+        worm_root=worm_root,
+    )
+    assert result.worm_publish_path is not None
+    assert result.worm_publish_path.is_file()
+
+    record = json.loads(result.worm_publish_path.read_text(encoding="utf-8"))
+    assert record["storage_target"] == "mock"
+    assert len(record["objects"]) >= 2
+    keys = {o["object_key"] for o in record["objects"]}
+    assert "evaluation_manifest.json" in keys
+    assert "integrated_snapshot.json" in keys
+
+    verified = verify_retention(result.worm_publish_path, worm_root=worm_root)
+    assert verified["status"] == "verified"
+    assert verified["manifest_audit_refs"] == "ok"
+
+
+def test_publish_refuses_object_lock_violation(tmp_path: Path) -> None:
+    worm_root = tmp_path / "worm"
+    source = tmp_path / "artifact.json"
+    source.write_text('{"v":1}', encoding="utf-8")
+
+    namespace_hash = "a" * 64
+    manifest_v1 = tmp_path / "manifest_v1.json"
+    manifest_v1.write_text(
+        json.dumps({"decision_hash": namespace_hash, "vessel_key": "vessel-hold", "v": 1}),
+        encoding="utf-8",
+    )
+    publish_clearance_run(
+        tmp_path / "run1",
+        prefix="vessel-hold_pc1",
+        manifest_path=manifest_v1,
+        worm_root=worm_root,
+    )
+
+    manifest_v2 = tmp_path / "manifest_v2.json"
+    manifest_v2.write_text(
+        json.dumps({"decision_hash": namespace_hash, "vessel_key": "vessel-hold", "v": 2}),
+        encoding="utf-8",
+    )
+    with pytest.raises(WormTamperError, match="object-lock"):
+        publish_clearance_run(
+            tmp_path / "run2",
+            prefix="vessel-hold_pc1",
+            manifest_path=manifest_v2,
+            worm_root=worm_root,
+        )
+
+
+def test_verify_retention_fails_after_tamper(tmp_path: Path) -> None:
+    worm_root = tmp_path / "worm"
+    result = run_clearance(
+        "vessel-hold",
+        output_dir=tmp_path / "hold",
+        write_graph=False,
+        skip_render=True,
+        skip_seal=True,
+        worm_root=worm_root,
+    )
+    assert result.worm_publish_path is not None
+    tamper_worm_object(result.worm_publish_path, "integrated_snapshot.json", worm_root=worm_root)
+
+    with pytest.raises(WormTamperError, match="hash mismatch"):
+        verify_retention(result.worm_publish_path, worm_root=worm_root)
+
+
+def test_skip_worm_skips_publish_record(tmp_path: Path) -> None:
+    result = run_clearance(
+        "vessel-hold",
+        output_dir=tmp_path / "hold",
+        write_graph=False,
+        skip_render=True,
+        skip_seal=True,
+        skip_worm=True,
+    )
+    assert result.worm_publish_path is None


### PR DESCRIPTION
## Summary
- mock WORM publish after `run_clearance` (`*_worm_publish.json`, per-run namespace from `decision_hash`)
- `verify_retention` CLI for third-party fetch + SHA-256 + manifest audit refs
- tamper detection tests; `--skip-worm` / `CLEARANCE_WORM_ROOT` supported

## Acceptance criteria (#158)
- [x] AC1 Publish step + publish record
- [x] AC2 README + verify_retention CLI
- [x] AC4 Tamper → verify fails
- [x] AC5 Tests (no cloud credentials)
- AC3 VALIDATION.md in edgesentry-commercial (same PR batch, docs branch)

## Test plan
- [x] `uv run pytest tests/maritime_cyber/ -q` (34 passed)

## Linked issue
- Closes https://github.com/edgesentry/edgesentry-commercial/issues/158

Made with [Cursor](https://cursor.com)