### PR TITLE
feat(maritime-cyber): copy D4 HTML to commercial submission from indago

### DIFF
--- a/agents/port_clearance/README.md
+++ b/agents/port_clearance/README.md
@@ -56,11 +56,14 @@ uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-worm
 # Skip impacted-path export (D4)
 uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-graph-export
 
-# Copy impacted-path HTML to documaris/dist (D4 demo bundle)
+# Copy impacted-path HTML to documaris/dist and/or commercial submission/artefacts
 uv run python -m agents.port_clearance.run_clearance vessel-hold --copy-graph-to-documaris
+uv run python -m agents.port_clearance.run_clearance vessel-hold --copy-graph-to-capvista-submission
 
-# D4 only (standalone export + optional documaris/dist copy)
-uv run python -m pipelines.export_vessel_graph vessel-hold --copy-to-documaris-dist
+# D4 only (standalone export)
+uv run python -m pipelines.export_vessel_graph vessel-hold \
+  --copy-to-documaris-dist \
+  --copy-to-capvista-submission
 
 # Machine-readable summary
 uv run python -m agents.port_clearance.run_clearance vessel-hold --json

--- a/agents/port_clearance/run_clearance.py
+++ b/agents/port_clearance/run_clearance.py
@@ -180,6 +180,7 @@ def run_clearance(
     worm_root: Path | None = None,
     skip_graph_export: bool = False,
     copy_graph_to_documaris: bool = False,
+    copy_graph_to_capvista_submission: bool = False,
     prior_decision_hash: str | None = None,
     lifecycle_event: str | None = None,
 ) -> ClearanceRunResult:
@@ -312,6 +313,7 @@ def run_clearance(
             cve_snapshot_path=cve_snapshot_path,
             sbom_dir=sbom_dir,
             copy_to_documaris_dist=copy_graph_to_documaris,
+            copy_to_capvista_submission=copy_graph_to_capvista_submission,
         )
         impacted_paths_json = graph_exports["json"]
         impacted_path_html = graph_exports["html"]
@@ -400,6 +402,7 @@ def run_hold_to_pass_scenario(
     worm_root: Path | None = None,
     skip_graph_export: bool = False,
     copy_graph_to_documaris: bool = False,
+    copy_graph_to_capvista_submission: bool = False,
 ) -> dict[str, Any]:
     """D1: E7 -> E9 -> E10 -> re-E7 — hold, domino query, remediation, pass."""
     if vessel_key != "vessel-hold":
@@ -429,6 +432,7 @@ def run_hold_to_pass_scenario(
         worm_root=worm_root,
         skip_graph_export=skip_graph_export,
         copy_graph_to_documaris=copy_graph_to_documaris,
+        copy_graph_to_capvista_submission=copy_graph_to_capvista_submission,
         lifecycle_event="E7",
     )
 
@@ -479,6 +483,7 @@ def run_hold_to_pass_scenario(
         worm_root=worm_root,
         skip_graph_export=skip_graph_export,
         copy_graph_to_documaris=copy_graph_to_documaris,
+        copy_graph_to_capvista_submission=copy_graph_to_capvista_submission,
         prior_decision_hash=baseline.decision_hash,
         lifecycle_event="E7",
     )
@@ -614,6 +619,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Also write documaris/dist/<vessel>_impacted-path.html",
     )
+    parser.add_argument(
+        "--copy-graph-to-capvista-submission",
+        action="store_true",
+        help="Also write edgesentry-commercial/.../submission/artefacts/<vessel>_impacted-path.html",
+    )
     parser.add_argument("--json", action="store_true", help="Print run summary JSON to stdout")
     args = parser.parse_args(argv)
 
@@ -646,6 +656,7 @@ def main(argv: list[str] | None = None) -> int:
                 worm_root=args.worm_root,
                 skip_graph_export=args.skip_graph_export,
                 copy_graph_to_documaris=args.copy_graph_to_documaris,
+                copy_graph_to_capvista_submission=args.copy_graph_to_capvista_submission,
             )
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -696,6 +707,7 @@ def main(argv: list[str] | None = None) -> int:
             worm_root=args.worm_root,
             skip_graph_export=args.skip_graph_export,
             copy_graph_to_documaris=args.copy_graph_to_documaris,
+            copy_graph_to_capvista_submission=args.copy_graph_to_capvista_submission,
         )
     except (FileNotFoundError, RuntimeError) as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/docs/ref-maritime-cyber-capvista.md
+++ b/docs/ref-maritime-cyber-capvista.md
@@ -54,8 +54,10 @@ uv run python -m agents.port_clearance.run_clearance vessel-hold --scenario hold
 # Eval only (no eds, no WORM, no graph export)
 uv run python -m agents.port_clearance.run_clearance vessel-hold --skip-render --skip-seal --skip-worm --skip-graph-export
 
-# D4 standalone → documaris demo bundle
-uv run python -m pipelines.export_vessel_graph vessel-hold --copy-to-documaris-dist
+# D4 standalone → documaris + commercial submission snapshots (sibling repos)
+uv run python -m pipelines.export_vessel_graph vessel-hold \
+  --copy-to-documaris-dist \
+  --copy-to-capvista-submission
 
 # D3 retention verify
 uv run python -m agents.port_clearance.verify_retention \

--- a/pipelines/export_vessel_graph.py
+++ b/pipelines/export_vessel_graph.py
@@ -17,6 +17,21 @@ from pipelines.maritime_cyber.graph import (
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _DOCUMARIS_DIST = _REPO_ROOT.parent / "documaris" / "dist"
+_CAPVISTA_SUBMISSION_ARTEFACTS = (
+    _REPO_ROOT.parent
+    / "edgesentry-commercial"
+    / "docs/programs/20260630-capvista-products/submission/artefacts"
+)
+
+
+def _copy_impacted_path_html(html_path: Path, vessel_key: str, dest_dir: Path) -> Path | None:
+    """Copy HTML to an external bundle dir when the parent repo exists."""
+    if not dest_dir.parent.is_dir():
+        return None
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_html = dest_dir / f"{vessel_key}_impacted-path.html"
+    dest_html.write_text(html_path.read_text(encoding="utf-8"), encoding="utf-8")
+    return dest_html
 _POC_DISCLAIMER = (
     "PoC: public CVE snapshot and synthetic SBOM/asset_map fixtures. "
     "Not an official port-state or MPA berth approval."
@@ -163,6 +178,7 @@ def write_vessel_graph_artifacts(
     cve_snapshot_path: Path | None = None,
     sbom_dir: Path | None = None,
     copy_to_documaris_dist: bool = False,
+    copy_to_capvista_submission: bool = False,
 ) -> dict[str, Path]:
     """Write JSON + HTML impacted-path exports; return paths."""
     paths = impacted_paths
@@ -194,11 +210,15 @@ def write_vessel_graph_artifacts(
 
     result = {"json": json_path, "html": html_path}
 
-    if copy_to_documaris_dist and _DOCUMARIS_DIST.parent.is_dir():
-        _DOCUMARIS_DIST.mkdir(parents=True, exist_ok=True)
-        dist_html = _DOCUMARIS_DIST / f"{vessel_key}_impacted-path.html"
-        dist_html.write_text(html_path.read_text(encoding="utf-8"), encoding="utf-8")
-        result["documaris_dist_html"] = dist_html
+    if copy_to_documaris_dist:
+        copied = _copy_impacted_path_html(html_path, vessel_key, _DOCUMARIS_DIST)
+        if copied:
+            result["documaris_dist_html"] = copied
+
+    if copy_to_capvista_submission:
+        copied = _copy_impacted_path_html(html_path, vessel_key, _CAPVISTA_SUBMISSION_ARTEFACTS)
+        if copied:
+            result["capvista_submission_html"] = copied
 
     return result
 
@@ -212,6 +232,11 @@ def main(argv: list[str] | None = None) -> int:
         "--copy-to-documaris-dist",
         action="store_true",
         help="Also write documaris/dist/<vessel>_impacted-path.html",
+    )
+    parser.add_argument(
+        "--copy-to-capvista-submission",
+        action="store_true",
+        help="Also write edgesentry-commercial/.../submission/artefacts/<vessel>_impacted-path.html",
     )
     parser.add_argument("--json", action="store_true", help="Print paths JSON to stdout")
     args = parser.parse_args(argv)
@@ -234,6 +259,7 @@ def main(argv: list[str] | None = None) -> int:
         port_call_id=args.port_call_id,
         outcome=eval_result.outcome,
         copy_to_documaris_dist=args.copy_to_documaris_dist,
+        copy_to_capvista_submission=args.copy_to_capvista_submission,
     )
     if args.json:
         print(json.dumps(json.loads(paths["json"].read_text(encoding="utf-8")), indent=2))

--- a/tests/maritime_cyber/test_export_vessel_graph.py
+++ b/tests/maritime_cyber/test_export_vessel_graph.py
@@ -8,13 +8,7 @@ from pathlib import Path
 import pytest
 
 from agents.port_clearance.run_clearance import run_clearance
-from pipelines.export_vessel_graph import (
-    _copy_impacted_path_html,
-    build_impacted_paths,
-    export_impacted_paths_document,
-    render_impacted_paths_html,
-    write_vessel_graph_artifacts,
-)
+import pipelines.export_vessel_graph as evg
 from pipelines.maritime_cyber.eval import evaluate_port_clearance
 from pipelines.maritime_cyber.graph import build_maritime_cyber_graph
 
@@ -22,7 +16,7 @@ CVE_LOG4SHELL = "CVE-2021-44228"
 
 
 def test_hold_vessel_has_log4j_path() -> None:
-    paths = build_impacted_paths("vessel-hold")
+    paths = evg.build_impacted_paths("vessel-hold")
     assert len(paths) >= 1
     assert any(CVE_LOG4SHELL in (p.get("cve_id") or "") for p in paths)
     assert paths[0]["component_purl"]
@@ -30,7 +24,7 @@ def test_hold_vessel_has_log4j_path() -> None:
 
 
 def test_clean_vessel_has_no_impacted_paths() -> None:
-    paths = build_impacted_paths("vessel-clean")
+    paths = evg.build_impacted_paths("vessel-clean")
     assert paths == []
 
 
@@ -39,14 +33,14 @@ def test_export_json_is_deterministic(tmp_path: Path) -> None:
     eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
     prefix = "vessel-hold_port-call-demo-sgsin"
 
-    a = write_vessel_graph_artifacts(
+    a = evg.write_vessel_graph_artifacts(
         "vessel-hold",
         tmp_path / "a",
         prefix=prefix,
         impacted_paths=eval_result.facts["impacted_paths"],
         outcome="hold",
     )
-    b = write_vessel_graph_artifacts(
+    b = evg.write_vessel_graph_artifacts(
         "vessel-hold",
         tmp_path / "b",
         prefix=prefix,
@@ -59,7 +53,7 @@ def test_export_json_is_deterministic(tmp_path: Path) -> None:
 def test_html_contains_hold_path_and_disclaimer(tmp_path: Path) -> None:
     graph = build_maritime_cyber_graph(["vessel-hold"])
     eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
-    written = write_vessel_graph_artifacts(
+    written = evg.write_vessel_graph_artifacts(
         "vessel-hold",
         tmp_path,
         prefix="vessel-hold_pc",
@@ -76,7 +70,7 @@ def test_html_contains_hold_path_and_disclaimer(tmp_path: Path) -> None:
 def test_paths_match_facts_impacted_paths() -> None:
     graph = build_maritime_cyber_graph(["vessel-hold"])
     eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
-    built = build_impacted_paths("vessel-hold", graph_result=graph)
+    built = evg.build_impacted_paths("vessel-hold", graph_result=graph)
     assert built == eval_result.facts["impacted_paths"]
 
 
@@ -99,8 +93,8 @@ def test_run_clearance_writes_graph_exports(tmp_path: Path) -> None:
 
 
 def test_render_pass_vessel_empty_paths() -> None:
-    doc = export_impacted_paths_document("vessel-clean", [], outcome="pass")
-    html = render_impacted_paths_html(doc)
+    doc = evg.export_impacted_paths_document("vessel-clean", [], outcome="pass")
+    html = evg.render_impacted_paths_html(doc)
     assert "No impacted vulnerability paths" in html
 
 
@@ -109,7 +103,7 @@ def test_copy_impacted_path_html_writes_bundle(tmp_path: Path) -> None:
     dest_dir = tmp_path / "bundle"
     src.write_text("<p>hold path</p>", encoding="utf-8")
 
-    copied = _copy_impacted_path_html(src, "vessel-hold", dest_dir)
+    copied = evg._copy_impacted_path_html(src, "vessel-hold", dest_dir)
 
     assert copied == dest_dir / "vessel-hold_impacted-path.html"
     assert copied is not None
@@ -121,20 +115,18 @@ def test_copy_impacted_path_html_skips_missing_parent(tmp_path: Path) -> None:
     src.write_text("<p>x</p>", encoding="utf-8")
     dest_dir = tmp_path / "no_such_parent" / "bundle"
 
-    assert _copy_impacted_path_html(src, "vessel-hold", dest_dir) is None
+    assert evg._copy_impacted_path_html(src, "vessel-hold", dest_dir) is None
 
 
 def test_write_vessel_graph_artifacts_copy_to_documaris_dist(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    import pipelines.export_vessel_graph as evg
-
     bundle = tmp_path / "documaris-dist"
     monkeypatch.setattr(evg, "_DOCUMARIS_DIST", bundle)
 
     graph = build_maritime_cyber_graph(["vessel-hold"])
     eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
-    written = write_vessel_graph_artifacts(
+    written = evg.write_vessel_graph_artifacts(
         "vessel-hold",
         tmp_path / "out",
         prefix="vessel-hold_pc",
@@ -150,14 +142,12 @@ def test_write_vessel_graph_artifacts_copy_to_documaris_dist(
 def test_write_vessel_graph_artifacts_copy_to_capvista_submission(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    import pipelines.export_vessel_graph as evg
-
     bundle = tmp_path / "capvista-artefacts"
     monkeypatch.setattr(evg, "_CAPVISTA_SUBMISSION_ARTEFACTS", bundle)
 
     graph = build_maritime_cyber_graph(["vessel-hold"])
     eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
-    written = write_vessel_graph_artifacts(
+    written = evg.write_vessel_graph_artifacts(
         "vessel-hold",
         tmp_path / "out",
         prefix="vessel-hold_pc",

--- a/tests/maritime_cyber/test_export_vessel_graph.py
+++ b/tests/maritime_cyber/test_export_vessel_graph.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from agents.port_clearance.run_clearance import run_clearance
 from pipelines.export_vessel_graph import (
+    _copy_impacted_path_html,
     build_impacted_paths,
     export_impacted_paths_document,
     render_impacted_paths_html,
@@ -99,3 +102,69 @@ def test_render_pass_vessel_empty_paths() -> None:
     doc = export_impacted_paths_document("vessel-clean", [], outcome="pass")
     html = render_impacted_paths_html(doc)
     assert "No impacted vulnerability paths" in html
+
+
+def test_copy_impacted_path_html_writes_bundle(tmp_path: Path) -> None:
+    src = tmp_path / "src.html"
+    dest_dir = tmp_path / "bundle"
+    src.write_text("<p>hold path</p>", encoding="utf-8")
+
+    copied = _copy_impacted_path_html(src, "vessel-hold", dest_dir)
+
+    assert copied == dest_dir / "vessel-hold_impacted-path.html"
+    assert copied is not None
+    assert copied.read_text(encoding="utf-8") == src.read_text(encoding="utf-8")
+
+
+def test_copy_impacted_path_html_skips_missing_parent(tmp_path: Path) -> None:
+    src = tmp_path / "src.html"
+    src.write_text("<p>x</p>", encoding="utf-8")
+    dest_dir = tmp_path / "no_such_parent" / "bundle"
+
+    assert _copy_impacted_path_html(src, "vessel-hold", dest_dir) is None
+
+
+def test_write_vessel_graph_artifacts_copy_to_documaris_dist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import pipelines.export_vessel_graph as evg
+
+    bundle = tmp_path / "documaris-dist"
+    monkeypatch.setattr(evg, "_DOCUMARIS_DIST", bundle)
+
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    written = write_vessel_graph_artifacts(
+        "vessel-hold",
+        tmp_path / "out",
+        prefix="vessel-hold_pc",
+        impacted_paths=eval_result.facts["impacted_paths"],
+        outcome="hold",
+        copy_to_documaris_dist=True,
+    )
+
+    assert written["documaris_dist_html"] == bundle / "vessel-hold_impacted-path.html"
+    assert "capvista_submission_html" not in written
+
+
+def test_write_vessel_graph_artifacts_copy_to_capvista_submission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import pipelines.export_vessel_graph as evg
+
+    bundle = tmp_path / "capvista-artefacts"
+    monkeypatch.setattr(evg, "_CAPVISTA_SUBMISSION_ARTEFACTS", bundle)
+
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    eval_result = evaluate_port_clearance("vessel-hold", graph_result=graph)
+    written = write_vessel_graph_artifacts(
+        "vessel-hold",
+        tmp_path / "out",
+        prefix="vessel-hold_pc",
+        impacted_paths=eval_result.facts["impacted_paths"],
+        outcome="hold",
+        copy_to_capvista_submission=True,
+    )
+
+    assert written["capvista_submission_html"] == bundle / "vessel-hold_impacted-path.html"
+    assert "documaris_dist_html" not in written


### PR DESCRIPTION
## Summary
- Adds `--copy-to-capvista-submission` on `export_vessel_graph` and `run_clearance` to write `edgesentry-commercial/.../submission/artefacts/<vessel>_impacted-path.html` when the sibling repo exists.
- Keeps **pipeline logic in indago**; commercial stays submission docs + committed snapshots only.

Pairs with [edgesentry-commercial#167](https://github.com/edgesentry/edgesentry-commercial/pull/167) (removed `submission/scripts/refresh-d4-artefacts.sh`).

## Usage

```bash
cd indago
uv run python -m pipelines.export_vessel_graph vessel-hold \
  --copy-to-documaris-dist \
  --copy-to-capvista-submission
```

## Test plan
- [x] `uv run python -m pytest tests/maritime_cyber/test_export_vessel_graph.py -q`
- [x] `uv run python -m pipelines.export_vessel_graph vessel-hold --copy-to-capvista-submission` (writes commercial artefact when monorepo layout present)


Made with [Cursor](https://cursor.com)