### PR TITLE
ci: disable scheduled GitHub Actions workflows

### DIFF
--- a/.agents/skills/indago-launchagents/SKILL.md
+++ b/.agents/skills/indago-launchagents/SKILL.md
@@ -16,6 +16,8 @@ metadata:
 
 Plist files live in `config/launchagents/`. The `*.local.plist` files contain real credentials and are gitignored — edit them before installing on a new machine.
 
+Templates currently ship with `<key>Disabled</key><true/>` so agents do not auto-start after install. Remove that key from the template (or generated `*.local.plist`) before loading when automated local ingest should run.
+
 ---
 
 ## Install (new machine setup)

--- a/.github/workflows/ais-validate.yml
+++ b/.github/workflows/ais-validate.yml
@@ -1,8 +1,9 @@
 name: AIS Upload Validation
 
 on:
-  schedule:
-    - cron: '30 23 * * *'   # 23:30 UTC daily (07:30 SGT / 08:30 JST) — after r2sync, data ready before work starts
+  # schedule disabled — re-enable when automated publish is needed
+  # schedule:
+  #   - cron: '30 23 * * *'   # 23:30 UTC daily (07:30 SGT / 08:30 JST) — after r2sync, data ready before work starts
   workflow_dispatch:
     inputs:
       validate_days:

--- a/.github/workflows/gdelt-ingest.yml
+++ b/.github/workflows/gdelt-ingest.yml
@@ -9,8 +9,9 @@ name: GDELT Ingest
 #   - Manual dispatch
 
 on:
-  schedule:
-    - cron: '0 23 * * 0'  # weekly Sunday 23:00 UTC
+  # schedule disabled — re-enable when automated publish is needed
+  # schedule:
+  #   - cron: '0 23 * * 0'  # weekly Sunday 23:00 UTC
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/gfw-ingest.yml
+++ b/.github/workflows/gfw-ingest.yml
@@ -13,8 +13,9 @@ name: GFW EO Ingest
 # is never contended across jobs.
 
 on:
-  schedule:
-    - cron: '0 0 * * 1'  # weekly Monday 00:00 UTC
+  # schedule disabled — re-enable when automated publish is needed
+  # schedule:
+  #   - cron: '0 0 * * 1'  # weekly Monday 00:00 UTC
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/lead-time-validation.yml
+++ b/.github/workflows/lead-time-validation.yml
@@ -1,8 +1,9 @@
 name: Lead Time Validation
 
 on:
-  schedule:
-    - cron: '0 1 * * 1'   # 01:00 UTC every Monday (09:00 SGT)
+  # schedule disabled — re-enable when automated publish is needed
+  # schedule:
+  #   - cron: '0 1 * * 1'   # 01:00 UTC every Monday (09:00 SGT)
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/osint-report.yml
+++ b/.github/workflows/osint-report.yml
@@ -7,8 +7,9 @@ name: OSINT Watchlist Report
 #           data-publish (01:00) have both completed and pushed fresh watchlists.
 
 on:
-  schedule:
-    - cron: '0 7 * * 1'  # weekly Monday 07:00 UTC
+  # schedule disabled — re-enable when automated publish is needed
+  # schedule:
+  #   - cron: '0 7 * * 1'  # weekly Monday 07:00 UTC
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/sanctions-refresh.yml
+++ b/.github/workflows/sanctions-refresh.yml
@@ -11,8 +11,9 @@ name: Sanctions DB Refresh
 # Schedule: Monday 00:30 UTC — after GFW ingest (00:00), before data-publish (01:00).
 
 on:
-  schedule:
-    - cron: '30 0 * * 1'  # weekly Monday 00:30 UTC
+  # schedule disabled — re-enable when automated publish is needed
+  # schedule:
+  #   - cron: '30 0 * * 1'  # weekly Monday 00:30 UTC
   workflow_dispatch:
 
 permissions: {}

--- a/config/launchagents/io.indago.aisstream.plist
+++ b/config/launchagents/io.indago.aisstream.plist
@@ -6,6 +6,10 @@
   <key>Label</key>
   <string>io.indago.aisstream</string>
 
+  <!-- Disabled — re-enable when automated ingest is needed -->
+  <key>Disabled</key>
+  <true/>
+
   <key>ProgramArguments</key>
   <array>
     <string>REPLACE_WITH_UV_BIN</string>

--- a/config/launchagents/io.indago.bca-aggregate.plist
+++ b/config/launchagents/io.indago.bca-aggregate.plist
@@ -6,6 +6,10 @@
   <key>Label</key>
   <string>io.indago.bca-aggregate</string>
 
+  <!-- Disabled — re-enable when automated ingest is needed -->
+  <key>Disabled</key>
+  <true/>
+
   <key>ProgramArguments</key>
   <array>
     <string>REPLACE_WITH_UV_BIN</string>

--- a/config/launchagents/io.indago.r2sync.plist
+++ b/config/launchagents/io.indago.r2sync.plist
@@ -6,6 +6,10 @@
   <key>Label</key>
   <string>io.indago.r2sync</string>
 
+  <!-- Disabled — re-enable when automated ingest is needed -->
+  <key>Disabled</key>
+  <true/>
+
   <key>ProgramArguments</key>
   <array>
     <string>REPLACE_WITH_UV_BIN</string>

--- a/scripts/install_launchagents.sh
+++ b/scripts/install_launchagents.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
-# Install or unload the two indago LaunchAgents:
-#   io.indago.aisstream  — AIS stream rotator (max 3 concurrent regions)
-#   io.indago.r2sync     — hourly DuckDB → Parquet → R2 sync
+# Install or unload the indago LaunchAgents:
+#   io.indago.aisstream     — AIS stream rotator (max 3 concurrent regions)
+#   io.indago.r2sync        — hourly DuckDB → Parquet → R2 sync
+#   io.indago.bca-aggregate — daily clarus BCA rollup
+#
+# Templates in config/launchagents/ ship with Disabled=true. Remove that key
+# before loading when automated local ingest should run again.
 #
 # Usage:
-#   bash scripts/install_launchagents.sh           # load both
-#   bash scripts/install_launchagents.sh --unload  # unload both
+#   bash scripts/install_launchagents.sh           # load all (requires Disabled removed)
+#   bash scripts/install_launchagents.sh --unload  # unload all
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Comment out `schedule` cron triggers on six workflows (AIS validation, GFW/GDELT ingest, sanctions refresh, lead-time validation, OSINT report).
- Keep `workflow_dispatch` so jobs can still be run manually from Actions.

## Impact
- Stops the automated weekly/daily CI chain, including indirect `data-publish` runs triggered by AIS Upload Validation on `main`.
- Re-enable by uncommenting the `schedule` blocks when automated publish should resume.

## Test plan
- [ ] Merge and confirm no scheduled runs appear in Actions after the next cron window
- [ ] Verify manual `workflow_dispatch` still works for at least one affected workflow (e.g. AIS Upload Validation)


Made with [Cursor](https://cursor.com)