### PR TITLE
docs: port-cyber canonical home is catena (freeze notice)

### DIFF
--- a/agents/port_clearance/README.md
+++ b/agents/port_clearance/README.md
@@ -1,6 +1,10 @@
 # Port Cyber Clearance — E2E orchestrator (W6)
 
-**Program status:** [docs/ref-maritime-cyber-capvista.md](../../docs/ref-maritime-cyber-capvista.md) — indago **W0–W6** and demo **D1–D4** done; **W7** submission is in `edgesentry-commercial`.
+> **Canonical home:** [edgesentry/catena](https://github.com/edgesentry/catena)
+> (`agents/port_clearance/`). This package is **frozen**; use catena for new work.
+> [catena#1](https://github.com/edgesentry/catena/issues/1).
+
+**Program status:** [docs/ref-maritime-cyber-capvista.md](../../docs/ref-maritime-cyber-capvista.md) — **W7** submission is in `edgesentry-commercial`.
 
 | Workstream | Status | This package |
 |------------|--------|--------------|

--- a/pipelines/maritime_cyber/README.md
+++ b/pipelines/maritime_cyber/README.md
@@ -1,5 +1,10 @@
 # `pipelines/maritime_cyber` — graph + evaluation
 
+> **Canonical home:** [edgesentry/catena](https://github.com/edgesentry/catena)
+> (`pipeline/maritime_cyber/`). This tree is **frozen** for Port Cyber; new work
+> and CI target **catena** only. Tracker:
+> [catena#1](https://github.com/edgesentry/catena/issues/1).
+
 | Module | Workstream | Role |
 |--------|------------|------|
 | `graph.py` | **W2** | SBOM + CVE + `asset_map` → NetworkX + Parquet |


### PR DESCRIPTION
## Summary

Add README banners on legacy Port Cyber paths directing contributors to
**edgesentry/catena** per [catena#1](https://github.com/edgesentry/catena/issues/1) decommission Stage 2.

## Test plan

- [ ] Docs only


Made with [Cursor](https://cursor.com)