### PR TITLE
feat(port-clearance): D5 operator explanation (non-authoritative)

### DIFF
--- a/agents/port_clearance/README.md
+++ b/agents/port_clearance/README.md
@@ -8,6 +8,7 @@
 | D1 lifecycle | Done | `--scenario hold-to-pass` |
 | D3 mock WORM | Done | `worm_store.py`, `verify_retention.py` |
 | D4 path viz | Done | calls `pipelines/export_vessel_graph` |
+| D5 AI narrative | Done | `--ai-narrative`, `ai_narrative.py`, `prompts/operator_explanation_policy.txt` |
 
 One command runs the Cap Vista UC1 demo path:
 
@@ -18,7 +19,8 @@ One command runs the Cap Vista UC1 demo path:
 5. Seal audit chain (`eds audit sign-clearance`)
 6. Publish artefacts to **mock WORM** store (G11 — append-only, content-addressed)
 7. Export **impacted vulnerability paths** (D4 — JSON + self-contained HTML)
-8. Print third-party verify instructions
+8. Optional **operator explanation** (D5 — facts-derived, guardrailed; certificate section 1a)
+9. Print third-party verify instructions
 
 ## Prerequisites
 
@@ -64,6 +66,13 @@ uv run python -m agents.port_clearance.run_clearance vessel-hold --copy-graph-to
 uv run python -m pipelines.export_vessel_graph vessel-hold \
   --copy-to-documaris-dist \
   --copy-to-capvista-submission
+
+# D5: operator explanation on certificate (does not change decision_hash)
+uv run python -m agents.port_clearance.run_clearance vessel-hold --ai-narrative
+
+# Standalone narrative from facts
+uv run python -m agents.port_clearance.generate_narrative \
+  data/processed/maritime_cyber/clearance_runs/vessel-hold/vessel-hold_facts.json --write
 
 # Machine-readable summary
 uv run python -m agents.port_clearance.run_clearance vessel-hold --json
@@ -114,6 +123,7 @@ Copy to documaris demo bundle: `--copy-graph-to-documaris` → `documaris/dist/<
 | `*_clearance_chain.json` | W4 |
 | `*_worm_publish.json` | D3 |
 | `*_impacted_paths.json`, `*_impacted-path.html` | D4 |
+| `*_operator_explanation.txt`, `*_operator_explanation_meta.json` | D5 (with `--ai-narrative`) |
 | `*_run_summary.json` | W6 |
 
 ## Related

--- a/agents/port_clearance/ai_narrative.py
+++ b/agents/port_clearance/ai_narrative.py
@@ -1,0 +1,175 @@
+"""D5 — Operator explanation from clearance facts (non-authoritative, guardrailed)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_POLICY_PATH = Path(__file__).resolve().parent / "prompts" / "operator_explanation_policy.txt"
+
+_OUTCOME_CONTRADICTION_PATTERNS: dict[str, list[str]] = {
+    "hold": [
+        r"\boutcome\s+is\s+pass\b",
+        r"\bclearance\s+outcome\s+pass\b",
+        r"\brecommend(?:ed)?\s+(?:for\s+)?pass\b",
+        r"\bshould\s+(?:be\s+)?pass\b",
+        r"\bberth\s+approved\b",
+    ],
+    "pass": [
+        r"\boutcome\s+is\s+hold\b",
+        r"\bclearance\s+outcome\s+hold\b",
+        r"\brecommend(?:ed)?\s+(?:for\s+)?hold\b",
+        r"\bshould\s+(?:be\s+)?hold\b",
+        r"\bdo\s+not\s+(?:allow|permit)\s+entry\b",
+    ],
+}
+
+
+class NarrativeGuardrailError(ValueError):
+    """Raised when synthesized text violates D5 policy."""
+
+
+def load_operator_explanation_policy() -> str:
+    return _POLICY_PATH.read_text(encoding="utf-8")
+
+
+def normalize_cve_id(raw: str) -> str:
+    token = raw.strip()
+    if token.lower().startswith("cve:"):
+        token = token[4:]
+    return token.upper()
+
+
+def allowed_cve_ids(facts: dict[str, Any]) -> set[str]:
+    allowed: set[str] = set()
+    for raw in facts.get("cve_ids") or []:
+        if isinstance(raw, str) and raw.strip():
+            allowed.add(normalize_cve_id(raw))
+    for path in facts.get("impacted_paths") or []:
+        if not isinstance(path, dict):
+            continue
+        cve_id = path.get("cve_id")
+        if isinstance(cve_id, str) and cve_id.strip():
+            allowed.add(normalize_cve_id(cve_id))
+    return allowed
+
+
+def build_deterministic_narrative(facts: dict[str, Any]) -> str:
+    """Template synthesis from facts only (no LLM)."""
+    outcome = str(facts.get("outcome", "")).strip().lower()
+    outcome_upper = outcome.upper() if outcome else "UNKNOWN"
+    vessel = facts.get("vessel_key", "—")
+    port_call = facts.get("port_call_id", "—")
+    rules = [r for r in (facts.get("rules_fired") or []) if isinstance(r, dict)]
+    paths = [p for p in (facts.get("paths") or []) if isinstance(p, dict)]
+
+    rule_lines = "\n".join(
+        f"- {r.get('id', '?')}: {r.get('title', '—')} ({r.get('severity', '—')})" for r in rules
+    )
+    path_lines = "\n".join(
+        f"- {', '.join(p.get('rule_ids') or [])}: {p.get('summary', '—')}" for p in paths
+    )
+
+    cve_tokens = sorted(allowed_cve_ids(facts))
+    cve_line = ", ".join(cve_tokens) if cve_tokens else "none on cited paths"
+
+    paragraphs = [
+        (
+            "Operator context (non-authoritative). This explanation is synthesized from "
+            "evaluation facts only. It does not alter the deterministic clearance outcome "
+            "or the decision hash sealed in the audit manifest."
+        ),
+        (
+            f"The rule engine recorded clearance outcome {outcome_upper} for vessel {vessel} "
+            f"on port call {port_call}. {len(rules)} rule(s) fired across {len(paths)} "
+            "cited path(s)."
+        ),
+    ]
+    if rule_lines:
+        paragraphs.append("Rules cited in this evaluation:\n" + rule_lines)
+    if path_lines:
+        paragraphs.append("Vulnerability paths summarized for operators:\n" + path_lines)
+    paragraphs.append(f"CVE identifiers present on cited paths: {cve_line}.")
+    paragraphs.append(
+        f"The authoritative outcome remains {outcome_upper} as determined by the "
+        "maritime_cyber rule profile; this narrative is for operator explanation only."
+    )
+    return "\n\n".join(paragraphs)
+
+
+def validate_narrative_guardrails(narrative: str, facts: dict[str, Any]) -> None:
+    """Raise NarrativeGuardrailError if text contradicts facts or invents CVEs."""
+    outcome = str(facts.get("outcome", "")).strip().lower()
+    if outcome not in {"pass", "hold"}:
+        raise NarrativeGuardrailError(f"unsupported facts.outcome: {outcome!r}")
+
+    lowered = narrative.lower()
+    if outcome not in lowered:
+        raise NarrativeGuardrailError(
+            f"narrative must mention recorded outcome '{outcome}'"
+        )
+
+    for pattern in _OUTCOME_CONTRADICTION_PATTERNS[outcome]:
+        if re.search(pattern, lowered):
+            raise NarrativeGuardrailError(
+                f"narrative contradicts recorded outcome '{outcome}' (pattern: {pattern})"
+            )
+
+    allowed = allowed_cve_ids(facts)
+    for match in re.finditer(r"CVE-\d{4}-\d+", narrative, flags=re.IGNORECASE):
+        token = normalize_cve_id(match.group(0))
+        if token not in allowed:
+            raise NarrativeGuardrailError(
+                f"narrative cites CVE not in facts: {token} (allowed: {sorted(allowed)})"
+            )
+
+
+def generate_operator_explanation(
+    facts: dict[str, Any],
+    *,
+    mode: str = "template",
+) -> str:
+    """Return guardrailed operator explanation text."""
+    if mode != "template":
+        raise ValueError(f"unsupported narrative mode: {mode!r} (use 'template')")
+
+    narrative = build_deterministic_narrative(facts)
+    validate_narrative_guardrails(narrative, facts)
+    return narrative
+
+
+def write_operator_explanation_artifacts(
+    facts_path: Path,
+    *,
+    prefix: str | None = None,
+    output_dir: Path | None = None,
+) -> dict[str, Path]:
+    """Write *_operator_explanation.txt and *_operator_explanation_meta.json."""
+    facts_path = facts_path.resolve()
+    facts = json.loads(facts_path.read_text(encoding="utf-8"))
+    narrative = generate_operator_explanation(facts, mode="template")
+
+    out_dir = output_dir or facts_path.parent
+    stem = prefix or facts_path.stem.replace("_facts", "")
+    text_path = out_dir / f"{stem}_operator_explanation.txt"
+    meta_path = out_dir / f"{stem}_operator_explanation_meta.json"
+
+    text_path.write_text(narrative + "\n", encoding="utf-8")
+    meta_path.write_text(
+        json.dumps(
+            {
+                "source": "template",
+                "policy": str(_POLICY_PATH.relative_to(Path(__file__).resolve().parents[2])),
+                "facts_path": str(facts_path),
+                "outcome": facts.get("outcome"),
+                "decision_hash": facts.get("decision_hash"),
+                "non_authoritative": True,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return {"text": text_path, "meta": meta_path}

--- a/agents/port_clearance/generate_narrative.py
+++ b/agents/port_clearance/generate_narrative.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""CLI — generate D5 operator explanation from clearance *_facts.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from agents.port_clearance.ai_narrative import (
+    NarrativeGuardrailError,
+    generate_operator_explanation,
+    write_operator_explanation_artifacts,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate guardrailed operator explanation (D5)")
+    parser.add_argument("facts", type=Path, help="Path to *_facts.json")
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write *_operator_explanation.txt and *_operator_explanation_meta.json",
+    )
+    parser.add_argument("--json", action="store_true", help="Print narrative JSON to stdout")
+    args = parser.parse_args(argv)
+
+    facts_path = args.facts.resolve()
+    if not facts_path.is_file():
+        print(f"error: facts not found: {facts_path}", file=sys.stderr)
+        return 2
+
+    try:
+        facts = json.loads(facts_path.read_text(encoding="utf-8"))
+        narrative = generate_operator_explanation(facts, mode="template")
+    except (NarrativeGuardrailError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        paths = write_operator_explanation_artifacts(facts_path)
+        print(paths["text"], file=sys.stderr)
+        print(paths["meta"], file=sys.stderr)
+
+    if args.json:
+        print(json.dumps({"narrative": narrative, "facts": str(facts_path)}, indent=2))
+    else:
+        print(narrative)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/port_clearance/prompts/operator_explanation_policy.txt
+++ b/agents/port_clearance/prompts/operator_explanation_policy.txt
@@ -1,0 +1,21 @@
+EdgeSentry Port Cyber Clearance — operator explanation policy (D5)
+
+Purpose
+  Synthesize plain-language context for port operators from *_facts.json only.
+  The deterministic rule engine outcome (pass/hold) and decision_hash are authoritative.
+
+MUST
+  - State the recorded outcome exactly as in facts.outcome (pass or hold).
+  - Cite only CVE IDs present in facts.cve_ids or facts.impacted_paths[].cve_id.
+  - Cite only rule IDs present in facts.rules_fired[].id.
+  - Include a non-authoritative disclaimer (facts-derived, does not change judgment).
+
+MUST NOT
+  - Override, reverse, or recommend a different pass/hold outcome.
+  - Invent CVE IDs, CVSS scores, rules, or asset paths not in facts.
+  - Imply official MPA/port-state berth approval.
+  - Write or modify AuditRecord, manifest, or decision_hash fields.
+
+LLM use (optional)
+  - When CLEARANCE_LLM_URL is set, prompts must embed this policy verbatim.
+  - On guardrail failure or LLM error, fall back to template synthesis from facts.

--- a/agents/port_clearance/run_clearance.py
+++ b/agents/port_clearance/run_clearance.py
@@ -32,6 +32,7 @@ from pipelines.maritime_cyber.graph import (
     write_graph_parquet,
 )
 
+from agents.port_clearance.ai_narrative import write_operator_explanation_artifacts  # noqa: E402
 from agents.port_clearance.worm_store import publish_clearance_run  # noqa: E402
 from pipelines.export_vessel_graph import write_vessel_graph_artifacts  # noqa: E402
 
@@ -59,6 +60,7 @@ class ClearanceRunResult:
     worm_publish_path: Path | None
     impacted_paths_json: Path | None
     impacted_path_html: Path | None
+    operator_explanation_path: Path | None
 
 
 def load_profile_manifest(path: Path | None = None) -> dict[str, Any]:
@@ -181,6 +183,7 @@ def run_clearance(
     skip_graph_export: bool = False,
     copy_graph_to_documaris: bool = False,
     copy_graph_to_capvista_submission: bool = False,
+    ai_narrative: bool = False,
     prior_decision_hash: str | None = None,
     lifecycle_event: str | None = None,
 ) -> ClearanceRunResult:
@@ -227,20 +230,29 @@ def run_clearance(
     if not skip_render or not skip_seal:
         eds = find_eds_binary(str(eds_bin) if eds_bin else None)
 
-    if not skip_render and html_path is not None and eds is not None:
-        render = _run_eds(
-            [
-                "document",
-                "render-clearance",
-                "--facts",
-                str(facts_path),
-                "--verify-url",
-                url,
-                "--out",
-                str(html_path),
-            ],
-            eds,
+    operator_explanation_path: Path | None = None
+    if ai_narrative:
+        narrative_paths = write_operator_explanation_artifacts(
+            facts_path,
+            prefix=prefix,
+            output_dir=out,
         )
+        operator_explanation_path = narrative_paths["text"]
+
+    if not skip_render and html_path is not None and eds is not None:
+        render_args = [
+            "document",
+            "render-clearance",
+            "--facts",
+            str(facts_path),
+            "--verify-url",
+            url,
+            "--out",
+            str(html_path),
+        ]
+        if operator_explanation_path is not None:
+            render_args.extend(["--operator-explanation", str(operator_explanation_path)])
+        render = _run_eds(render_args, eds)
         if render.returncode != 0:
             raise RuntimeError(f"eds document render-clearance failed:\n{render.stderr}")
 
@@ -319,6 +331,8 @@ def run_clearance(
         impacted_path_html = graph_exports["html"]
         summary["impacted_paths_json"] = str(impacted_paths_json)
         summary["impacted_path_html"] = str(impacted_path_html)
+    if operator_explanation_path is not None:
+        summary["operator_explanation"] = str(operator_explanation_path)
 
     worm_publish_path: Path | None = None
     if not skip_worm:
@@ -354,6 +368,7 @@ def run_clearance(
         worm_publish_path=worm_publish_path,
         impacted_paths_json=impacted_paths_json,
         impacted_path_html=impacted_path_html,
+        operator_explanation_path=operator_explanation_path,
     )
 
 
@@ -403,6 +418,7 @@ def run_hold_to_pass_scenario(
     skip_graph_export: bool = False,
     copy_graph_to_documaris: bool = False,
     copy_graph_to_capvista_submission: bool = False,
+    ai_narrative: bool = False,
 ) -> dict[str, Any]:
     """D1: E7 -> E9 -> E10 -> re-E7 — hold, domino query, remediation, pass."""
     if vessel_key != "vessel-hold":
@@ -433,6 +449,7 @@ def run_hold_to_pass_scenario(
         skip_graph_export=skip_graph_export,
         copy_graph_to_documaris=copy_graph_to_documaris,
         copy_graph_to_capvista_submission=copy_graph_to_capvista_submission,
+        ai_narrative=ai_narrative,
         lifecycle_event="E7",
     )
 
@@ -484,6 +501,7 @@ def run_hold_to_pass_scenario(
         skip_graph_export=skip_graph_export,
         copy_graph_to_documaris=copy_graph_to_documaris,
         copy_graph_to_capvista_submission=copy_graph_to_capvista_submission,
+        ai_narrative=ai_narrative,
         prior_decision_hash=baseline.decision_hash,
         lifecycle_event="E7",
     )
@@ -624,6 +642,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Also write edgesentry-commercial/.../submission/artefacts/<vessel>_impacted-path.html",
     )
+    parser.add_argument(
+        "--ai-narrative",
+        action="store_true",
+        help="D5: add facts-derived operator explanation to certificate (non-authoritative)",
+    )
     parser.add_argument("--json", action="store_true", help="Print run summary JSON to stdout")
     args = parser.parse_args(argv)
 
@@ -657,6 +680,7 @@ def main(argv: list[str] | None = None) -> int:
                 skip_graph_export=args.skip_graph_export,
                 copy_graph_to_documaris=args.copy_graph_to_documaris,
                 copy_graph_to_capvista_submission=args.copy_graph_to_capvista_submission,
+                ai_narrative=args.ai_narrative,
             )
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -708,6 +732,7 @@ def main(argv: list[str] | None = None) -> int:
             skip_graph_export=args.skip_graph_export,
             copy_graph_to_documaris=args.copy_graph_to_documaris,
             copy_graph_to_capvista_submission=args.copy_graph_to_capvista_submission,
+            ai_narrative=args.ai_narrative,
         )
     except (FileNotFoundError, RuntimeError) as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/docs/ref-maritime-cyber-capvista.md
+++ b/docs/ref-maritime-cyber-capvista.md
@@ -36,7 +36,7 @@ Runnable demo before deck/video; all implemented in indago unless noted.
 | **D3** | Mock WORM publish + third-party retention verify | **Done** | `agents/port_clearance/worm_store.py` · `verify_retention.py` · [indago#193](https://github.com/edgesentry/indago/pull/193) |
 | **D4** | Impacted-path JSON + HTML (explainability) | **Done** | `pipelines/export_vessel_graph.py` · wired in `run_clearance` · [indago#194](https://github.com/edgesentry/indago/pull/194) |
 | **D4-3** | Deck frame from generated HTML | **Open** | [commercial#163](https://github.com/edgesentry/edgesentry-commercial/issues/163) (W7) |
-| **D5** | Optional AI narrative (facts in, no pass/hold out) | **Open** | documaris + prompt guardrails |
+| **D5** | Optional AI narrative (facts in, no pass/hold out) | **Done** | `agents/port_clearance/ai_narrative.py`, `--ai-narrative`; eds `render-clearance --operator-explanation` |
 
 ---
 

--- a/tests/maritime_cyber/test_ai_narrative.py
+++ b/tests/maritime_cyber/test_ai_narrative.py
@@ -1,0 +1,68 @@
+"""D5 — operator explanation guardrails and template synthesis."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agents.port_clearance.ai_narrative import (
+    NarrativeGuardrailError,
+    build_deterministic_narrative,
+    generate_operator_explanation,
+    validate_narrative_guardrails,
+    write_operator_explanation_artifacts,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOLD_FACTS = (
+    _REPO_ROOT.parent
+    / "edgesentry-rs/crates/edgesentry-document/fixtures/clearance/vessel-hold_facts.json"
+)
+
+
+@pytest.fixture
+def hold_facts() -> dict:
+    return json.loads(_HOLD_FACTS.read_text(encoding="utf-8"))
+
+
+def test_build_deterministic_narrative_mentions_hold_and_rules(hold_facts: dict) -> None:
+    text = build_deterministic_narrative(hold_facts)
+    assert "HOLD" in text
+    assert "vessel-hold" in text
+    assert "SG-CC-001" in text
+    assert "CVE-2021-44228" in text
+    assert "non-authoritative" in text.lower()
+
+
+def test_validate_rejects_invented_cve(hold_facts: dict) -> None:
+    bad = build_deterministic_narrative(hold_facts) + "\n\nAlso see CVE-1999-0001."
+    with pytest.raises(NarrativeGuardrailError, match="not in facts"):
+        validate_narrative_guardrails(bad, hold_facts)
+
+
+def test_validate_rejects_contradictory_pass_on_hold(hold_facts: dict) -> None:
+    bad = (
+        "The rule engine recorded clearance outcome HOLD for vessel vessel-hold. "
+        "Recommended clearance outcome pass for berth entry."
+    )
+    with pytest.raises(NarrativeGuardrailError, match="contradicts"):
+        validate_narrative_guardrails(bad, hold_facts)
+
+
+def test_generate_operator_explanation_round_trip(hold_facts: dict) -> None:
+    text = generate_operator_explanation(hold_facts, mode="template")
+    validate_narrative_guardrails(text, hold_facts)
+
+
+def test_write_operator_explanation_artifacts(tmp_path: Path, hold_facts: dict) -> None:
+    facts_path = tmp_path / "vessel-hold_facts.json"
+    facts_path.write_text(json.dumps(hold_facts, indent=2), encoding="utf-8")
+    paths = write_operator_explanation_artifacts(facts_path, prefix="vessel-hold_port-call-demo-sgsin")
+    assert paths["text"].is_file()
+    assert paths["meta"].is_file()
+    meta = json.loads(paths["meta"].read_text(encoding="utf-8"))
+    assert meta["source"] == "template"
+    assert meta["non_authoritative"] is True
+    assert meta["outcome"] == "hold"

--- a/tests/maritime_cyber/test_ai_narrative.py
+++ b/tests/maritime_cyber/test_ai_narrative.py
@@ -14,17 +14,21 @@ from agents.port_clearance.ai_narrative import (
     validate_narrative_guardrails,
     write_operator_explanation_artifacts,
 )
-
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_HOLD_FACTS = (
-    _REPO_ROOT.parent
-    / "edgesentry-rs/crates/edgesentry-document/fixtures/clearance/vessel-hold_facts.json"
-)
+from pipelines.maritime_cyber.eval import evaluate_port_clearance
+from pipelines.maritime_cyber.graph import build_maritime_cyber_graph
 
 
 @pytest.fixture
 def hold_facts() -> dict:
-    return json.loads(_HOLD_FACTS.read_text(encoding="utf-8"))
+    """PoC vessel-hold facts from indago fixtures (no sibling-repo path)."""
+    graph = build_maritime_cyber_graph(["vessel-hold"])
+    result = evaluate_port_clearance(
+        "vessel-hold",
+        port_call_id="port-call-demo-sgsin",
+        graph_result=graph,
+    )
+    assert result.outcome == "hold"
+    return result.facts
 
 
 def test_build_deterministic_narrative_mentions_hold_and_rules(hold_facts: dict) -> None:

--- a/tests/maritime_cyber/test_run_clearance.py
+++ b/tests/maritime_cyber/test_run_clearance.py
@@ -74,6 +74,32 @@ def test_run_clearance_eval_only(tmp_path: Path, vessel_key: str, expected_outco
     assert summary_path.is_file()
 
 
+def test_ai_narrative_does_not_change_decision_hash(tmp_path: Path) -> None:
+    """D5: operator explanation is sidecar-only; facts hash unchanged."""
+    baseline = run_clearance(
+        "vessel-hold",
+        output_dir=tmp_path / "without",
+        write_graph=False,
+        skip_render=True,
+        skip_seal=True,
+        ai_narrative=False,
+    )
+    with_narrative = run_clearance(
+        "vessel-hold",
+        output_dir=tmp_path / "with",
+        write_graph=False,
+        skip_render=True,
+        skip_seal=True,
+        ai_narrative=True,
+    )
+    assert baseline.decision_hash == with_narrative.decision_hash
+    assert with_narrative.operator_explanation_path is not None
+    assert with_narrative.operator_explanation_path.is_file()
+    baseline_facts = json.loads(baseline.facts_path.read_text(encoding="utf-8"))
+    narrative_facts = json.loads(with_narrative.facts_path.read_text(encoding="utf-8"))
+    assert baseline_facts == narrative_facts
+
+
 def test_hold_to_pass_scenario_eval_only(tmp_path: Path) -> None:
     """D1: E7 -> E9 -> E10 -> re-E7 without eds (CI-safe)."""
     results = run_hold_to_pass_scenario(


### PR DESCRIPTION
## Summary

- Adds `agents/port_clearance/ai_narrative.py` — deterministic operator explanation from clearance `facts.json` only (no LLM in CI path).
- Adds `generate_narrative` CLI and `prompts/operator_explanation_policy.txt` guardrails (no pass/hold override, no new CVE IDs).
- Adds `run_clearance --ai-narrative` writing `*_operator_explanation.txt` and `*_operator_explanation_meta.json`.
- Tests confirm `decision_hash` is unchanged when narrative is enabled.

Refs [edgesentry-commercial#160](https://github.com/edgesentry/edgesentry-commercial/issues/160)

Companion PR: edgesentry-rs `render-clearance --operator-explanation` for certificate section 1a.

## Test plan

- [x] `uv run pytest tests/maritime_cyber/test_ai_narrative.py tests/maritime_cyber/test_run_clearance.py -q`
- [x] `uv run pytest tests/maritime_cyber/ -q`
- [ ] `uv run python -m agents.port_clearance.run_clearance vessel-hold --ai-narrative` (manual smoke)


Made with [Cursor](https://cursor.com)