### PR TITLE
feat(maritime-cyber): D4 impacted-path export (#159)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,14 +30,18 @@ Multi-domain OSINT data layer. indago ingests raw signals from maritime, corpora
 | `scripts/notify_metrics.py` | Data-publish summary email |
 | `scripts/fetch_publish_metrics.py` | Fetch latest metrics from public R2 (no credentials) |
 | `config/sanction_regimes.yaml` | Configurable sanction regime definitions |
-| `profiles/maritime_cyber/` | Port Cyber Clearance ontology + manifest (Cap Vista PoC) |
-| `rules/sg-cyber-clearance-v0.yaml` | Singapore clearance rule pack (E26/E27-inspired) |
-| `fixtures/` | Maritime cyber PoC fixtures (`asset_map.yaml`, SBOM, CVE — W1+) |
-| `pipelines/maritime_cyber/` | Rule pack loader; graph build (`graph.py`); eval (W3) |
+| `profiles/maritime_cyber/` | Port Cyber Clearance profile (Cap Vista 6/30) — **W1** done |
+| `rules/sg-cyber-clearance-v0.yaml` | Singapore clearance rule pack — **W0** done |
+| `fixtures/` | Maritime cyber PoC fixtures — **W1** ([fixtures/README.md](fixtures/README.md)) |
+| `pipelines/maritime_cyber/` | Graph (**W2**), eval (**W3**), audit refs (**D2**) |
 | `pipelines/maritime_cyber_graph.py` | CLI — build graph Parquet under `data/processed/maritime_cyber/` |
 | `pipelines/port_clearance_eval.py` | CLI — pass/hold eval + UC2 `affected-vessels` |
-| `pipelines/maritime_cyber/eval.py` | Rule engine, facts.json, decision_hash (W3) |
-| `agents/port_clearance/run_clearance.py` | W6 E2E — graph → eval → HTML → audit seal + verify instructions |
+| `pipelines/export_vessel_graph.py` | **D4** — impacted-path JSON + HTML export |
+| `agents/port_clearance/run_clearance.py` | **W6** E2E (+ **D1** scenario, **D3** WORM, **D4** graph export) |
+| `agents/port_clearance/worm_store.py` | **D3** — mock immutable publish |
+| `agents/port_clearance/verify_retention.py` | **D3** — third-party retention verify CLI |
+| `tests/maritime_cyber/` | CI for W2–W3, W6, D1–D4 |
+| `docs/ref-maritime-cyber-capvista.md` | **W0–W7 + D1–D4** status, commands, repo map |
 | `config/geopolitical_events.json` | Geopolitical filter zones |
 
 ## R2 buckets
@@ -104,6 +108,7 @@ Conventional Commits (`fix:`, `feat:`, `feat!:`)
 
 ## Docs
 
+- Port Cyber Clearance (Cap Vista): `docs/ref-maritime-cyber-capvista.md`
 - Analytics overview: `docs/ref-analytics-overview.md`
 - Feature engineering: `docs/ref-feature-engineering.md`
 - Scoring model: `docs/ref-scoring-model.md`

--- a/README.md
+++ b/README.md
@@ -46,11 +46,20 @@ See [`docs/ref-r2-buckets.md`](docs/ref-r2-buckets.md) for full partition layout
 
 Analyst metrics (Precision@50, Recall, pre-designation lead time, SHAP scores) are displayed at **[arktrace.edgesentry.io](https://arktrace.edgesentry.io)**.
 
+## Port Cyber Clearance (Cap Vista 6/30)
+
+Deterministic port cyber clearance on synthetic SBOM/CVE fixtures — separate from the 11-step shadow-fleet pipeline.
+
+- **Status:** indago **W0–W6** + demo **D1–D4** complete; submission **W7** in [edgesentry-commercial](https://github.com/edgesentry/edgesentry-commercial/tree/main/docs/programs/20260630-capvista-products/analysis)
+- **Guide:** [docs/ref-maritime-cyber-capvista.md](docs/ref-maritime-cyber-capvista.md)
+- **Run:** `uv run python -m agents.port_clearance.run_clearance vessel-hold`
+
 ## Repository layout
 
 ```
 indago/
   .agents/skills/      # agent skills (npx skills add edgesentry/indago)
+  agents/port_clearance/  # Cap Vista E2E (W6, D1, D3, D4)
   dashboard/           # maintainer pipeline ops dashboard
   docs/                # reference material (ref-*.md)
   pipelines/           # ingest and transformation pipeline implementations

--- a/agents/port_clearance/README.md
+++ b/agents/port_clearance/README.md
@@ -1,5 +1,14 @@
 # Port Cyber Clearance — E2E orchestrator (W6)
 
+**Program status:** [docs/ref-maritime-cyber-capvista.md](../../docs/ref-maritime-cyber-capvista.md) — indago **W0–W6** and demo **D1–D4** done; **W7** submission is in `edgesentry-commercial`.
+
+| Workstream | Status | This package |
+|------------|--------|--------------|
+| W6 E2E | Done | `run_clearance.py` |
+| D1 lifecycle | Done | `--scenario hold-to-pass` |
+| D3 mock WORM | Done | `worm_store.py`, `verify_retention.py` |
+| D4 path viz | Done | calls `pipelines/export_vessel_graph` |
+
 One command runs the Cap Vista UC1 demo path:
 
 1. Load `profiles/maritime_cyber/manifest.yaml`
@@ -44,6 +53,12 @@ uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-render -
 # Skip immutable publish (G11 demo off)
 uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-worm
 
+# Skip impacted-path export (D4)
+uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-graph-export
+
+# Copy impacted-path HTML to documaris/dist (D4 demo bundle)
+uv run python -m agents.port_clearance.run_clearance vessel-hold --copy-graph-to-documaris
+
 # D4 only (standalone export + optional documaris/dist copy)
 uv run python -m pipelines.export_vessel_graph vessel-hold --copy-to-documaris-dist
 
@@ -86,8 +101,22 @@ Each clearance run writes (unless `--skip-graph-export`):
 
 Copy to documaris demo bundle: `--copy-graph-to-documaris` → `documaris/dist/<vessel>_impacted-path.html`
 
+## Run outputs (typical prefix `vessel-hold_port-call-demo-sgsin`)
+
+| Artefact | Workstream |
+|----------|------------|
+| `*_facts.json`, `*_evaluation_manifest.json` | W3 |
+| `*_integrated_snapshot.json` | D2 |
+| `*_port-cyber-clearance.html` | W5 (via `eds`) |
+| `*_clearance_chain.json` | W4 |
+| `*_worm_publish.json` | D3 |
+| `*_impacted_paths.json`, `*_impacted-path.html` | D4 |
+| `*_run_summary.json` | W6 |
+
 ## Related
 
+- Program map: [docs/ref-maritime-cyber-capvista.md](../../docs/ref-maritime-cyber-capvista.md)
 - W3: `pipelines/port_clearance_eval.py`
 - W4: `edgesentry-rs/docs/port-cyber-clearance-audit.md`
 - W5: `documaris/dist/*_port-cyber-clearance.html`
+- Tests: `tests/maritime_cyber/README.md`

--- a/agents/port_clearance/README.md
+++ b/agents/port_clearance/README.md
@@ -8,7 +8,8 @@ One command runs the Cap Vista UC1 demo path:
 4. Render certificate HTML (`eds document render-clearance`)
 5. Seal audit chain (`eds audit sign-clearance`)
 6. Publish artefacts to **mock WORM** store (G11 — append-only, content-addressed)
-7. Print third-party verify instructions
+7. Export **impacted vulnerability paths** (D4 — JSON + self-contained HTML)
+8. Print third-party verify instructions
 
 ## Prerequisites
 
@@ -43,6 +44,9 @@ uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-render -
 # Skip immutable publish (G11 demo off)
 uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-worm
 
+# D4 only (standalone export + optional documaris/dist copy)
+uv run python -m pipelines.export_vessel_graph vessel-hold --copy-to-documaris-dist
+
 # Machine-readable summary
 uv run python -m agents.port_clearance.run_clearance vessel-hold --json
 ```
@@ -72,6 +76,15 @@ uv run python -m agents.port_clearance.verify_retention \
 Steps performed: fetch each WORM object → verify SHA-256 → `assert_manifest_audit_refs` on stored manifest.
 
 Production pilots may set `CLEARANCE_WORM_URI` (future); **Cap Vista PoC does not require R2 upload**.
+
+## Impacted path visualization (D4)
+
+Each clearance run writes (unless `--skip-graph-export`):
+
+- `<prefix>_impacted_paths.json` — same `impacted_paths[]` as evaluation facts
+- `<prefix>_impacted-path.html` — Component → CVE → Asset → Vessel table + chain blocks
+
+Copy to documaris demo bundle: `--copy-graph-to-documaris` → `documaris/dist/<vessel>_impacted-path.html`
 
 ## Related
 

--- a/agents/port_clearance/run_clearance.py
+++ b/agents/port_clearance/run_clearance.py
@@ -33,6 +33,7 @@ from pipelines.maritime_cyber.graph import (
 )
 
 from agents.port_clearance.worm_store import publish_clearance_run  # noqa: E402
+from pipelines.export_vessel_graph import write_vessel_graph_artifacts  # noqa: E402
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PROFILE_MANIFEST = _REPO_ROOT / "profiles" / "maritime_cyber" / "manifest.yaml"
@@ -56,6 +57,8 @@ class ClearanceRunResult:
     chain_path: Path | None
     verify_url: str
     worm_publish_path: Path | None
+    impacted_paths_json: Path | None
+    impacted_path_html: Path | None
 
 
 def load_profile_manifest(path: Path | None = None) -> dict[str, Any]:
@@ -175,6 +178,8 @@ def run_clearance(
     skip_seal: bool = False,
     skip_worm: bool = False,
     worm_root: Path | None = None,
+    skip_graph_export: bool = False,
+    copy_graph_to_documaris: bool = False,
     prior_decision_hash: str | None = None,
     lifecycle_event: str | None = None,
 ) -> ClearanceRunResult:
@@ -292,6 +297,27 @@ def run_clearance(
     if prior_decision_hash:
         summary["prior_decision_hash"] = prior_decision_hash
 
+    impacted_paths_json: Path | None = None
+    impacted_path_html: Path | None = None
+    if not skip_graph_export:
+        graph_exports = write_vessel_graph_artifacts(
+            vessel_key,
+            out,
+            prefix=prefix,
+            impacted_paths=eval_result.facts["impacted_paths"],
+            port_call_id=port_call_id,
+            outcome=eval_result.outcome,
+            graph_result=graph_result,
+            asset_map_path=asset_map_path,
+            cve_snapshot_path=cve_snapshot_path,
+            sbom_dir=sbom_dir,
+            copy_to_documaris_dist=copy_graph_to_documaris,
+        )
+        impacted_paths_json = graph_exports["json"]
+        impacted_path_html = graph_exports["html"]
+        summary["impacted_paths_json"] = str(impacted_paths_json)
+        summary["impacted_path_html"] = str(impacted_path_html)
+
     worm_publish_path: Path | None = None
     if not skip_worm:
         worm_record = publish_clearance_run(
@@ -324,6 +350,8 @@ def run_clearance(
         chain_path=chain_path,
         verify_url=url,
         worm_publish_path=worm_publish_path,
+        impacted_paths_json=impacted_paths_json,
+        impacted_path_html=impacted_path_html,
     )
 
 
@@ -370,6 +398,8 @@ def run_hold_to_pass_scenario(
     skip_seal: bool = False,
     skip_worm: bool = False,
     worm_root: Path | None = None,
+    skip_graph_export: bool = False,
+    copy_graph_to_documaris: bool = False,
 ) -> dict[str, Any]:
     """D1: E7 -> E9 -> E10 -> re-E7 — hold, domino query, remediation, pass."""
     if vessel_key != "vessel-hold":
@@ -397,6 +427,8 @@ def run_hold_to_pass_scenario(
         skip_seal=skip_seal,
         skip_worm=skip_worm,
         worm_root=worm_root,
+        skip_graph_export=skip_graph_export,
+        copy_graph_to_documaris=copy_graph_to_documaris,
         lifecycle_event="E7",
     )
 
@@ -445,6 +477,8 @@ def run_hold_to_pass_scenario(
         skip_seal=skip_seal,
         skip_worm=skip_worm,
         worm_root=worm_root,
+        skip_graph_export=skip_graph_export,
+        copy_graph_to_documaris=copy_graph_to_documaris,
         prior_decision_hash=baseline.decision_hash,
         lifecycle_event="E7",
     )
@@ -570,6 +604,16 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Mock WORM store root (default: CLEARANCE_WORM_ROOT or data/processed/.../worm_store/clearance)",
     )
+    parser.add_argument(
+        "--skip-graph-export",
+        action="store_true",
+        help="Skip D4 impacted-path JSON/HTML export",
+    )
+    parser.add_argument(
+        "--copy-graph-to-documaris",
+        action="store_true",
+        help="Also write documaris/dist/<vessel>_impacted-path.html",
+    )
     parser.add_argument("--json", action="store_true", help="Print run summary JSON to stdout")
     args = parser.parse_args(argv)
 
@@ -600,6 +644,8 @@ def main(argv: list[str] | None = None) -> int:
                 skip_seal=args.skip_seal,
                 skip_worm=args.skip_worm,
                 worm_root=args.worm_root,
+                skip_graph_export=args.skip_graph_export,
+                copy_graph_to_documaris=args.copy_graph_to_documaris,
             )
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -648,6 +694,8 @@ def main(argv: list[str] | None = None) -> int:
             skip_seal=args.skip_seal,
             skip_worm=args.skip_worm,
             worm_root=args.worm_root,
+            skip_graph_export=args.skip_graph_export,
+            copy_graph_to_documaris=args.copy_graph_to_documaris,
         )
     except (FileNotFoundError, RuntimeError) as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -678,6 +726,8 @@ def main(argv: list[str] | None = None) -> int:
             print(f"chain: {result.chain_path}")
         if result.worm_publish_path:
             print(f"worm_publish: {result.worm_publish_path}")
+        if result.impacted_path_html:
+            print(f"impacted_path_html: {result.impacted_path_html}")
 
     try:
         eds = None if args.skip_seal else find_eds_binary(args.eds_bin)

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,12 @@ Runs daily via GitHub Actions across 5 regions. See [`/indago-run-pipeline`](htt
 - [ref-field-investigation.md](ref-field-investigation.md) — physical measurement tiers, VDES
 - [ref-triage-governance.md](ref-triage-governance.md) — human-in-the-loop review workflow
 
+## Cap Vista — Port Cyber Clearance (6/30)
+
+- [ref-maritime-cyber-capvista.md](ref-maritime-cyber-capvista.md) — **W0–W7** and **D1–D4** status, commands, tests
+- [agents/port_clearance/README.md](https://github.com/edgesentry/indago/blob/main/agents/port_clearance/README.md) — E2E operator guide (W6)
+- [profiles/maritime_cyber/README.md](https://github.com/edgesentry/indago/blob/main/profiles/maritime_cyber/README.md) — profile manifest
+
 ## Operations
 
 - [config/equasis/README.md](https://github.com/edgesentry/indago/blob/main/config/equasis/README.md) — Equasis ownership seed → graph edges (indago#169)

--- a/docs/ref-maritime-cyber-capvista.md
+++ b/docs/ref-maritime-cyber-capvista.md
@@ -133,9 +133,9 @@ See [lifecycle-events.md](https://github.com/edgesentry/edgesentry-commercial/bl
 
 | Doc | Repo |
 |-----|------|
-| [agents/port_clearance/README.md](../agents/port_clearance/README.md) | indago — operator commands |
-| [fixtures/README.md](../fixtures/README.md) | indago — W1 fixtures |
-| [profiles/maritime_cyber/README.md](../profiles/maritime_cyber/README.md) | indago — profile entry |
+| [agents/port_clearance/README.md](https://github.com/edgesentry/indago/blob/main/agents/port_clearance/README.md) | indago — operator commands |
+| [fixtures/README.md](https://github.com/edgesentry/indago/blob/main/fixtures/README.md) | indago — W1 fixtures |
+| [profiles/maritime_cyber/README.md](https://github.com/edgesentry/indago/blob/main/profiles/maritime_cyber/README.md) | indago — profile entry |
 | [implementation-plan.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/implementation-plan.md) | commercial |
 | [completed-tasks.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/completed-tasks.md) | commercial |
 | [VALIDATION.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/VALIDATION.md) | commercial — G11 WORM policy |

--- a/docs/ref-maritime-cyber-capvista.md
+++ b/docs/ref-maritime-cyber-capvista.md
@@ -1,0 +1,141 @@
+# Port Cyber Clearance — Cap Vista 6/30 (indago)
+
+**Program:** [edgesentry-commercial — 20260630-capvista-products](https://github.com/edgesentry/edgesentry-commercial/tree/main/docs/programs/20260630-capvista-products/analysis)  
+**Gates:** [mvp-build-checklist.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/mvp-build-checklist.md) (G1–G12)  
+**Status (2026-05-27):** indago workstreams **W0–W6** and demo track **D1–D4** are **done**. **W7** (submission artefacts) lives in `edgesentry-commercial`, not this repo.
+
+---
+
+## Workstream status (W0–W7)
+
+| ID | Workstream | Primary repo | Status | indago / sibling paths |
+|----|------------|--------------|--------|-------------------------|
+| **W0** | Regulatory → rule pack + schema | commercial + indago | **Done** | `rules/sg-cyber-clearance-v0.yaml` · [requirements matrix](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/regulatory-requirements-matrix.md) |
+| **W1** | Fixtures + profile | indago | **Done** | `fixtures/` · `profiles/maritime_cyber/` |
+| **W2** | Graph ingest + Parquet | indago | **Done** | `pipelines/maritime_cyber/graph.py` · `pipelines/maritime_cyber_graph.py` |
+| **W3** | `port_clearance_eval` + UC2 | indago | **Done** | `pipelines/maritime_cyber/eval.py` · `pipelines/port_clearance_eval.py` |
+| **W4** | Audit seal + verify | edgesentry-rs | **Done** | `eds audit sign-clearance` / `verify-clearance` — [port-cyber-clearance-audit.md](https://github.com/edgesentry/edgesentry-rs/blob/main/docs/port-cyber-clearance-audit.md) |
+| **W5** | Clearance PDF/HTML | documaris | **Done** | `documaris/templates/port-cyber-clearance.md` · `documaris/dist/*_port-cyber-clearance.html` |
+| **W6** | E2E orchestration | indago | **Done** | `agents/port_clearance/run_clearance.py` |
+| **W7** | Submission (video, deck, portal) | edgesentry-commercial | **Open** | G8–G12, L1–L4 — [issue #153](https://github.com/edgesentry/edgesentry-commercial/issues/153) |
+
+**Post-MVP (not portal blockers):** W8 fixture generator · W9 fleet graph viz (Cytoscape / arktrace S1). Minimal path export is covered by **D4** (`export_vessel_graph`).
+
+---
+
+## Demo track (D1–D4)
+
+Runnable demo before deck/video; all implemented in indago unless noted.
+
+| Track | Goal | Status | Entry point |
+|-------|------|--------|-------------|
+| **D1** | E7 → E9 → E10 → re-E7 (hold → patch → pass) | **Done** | `uv run python -m agents.port_clearance.run_clearance vessel-hold --scenario hold-to-pass` |
+| **D2** | G11/G12 — `bom_baseline_ref`, `cve_snapshot_ref`, drift, `impacted_paths[]` | **Done** | `pipelines/maritime_cyber/audit_refs.py` · manifest/facts · [indago#192](https://github.com/edgesentry/indago/pull/192) |
+| **D3** | Mock WORM publish + third-party retention verify | **Done** | `agents/port_clearance/worm_store.py` · `verify_retention.py` · [indago#193](https://github.com/edgesentry/indago/pull/193) |
+| **D4** | Impacted-path JSON + HTML (explainability) | **Done** | `pipelines/export_vessel_graph.py` · wired in `run_clearance` · [indago#194](https://github.com/edgesentry/indago/pull/194) |
+| **D4-3** | Deck frame from generated HTML | **Open** | [commercial#163](https://github.com/edgesentry/edgesentry-commercial/issues/163) (W7) |
+| **D5** | Optional AI narrative (facts in, no pass/hold out) | **Open** | documaris + prompt guardrails |
+
+---
+
+## Quick start (W6 + D1 + D4)
+
+```bash
+cd indago
+uv sync
+export EDS_BIN=../edgesentry-rs/target/debug/eds   # optional for W4/W5 render+seal
+
+# Single-vessel UC1 (W3 + W6 + D3 + D4)
+uv run python -m agents.port_clearance.run_clearance vessel-hold
+
+# Full lifecycle demo (D1)
+uv run python -m agents.port_clearance.run_clearance vessel-hold --scenario hold-to-pass
+
+# Eval only (no eds, no WORM, no graph export)
+uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-render --skip-seal --skip-worm --skip-graph-export
+
+# D4 standalone → documaris demo bundle
+uv run python -m pipelines.export_vessel_graph vessel-hold --copy-to-documaris-dist
+
+# D3 retention verify
+uv run python -m agents.port_clearance.verify_retention \
+  data/processed/maritime_cyber/clearance_runs/vessel-hold/vessel-hold_port-call-demo-sgsin_worm_publish.json
+```
+
+**Outputs:** `data/processed/maritime_cyber/clearance_runs/<vessel_key>/` — facts, manifest, integrated snapshot, optional chain/HTML, WORM publish record, impacted-path JSON/HTML.
+
+---
+
+## Repository map (indago)
+
+```text
+profiles/maritime_cyber/
+  manifest.yaml          # W1 — fixture paths, pipeline IDs
+  ontology.yaml
+fixtures/
+  README.md              # W1 — synthetic disclosure + three vessels
+  asset_map.yaml
+  cve/snapshot-2026-05-26.json
+  sbom/{vessel-hold,vessel-clean,vessel-thread}.json
+rules/
+  sg-cyber-clearance-v0.yaml   # W0
+pipelines/
+  maritime_cyber/
+    graph.py             # W2
+    eval.py              # W3
+    audit_refs.py        # D2
+    rules.py
+  maritime_cyber_graph.py
+  port_clearance_eval.py
+  export_vessel_graph.py # D4
+agents/port_clearance/
+  run_clearance.py       # W6 (+ D1, D3, D4 hooks)
+  worm_store.py          # D3
+  verify_retention.py    # D3
+  README.md
+tests/maritime_cyber/    # CI for W2–W3, D1–D4
+```
+
+---
+
+## Tests
+
+```bash
+uv run pytest tests/maritime_cyber/ -q
+```
+
+| Test module | Covers |
+|-------------|--------|
+| `test_graph.py` | W2 |
+| `test_eval.py`, `test_rule_pack.py` | W3 |
+| `test_audit_refs.py` | D2 |
+| `test_run_clearance.py` | W6, D1 |
+| `test_worm_store.py` | D3 |
+| `test_export_vessel_graph.py` | D4 |
+| `test_audit_integration.py` | W4 (when `eds` on PATH) |
+
+---
+
+## Lifecycle events (demo script)
+
+| Event | Demo beat | indago / tool |
+|-------|-----------|---------------|
+| **E7** | Port cyber clearance (hold/pass) | `run_clearance` |
+| **E9** | CVE domino / affected vessels | `port_clearance_eval affected-vessels` or D1 scenario artifact |
+| **E10** | SBOM remediation | Patched SBOM under scenario dir; re-E7 |
+| **re-E7** | Re-clearance after patch | Second `run_clearance` with `prior_decision_hash` |
+
+See [lifecycle-events.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/lifecycle-events.md) in commercial repo.
+
+---
+
+## Related docs
+
+| Doc | Repo |
+|-----|------|
+| [agents/port_clearance/README.md](../agents/port_clearance/README.md) | indago — operator commands |
+| [fixtures/README.md](../fixtures/README.md) | indago — W1 fixtures |
+| [profiles/maritime_cyber/README.md](../profiles/maritime_cyber/README.md) | indago — profile entry |
+| [implementation-plan.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/implementation-plan.md) | commercial |
+| [completed-tasks.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/completed-tasks.md) | commercial |
+| [VALIDATION.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/VALIDATION.md) | commercial — G11 WORM policy |

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,4 +1,8 @@
-# Maritime cyber fixtures — Port Cyber Clearance PoC
+# Maritime cyber fixtures — Port Cyber Clearance PoC (W1)
+
+**Status:** **W1 done** — three-vessel fleet + pinned CVE snapshot for Cap Vista G1–G2.
+
+Program context: [docs/ref-maritime-cyber-capvista.md](../docs/ref-maritime-cyber-capvista.md).
 
 ## Disclosure (portal honesty)
 
@@ -8,13 +12,13 @@ This matches [maritime-cyber-governance-use-cases.md](https://github.com/edgesen
 
 ## Layout
 
-| Path | Layer | Status |
-|------|-------|--------|
-| `cve/snapshot-2026-05-26.json` | Public (pinned OSV subset — Log4Shell) | G1 |
-| `sbom/vessel-hold.json` | Synthetic — critical CVE on ECDIS path | G2 |
-| `sbom/vessel-clean.json` | Synthetic — no open criticals | G2 |
-| `sbom/vessel-thread.json` | Synthetic — clean + signed ProcessLog (UC3) | G2 |
-| `asset_map.yaml` | **Synthetic bridge** — OT ↔ firmware ↔ SBOM components | W0 schema · W1 data |
+| Path | Layer | Gate / WS |
+|------|-------|-----------|
+| `cve/snapshot-2026-05-26.json` | Public (pinned OSV subset — Log4Shell) | G1 · W1 |
+| `sbom/vessel-hold.json` | Synthetic — critical CVE on ECDIS path | G2 · W1 |
+| `sbom/vessel-clean.json` | Synthetic — no open criticals | G2 · W1 |
+| `sbom/vessel-thread.json` | Synthetic — clean + signed ProcessLog (UC3) | G2 · W1 |
+| `asset_map.yaml` | **Synthetic bridge** — OT ↔ firmware ↔ SBOM components | W0 schema · W1 |
 | `port_calls/*.json` | Synthetic — OCEANS-X-shaped port-call events | W1 |
 | `process_logs/*.json` | Synthetic — yard patch / scan records | W1 |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
   - Operations:
     - Pipeline Overview: ref-pipeline.md
     - Pipeline Catalog: ref-pipeline-catalog.md
+    - Port Cyber Clearance (Cap Vista): ref-maritime-cyber-capvista.md
     - Knowledge Graph: ref-knowledge-graph.md
     - Regional Playbooks: ref-regional-playbooks.md
     - R2 Buckets: ref-r2-buckets.md

--- a/pipelines/export_vessel_graph.py
+++ b/pipelines/export_vessel_graph.py
@@ -1,0 +1,247 @@
+"""D4 — export per-vessel impacted vulnerability paths (Component → CVE → Asset → Vessel)."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+from pipelines.maritime_cyber.eval import format_impacted_paths, iter_cve_asset_paths
+from pipelines.maritime_cyber.graph import (
+    DEFAULT_OUTPUT_DIR,
+    GraphBuildResult,
+    build_maritime_cyber_graph,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DOCUMARIS_DIST = _REPO_ROOT.parent / "documaris" / "dist"
+_POC_DISCLAIMER = (
+    "PoC: public CVE snapshot and synthetic SBOM/asset_map fixtures. "
+    "Not an official port-state or MPA berth approval."
+)
+
+
+def build_impacted_paths(
+    vessel_key: str,
+    *,
+    graph_result: GraphBuildResult | None = None,
+    asset_map_path: Path | None = None,
+    cve_snapshot_path: Path | None = None,
+    sbom_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Build impacted paths from graph (same walk as port_clearance_eval)."""
+    gresult = graph_result or build_maritime_cyber_graph(
+        [vessel_key],
+        asset_map_path=asset_map_path,
+        cve_snapshot_path=cve_snapshot_path,
+        sbom_dir=sbom_dir,
+    )
+    raw = iter_cve_asset_paths(gresult.nx_graph, gresult.nodes, vessel_key)
+    return format_impacted_paths(raw)
+
+
+def export_impacted_paths_document(
+    vessel_key: str,
+    impacted_paths: list[dict[str, Any]],
+    *,
+    port_call_id: str = "port-call-demo-sgsin",
+    outcome: str | None = None,
+) -> dict[str, Any]:
+    """Canonical JSON document for D4-1 (deterministic key order)."""
+    return {
+        "vessel_key": vessel_key,
+        "port_call_id": port_call_id,
+        "outcome": outcome,
+        "path_direction": "PhysicalAsset → Firmware → SoftwareComponent → CVE (forward walk from vessel)",
+        "impacted_paths": impacted_paths,
+    }
+
+
+def render_impacted_paths_html(
+    document: dict[str, Any],
+) -> str:
+    """Self-contained HTML table + chain summary for one vessel (D4-2)."""
+    vessel_key = str(document.get("vessel_key", ""))
+    port_call_id = str(document.get("port_call_id", ""))
+    outcome = str(document.get("outcome") or "unknown").upper()
+    paths: list[dict[str, Any]] = list(document.get("impacted_paths") or [])
+
+    rows: list[str] = []
+    chain_blocks: list[str] = []
+    for idx, p in enumerate(paths, start=1):
+        component = p.get("component_purl") or p.get("component_name") or "—"
+        cve = p.get("cve_osv_id") or p.get("cve_id") or "—"
+        asset = p.get("asset_name") or p.get("asset_id") or "—"
+        cvss = p.get("cvss_score")
+        cvss_s = f"{cvss:.1f}" if isinstance(cvss, (int, float)) else "—"
+        nodes = p.get("path_nodes") or []
+        node_line = " → ".join(html.escape(str(n)) for n in nodes)
+        rows.append(
+            f"<tr><td>{idx}</td>"
+            f"<td>{html.escape(str(component))}</td>"
+            f"<td>{html.escape(str(cve))}</td>"
+            f"<td>{cvss_s}</td>"
+            f"<td>{html.escape(str(asset))}</td>"
+            f"<td><code>{node_line}</code></td></tr>"
+        )
+        chain_blocks.append(
+            f'<div class="chain">'
+            f"<strong>Path {idx}</strong>: "
+            f"{html.escape(str(component))} "
+            f"<span class=\"arrow\">→</span> "
+            f"{html.escape(str(cve))} "
+            f"<span class=\"arrow\">→</span> "
+            f"{html.escape(str(asset))} "
+            f"<span class=\"arrow\">→</span> "
+            f"{html.escape(vessel_key)}"
+            f"</div>"
+        )
+
+    if not rows:
+        rows.append(
+            '<tr><td colspan="6" class="muted">No impacted vulnerability paths on this vessel.</td></tr>'
+        )
+        chain_blocks.append('<p class="muted">No paths to display.</p>')
+
+    chains_html = "\n".join(chain_blocks)
+    table_rows = "\n".join(rows)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Impacted paths — {html.escape(vessel_key)}</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; margin: 24px; color: #0f172a; line-height: 1.45; }}
+  h1 {{ font-size: 1.25rem; margin: 0 0 8px; }}
+  .meta {{ color: #475569; font-size: 0.9rem; margin-bottom: 16px; }}
+  .outcome {{ display: inline-block; padding: 4px 10px; border-radius: 4px; font-weight: 700; }}
+  .outcome-HOLD {{ background: #fef2f2; color: #b91c1c; border: 1px solid #dc2626; }}
+  .outcome-PASS {{ background: #ecfdf5; color: #047857; border: 1px solid #10b981; }}
+  table {{ border-collapse: collapse; width: 100%; font-size: 0.85rem; margin: 16px 0; }}
+  th, td {{ border: 1px solid #cbd5e1; padding: 8px; text-align: left; vertical-align: top; }}
+  th {{ background: #e2e8f0; }}
+  .chain {{ background: #f8fafc; border: 1px solid #e2e8f0; padding: 10px 12px; margin: 8px 0; }}
+  .arrow {{ color: #1e4a7a; font-weight: bold; }}
+  .muted {{ color: #64748b; font-style: italic; }}
+  .disclaimer {{ margin-top: 24px; font-size: 0.75rem; color: #64748b; border-top: 1px solid #e2e8f0; padding-top: 12px; }}
+  code {{ font-size: 0.75rem; word-break: break-all; }}
+</style>
+</head>
+<body>
+<h1>Impacted vulnerability paths</h1>
+<p class="meta">Vessel <strong>{html.escape(vessel_key)}</strong> · Port call <strong>{html.escape(port_call_id)}</strong> ·
+<span class="outcome outcome-{html.escape(outcome)}">{html.escape(outcome)}</span></p>
+<p class="meta">Traversal: Component → CVE → Asset → Vessel (see table for graph node IDs)</p>
+{chains_html}
+<table>
+<thead>
+<tr><th>#</th><th>Component</th><th>CVE</th><th>CVSS</th><th>Asset</th><th>Graph path</th></tr>
+</thead>
+<tbody>
+{table_rows}
+</tbody>
+</table>
+<p class="disclaimer">{html.escape(_POC_DISCLAIMER)}</p>
+</body>
+</html>
+"""
+
+
+def write_vessel_graph_artifacts(
+    vessel_key: str,
+    output_dir: Path,
+    *,
+    prefix: str,
+    impacted_paths: list[dict[str, Any]] | None = None,
+    port_call_id: str = "port-call-demo-sgsin",
+    outcome: str | None = None,
+    graph_result: GraphBuildResult | None = None,
+    asset_map_path: Path | None = None,
+    cve_snapshot_path: Path | None = None,
+    sbom_dir: Path | None = None,
+    copy_to_documaris_dist: bool = False,
+) -> dict[str, Path]:
+    """Write JSON + HTML impacted-path exports; return paths."""
+    paths = impacted_paths
+    if paths is None:
+        paths = build_impacted_paths(
+            vessel_key,
+            graph_result=graph_result,
+            asset_map_path=asset_map_path,
+            cve_snapshot_path=cve_snapshot_path,
+            sbom_dir=sbom_dir,
+        )
+
+    document = export_impacted_paths_document(
+        vessel_key,
+        paths,
+        port_call_id=port_call_id,
+        outcome=outcome,
+    )
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    json_path = out / f"{prefix}_impacted_paths.json"
+    html_path = out / f"{prefix}_impacted-path.html"
+    json_path.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    html_path.write_text(render_impacted_paths_html(document), encoding="utf-8")
+
+    result = {"json": json_path, "html": html_path}
+
+    if copy_to_documaris_dist and _DOCUMARIS_DIST.parent.is_dir():
+        _DOCUMARIS_DIST.mkdir(parents=True, exist_ok=True)
+        dist_html = _DOCUMARIS_DIST / f"{vessel_key}_impacted-path.html"
+        dist_html.write_text(html_path.read_text(encoding="utf-8"), encoding="utf-8")
+        result["documaris_dist_html"] = dist_html
+
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Export vessel impacted vulnerability paths (D4)")
+    parser.add_argument("vessel_key", help="Fixture vessel key (e.g. vessel-hold)")
+    parser.add_argument("--port-call-id", default="port-call-demo-sgsin")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--copy-to-documaris-dist",
+        action="store_true",
+        help="Also write documaris/dist/<vessel>_impacted-path.html",
+    )
+    parser.add_argument("--json", action="store_true", help="Print paths JSON to stdout")
+    args = parser.parse_args(argv)
+
+    graph = build_maritime_cyber_graph([args.vessel_key])
+    from pipelines.maritime_cyber.eval import evaluate_port_clearance
+
+    eval_result = evaluate_port_clearance(
+        args.vessel_key,
+        port_call_id=args.port_call_id,
+        graph_result=graph,
+    )
+    prefix = f"{args.vessel_key}_{args.port_call_id}".replace("/", "-")
+    out_dir = Path(args.output_dir) / "clearance_runs" / args.vessel_key
+    paths = write_vessel_graph_artifacts(
+        args.vessel_key,
+        out_dir,
+        prefix=prefix,
+        impacted_paths=eval_result.facts["impacted_paths"],
+        port_call_id=args.port_call_id,
+        outcome=eval_result.outcome,
+        copy_to_documaris_dist=args.copy_to_documaris_dist,
+    )
+    if args.json:
+        print(json.dumps(json.loads(paths["json"].read_text(encoding="utf-8")), indent=2))
+    else:
+        for name, p in paths.items():
+            print(f"{name}: {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipelines/maritime_cyber/README.md
+++ b/pipelines/maritime_cyber/README.md
@@ -1,0 +1,20 @@
+# `pipelines/maritime_cyber` — graph + evaluation
+
+| Module | Workstream | Role |
+|--------|------------|------|
+| `graph.py` | **W2** | SBOM + CVE + `asset_map` → NetworkX + Parquet |
+| `eval.py` | **W3** | Rule pack → pass/hold, `facts.json`, `decision_hash`, UC2 helpers |
+| `audit_refs.py` | **D2** | `bom_baseline_ref`, `cve_snapshot_ref`, integrated snapshot fingerprint |
+| `rules.py` | **W0** | Load `sg-cyber-clearance-v0.yaml` |
+
+**CLIs (repo root):**
+
+```bash
+uv run python -m pipelines.maritime_cyber_graph vessel-hold vessel-clean
+uv run python -m pipelines.port_clearance_eval vessel-hold --port-call-id port-call-demo-sgsin
+uv run python -m pipelines.port_clearance_eval affected-vessels CVE-2021-44228
+```
+
+**D4 export** lives in sibling module `pipelines/export_vessel_graph.py` (not this package).
+
+Full program map: [docs/ref-maritime-cyber-capvista.md](../../docs/ref-maritime-cyber-capvista.md).

--- a/profiles/maritime_cyber/README.md
+++ b/profiles/maritime_cyber/README.md
@@ -1,0 +1,25 @@
+# Profile: `maritime_cyber` (Port Cyber Clearance PoC)
+
+Cap Vista 6/30 — Singapore port cyber clearance on synthetic fixtures.
+
+| Item | Path |
+|------|------|
+| Manifest | [manifest.yaml](manifest.yaml) |
+| Ontology | [ontology.yaml](ontology.yaml) |
+| Rule pack | [../../rules/sg-cyber-clearance-v0.yaml](../../rules/sg-cyber-clearance-v0.yaml) |
+| Fixtures | [../../fixtures/README.md](../../fixtures/README.md) |
+
+## Workstreams (this profile)
+
+| ID | Status | indago component |
+|----|--------|------------------|
+| W0 | Done | Rule pack + commercial requirements matrix |
+| W1 | Done | Fixtures + this manifest |
+| W2 | Done | `pipelines/maritime_cyber/graph.py` |
+| W3 | Done | `pipelines/maritime_cyber/eval.py` |
+| W6 | Done | `agents/port_clearance/run_clearance.py` |
+| D1–D4 | Done | Scenario, audit refs, WORM, `export_vessel_graph` |
+
+**W4/W5** — sibling repos (`edgesentry-rs`, `documaris`). **W7** — submission docs in `edgesentry-commercial`.
+
+Full status and commands: [docs/ref-maritime-cyber-capvista.md](../../docs/ref-maritime-cyber-capvista.md).

--- a/profiles/maritime_cyber/manifest.yaml
+++ b/profiles/maritime_cyber/manifest.yaml
@@ -1,5 +1,6 @@
 # EdgeSentry maritime cyber profile — Port Cyber Clearance PoC
-# See: edgesentry-commercial/docs/programs/20260630-capvista-products/analysis/
+# Status: W1 done — see indago/docs/ref-maritime-cyber-capvista.md
+# Commercial plan: edgesentry-commercial/docs/programs/20260630-capvista-products/analysis/
 
 version: "0.1.0"
 profile_id: maritime_cyber

--- a/rules/README.md
+++ b/rules/README.md
@@ -4,8 +4,10 @@ Machine-readable rule packs for domain profiles. Each pack maps public regulator
 
 | Pack | Profile | Status |
 |------|---------|--------|
-| [sg-cyber-clearance-v0.yaml](sg-cyber-clearance-v0.yaml) | `maritime_cyber` | PoC — Cap Vista 6/30 |
+| [sg-cyber-clearance-v0.yaml](sg-cyber-clearance-v0.yaml) | `maritime_cyber` | **W0 done** — Cap Vista 6/30 PoC |
 
 **Traceability matrix:** [regulatory-requirements-matrix.md](https://github.com/edgesentry/edgesentry-commercial/blob/main/docs/programs/20260630-capvista-products/analysis/regulatory-requirements-matrix.md)
 
 **Loader:** `pipelines/maritime_cyber/rules.py`
+
+**Program:** [docs/ref-maritime-cyber-capvista.md](../docs/ref-maritime-cyber-capvista.md)

--- a/tests/maritime_cyber/README.md
+++ b/tests/maritime_cyber/README.md
@@ -1,0 +1,18 @@
+# Maritime cyber tests — Cap Vista PoC
+
+```bash
+uv run pytest tests/maritime_cyber/ -q
+```
+
+| Module | Workstream / demo |
+|--------|-------------------|
+| `test_graph.py` | W2 — graph build, CVE edges |
+| `test_rule_pack.py` | W0/W3 — rule pack load |
+| `test_eval.py` | W3 — pass/hold, `decision_hash`, UC2 |
+| `test_audit_refs.py` | D2 — G11/G12 refs, drift fingerprint |
+| `test_run_clearance.py` | W6, D1 — E2E + hold-to-pass scenario |
+| `test_worm_store.py` | D3 — mock WORM publish/verify |
+| `test_export_vessel_graph.py` | D4 — JSON/HTML export |
+| `test_audit_integration.py` | W4 — `eds` sign/verify (skipped if no binary) |
+
+Program context: [docs/ref-maritime-cyber-capvista.md](../../docs/ref-maritime-cyber-capvista.md).

--- a/tests/maritime_cyber/test_export_vessel_graph.py
+++ b/tests/maritime_cyber/test_export_vessel_graph.py
@@ -1,0 +1,101 @@
+"""D4 — export_vessel_graph impacted path JSON + HTML."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agents.port_clearance.run_clearance import run_clearance
+from pipelines.export_vessel_graph import (
+    build_impacted_paths,
+    export_impacted_paths_document,
+    render_impacted_paths_html,
+    write_vessel_graph_artifacts,
+)
+from pipelines.maritime_cyber.eval import evaluate_port_clearance
+from pipelines.maritime_cyber.graph import build_maritime_cyber_graph
+
+CVE_LOG4SHELL = "CVE-2021-44228"
+
+
+def test_hold_vessel_has_log4j_path() -> None:
+    paths = build_impacted_paths("vessel-hold")
+    assert len(paths) >= 1
+    assert any(CVE_LOG4SHELL in (p.get("cve_id") or "") for p in paths)
+    assert paths[0]["component_purl"]
+    assert paths[0]["path_nodes"]
+
+
+def test_clean_vessel_has_no_impacted_paths() -> None:
+    paths = build_impacted_paths("vessel-clean")
+    assert paths == []
+
+
+def test_export_json_is_deterministic(tmp_path: Path) -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    prefix = "vessel-hold_port-call-demo-sgsin"
+
+    a = write_vessel_graph_artifacts(
+        "vessel-hold",
+        tmp_path / "a",
+        prefix=prefix,
+        impacted_paths=eval_result.facts["impacted_paths"],
+        outcome="hold",
+    )
+    b = write_vessel_graph_artifacts(
+        "vessel-hold",
+        tmp_path / "b",
+        prefix=prefix,
+        impacted_paths=eval_result.facts["impacted_paths"],
+        outcome="hold",
+    )
+    assert a["json"].read_bytes() == b["json"].read_bytes()
+
+
+def test_html_contains_hold_path_and_disclaimer(tmp_path: Path) -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    written = write_vessel_graph_artifacts(
+        "vessel-hold",
+        tmp_path,
+        prefix="vessel-hold_pc",
+        impacted_paths=eval_result.facts["impacted_paths"],
+        outcome="hold",
+    )
+    html = written["html"].read_text(encoding="utf-8")
+    assert "log4j-core" in html or "GHSA" in html
+    assert CVE_LOG4SHELL in html or "GHSA-jfhr" in html
+    assert "synthetic SBOM" in html
+    assert written["html"].is_file()
+
+
+def test_paths_match_facts_impacted_paths() -> None:
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    built = build_impacted_paths("vessel-hold", graph_result=graph)
+    assert built == eval_result.facts["impacted_paths"]
+
+
+def test_run_clearance_writes_graph_exports(tmp_path: Path) -> None:
+    result = run_clearance(
+        "vessel-hold",
+        output_dir=tmp_path / "hold",
+        write_graph=False,
+        skip_render=True,
+        skip_seal=True,
+        skip_worm=True,
+    )
+    prefix = "vessel-hold_port-call-demo-sgsin"
+    json_path = tmp_path / "hold" / f"{prefix}_impacted_paths.json"
+    html_path = tmp_path / "hold" / f"{prefix}_impacted-path.html"
+    assert json_path.is_file()
+    assert html_path.is_file()
+    doc = json.loads(json_path.read_text(encoding="utf-8"))
+    assert doc["impacted_paths"]
+
+
+def test_render_pass_vessel_empty_paths() -> None:
+    doc = export_impacted_paths_document("vessel-clean", [], outcome="pass")
+    html = render_impacted_paths_html(doc)
+    assert "No impacted vulnerability paths" in html

--- a/tests/maritime_cyber/test_export_vessel_graph.py
+++ b/tests/maritime_cyber/test_export_vessel_graph.py
@@ -78,7 +78,7 @@ def test_paths_match_facts_impacted_paths() -> None:
 
 
 def test_run_clearance_writes_graph_exports(tmp_path: Path) -> None:
-    result = run_clearance(
+    run_clearance(
         "vessel-hold",
         output_dir=tmp_path / "hold",
         write_graph=False,


### PR DESCRIPTION
## Summary

Closes #159 — D4 impacted-path visualization for Cap Vista PoC.

### Code (D4)
- Adds `pipelines/export_vessel_graph.py` — deterministic `*_impacted_paths.json` and self-contained `*_impacted-path.html` aligned with evaluation `impacted_paths[]`.
- Wires export into `run_clearance` by default (`--skip-graph-export` to opt out; `--copy-graph-to-documaris` for `documaris/dist/<vessel>_impacted-path.html`).
- Adds `tests/maritime_cyber/test_export_vessel_graph.py` (7 tests).

### Docs
- Adds [docs/ref-maritime-cyber-capvista.md](docs/ref-maritime-cyber-capvista.md) — **W0–W7** and **D1–D4** status, commands, repo map, test index.
- Updates `AGENTS.md`, root `README.md`, `agents/port_clearance/README.md`, fixtures/rules/profile READMEs.

**Out of scope (W7 / commercial):** AC3 deck frame — [edgesentry-commercial#163](https://github.com/edgesentry/edgesentry-commercial/issues/163).

**Related commercial docs:** [edgesentry-commercial#166](https://github.com/edgesentry/edgesentry-commercial/pull/166) (`completed-tasks.md`, implementation plan).

## Test plan

- [x] `uv run pytest tests/maritime_cyber/ -q` — 41 passed, 2 skipped
- [x] `uv run python -m pipelines.export_vessel_graph vessel-hold --copy-to-documaris-dist`
- [ ] Manual: open `documaris/dist/vessel-hold_impacted-path.html` in browser for deck capture (#163)